### PR TITLE
pallet: Handle re-register correctly

### DIFF
--- a/common/types/src/lib.rs
+++ b/common/types/src/lib.rs
@@ -70,7 +70,7 @@ impl SignedDataType<Vec<u8>> for SignedWorkerMessage {
 
 // Types used in storage
 
-#[derive(Encode, Decode, PartialEq, Eq)]
+#[derive(Encode, Decode, PartialEq, Eq, Debug)]
 pub enum WorkerStateEnum<BlockNumber> {
 	Empty,
 	Free,
@@ -147,4 +147,10 @@ pub struct RoundStats {
 	/// The targeted online reward in fraction (base: 100_000)
 	pub frac_target_online_reward: u32,
 	pub total_power: u32,
+}
+
+#[derive(Encode, Decode, Debug, Default, Clone, PartialEq, Eq)]
+pub struct MinerStatsDelta {
+	pub num_worker: i32,
+	pub num_power: i32,
 }

--- a/pallets/phala/src/lib.rs
+++ b/pallets/phala/src/lib.rs
@@ -25,7 +25,7 @@ use types::{
 	WorkerMessagePayload, SignedWorkerMessage,
 	TransferData, SignedDataType,
 	WorkerStateEnum, WorkerInfo, StashInfo, PayoutPrefs, Score, PRuntimeInfo, BlockRewardInfo,
-	RoundInfo, RoundStats
+	RoundInfo, RoundStats, MinerStatsDelta
 };
 
 #[cfg(test)]
@@ -111,6 +111,8 @@ decl_storage! {
 		ForceNextRound: bool;
 		/// Stash accounts with pending updates
 		PendingUpdate get(fn pending_updates): Vec<T::AccountId>;
+		/// The delta of the worker stats applaying at the end of this round due to exiting miners.
+		PendingExitingDelta get(fn pending_exiting): MinerStatsDelta;
 		/// Historical round stats; only the current and the last round are kept.
 		RoundStatsHistory get(fn round_stats_history):
 			map hasher(twox_64_concat) u32 => RoundStats;
@@ -185,7 +187,7 @@ decl_event!(
 		TransferToTee(AccountId, Balance),
 		TransferToChain(AccountId, Balance, u64),
 		WorkerRegistered(AccountId, Vec<u8>, Vec<u8>),  // stash, identity_key, machine_id
-		WorkerUnregistered(AccountId, Vec<u8>),
+		WorkerUnregistered(AccountId, Vec<u8>),  // stash, machine_id
 		Heartbeat(AccountId, u32),
 		Offline(AccountId),
 		Slash(AccountId, Balance, u32),
@@ -200,6 +202,7 @@ decl_event!(
 		NewMiningRound(u32),  // round
 		Payout(AccountId, Balance, Balance),  // dest, reward, treasury
 		PayoutMissed(AccountId, AccountId),  // stash, dest
+		WorkerRenewed(AccountId, Vec<u8>),  // stash, machine_id
 	}
 );
 
@@ -395,69 +398,16 @@ decl_module! {
 			ensure!(runtime_info_hash.to_vec() == report_data, Error::<T>::InvalidRuntimeInfoHash);
 			let runtime_info = PRuntimeInfo::decode(&mut &encoded_runtime_info[..]).map_err(|_| Error::<T>::InvalidRuntimeInfo)?;
 			let machine_id = runtime_info.machine_id.to_vec();
-			// Add into the registry
-			let perv_machine_owner = Self::take_machine_if_present(&machine_id);
-			// Maybe updated WorkerInfo fields
-			let last_updated = T::UnixTime::now().as_millis().saturated_into::<u64>();
 			let pubkey = runtime_info.pubkey.to_vec();
-			let score = Some(Score {
-				overall_score: calc_overall_score(&runtime_info.features).map_err(|()| Error::<T>::InvalidInput)?,
-				features: runtime_info.features
-			});
-			// Update the associated WorkerInfo for this stash
-			let worker_info = match perv_machine_owner {
-				// A new machine
-				None => WorkerInfo {
-					machine_id: machine_id.clone(),
-					pubkey: pubkey.clone(),
-					last_updated,
-					state: WorkerStateEnum::Free,
-					score,
-				},
-				// Just refreshed
-				Some((prev_stash, info)) if prev_stash == stash => WorkerInfo {
-					pubkey: pubkey.clone(),
-					last_updated,
-					score,
-					..info  // state unchanged
-				},
-				// Owner changed
-				Some((_prev_stash, info)) => {
-					WorkerInfo {
-						pubkey: pubkey.clone(),
-						last_updated,
-						state: WorkerStateEnum::Free,
-						score,
-						..info
-					}
-				},
-			};
-			WorkerState::<T>::insert(&stash, worker_info);
-			MachineOwner::<T>::insert(&machine_id, &stash);
-			WorkerIngress::<T>::insert(&stash, 0);
-			Self::deposit_event(RawEvent::WorkerRegistered(stash, pubkey, machine_id));
-			Ok(())
+			Self::register_worker_internal(&stash, &machine_id, &pubkey, &runtime_info.features)
+				.map_err(Into::into)
 		}
 
 		#[weight = 0]
 		fn force_register_worker(origin, stash: T::AccountId, machine_id: Vec<u8>, pubkey: Vec<u8>) -> dispatch::DispatchResult {
 			ensure_root(origin)?;
 			ensure!(StashState::<T>::contains_key(&stash), Error::<T>::StashNotFound);
-			Self::take_machine_if_present(&machine_id);
-			let worker_info = WorkerInfo {
-				machine_id: machine_id.clone(),
-				pubkey: pubkey.clone(),
-				last_updated: T::UnixTime::now().as_millis().saturated_into::<u64>(),
-				state: WorkerStateEnum::Free,
-				score: Some(Score {
-					overall_score: 100,
-					features: vec![1, 4]  // 1: one core, 4: the max feature level, score = 100
-				}),
-			};
-			WorkerState::<T>::insert(&stash, worker_info);
-			MachineOwner::<T>::insert(&machine_id, &stash);
-			WorkerIngress::<T>::insert(&stash, 0);
-			Self::deposit_event(RawEvent::WorkerRegistered(stash, pubkey, machine_id));
+			Self::register_worker_internal(&stash, &machine_id, &pubkey, &vec![1, 4])?;
 			Ok(())
 		}
 
@@ -671,8 +621,11 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
-	/// Try to remove a registered worker from the registry by its `machine_id` identity if
-	/// presents, keeping the stash untouched
+	/// Try to remove a registered worker from the registry by its `machine_id`
+	///
+	/// Take the storage items (WorkerState and MachineOwner) if they present. Otherwise returns
+	/// None. It doesn't change the stash info. It doesn't emmit any events, since it's up to the
+	/// caller to decide if the WorkerState is updated or not.
 	fn take_machine_if_present(machine_id: &Vec<u8>)
 	-> Option<(T::AccountId, WorkerInfo<T::BlockNumber>)> {
 		if !MachineOwner::<T>::contains_key(machine_id) {
@@ -680,8 +633,79 @@ impl<T: Trait> Module<T> {
 		}
 		let stash = MachineOwner::<T>::take(machine_id);
 		let worker_info = WorkerState::<T>::take(&stash);
-		Self::deposit_event(RawEvent::WorkerUnregistered(stash.clone(), machine_id.clone()));
 		Some((stash, worker_info))
+	}
+
+	fn register_worker_internal(
+		stash: &T::AccountId, machine_id: &Vec<u8>, pubkey: &Vec<u8>, worker_features: &Vec<u32>
+	) -> Result<(), Error<T>> {
+		// Add into the registry
+		let perv_machine_owner = Self::take_machine_if_present(&machine_id);
+		// Maybe updated WorkerInfo fields
+		let last_updated = T::UnixTime::now().as_millis().saturated_into::<u64>();
+		let score = Some(Score {
+			overall_score: calc_overall_score(worker_features)
+				.map_err(|()| Error::<T>::InvalidInput)?,
+			features: worker_features.clone()
+		});
+		// Update the associated WorkerInfo for this stash
+		let worker_info = match perv_machine_owner {
+			// A new machine
+			None => {
+				Self::deposit_event(RawEvent::WorkerRegistered(
+					stash.clone(), pubkey.clone(), machine_id.clone()));
+				WorkerInfo {
+					machine_id: machine_id.clone(),
+					pubkey: pubkey.clone(),
+					last_updated,
+					state: WorkerStateEnum::Free,
+					score,
+				}
+			},
+			// Just renewed
+			Some((prev_stash, info)) if &prev_stash == stash => {
+				Self::deposit_event(
+					RawEvent::WorkerRenewed(stash.clone(), machine_id.clone()));
+				WorkerInfo {
+					pubkey: pubkey.clone(),
+					last_updated,
+					score,
+					..info  // state unchanged
+				}
+			},
+			// Owner changed
+			Some((prev_stash, info)) => {
+				Self::deposit_event(
+					RawEvent::WorkerUnregistered(prev_stash.clone(), machine_id.clone()));
+				Self::deposit_event(RawEvent::WorkerRegistered(
+					stash.clone(), pubkey.clone(), machine_id.clone()));
+				match info.state {
+					WorkerStateEnum::Mining(_) | WorkerStateEnum::MiningStopping => {
+						// Necessary because the miner is force stopping mining and the new account
+						// is still free.
+						// TODO: this should triger a slash
+						PendingExitingDelta::mutate(|d| {
+							d.num_worker -= 1;
+							if let Some(score) = &info.score {
+								d.num_power -= score.overall_score as i32;
+							}
+						});
+					}
+					_ => ()
+				};
+				WorkerInfo {
+					pubkey: pubkey.clone(),
+					last_updated,
+					state: WorkerStateEnum::Free,
+					score,
+					..info
+				}
+			},
+		};
+		WorkerState::<T>::insert(&stash, worker_info);
+		MachineOwner::<T>::insert(&machine_id, &stash);
+		WorkerIngress::<T>::insert(&stash, 0);
+		Ok(())
 	}
 
 	fn clear_dirty() {
@@ -783,6 +807,11 @@ impl<T: Trait> Module<T> {
 		let dirty_accounts = PendingUpdate::<T>::get();
 		for account in dirty_accounts.iter() {
 			let mut updated = false;
+			if !WorkerState::<T>::contains_key(&account) {
+				// The worker just disappeared by force quite. In this case, the stats delta is
+				// caught by PendingExitingDelta
+				continue;
+			}
 			let mut worker_info = WorkerState::<T>::get(&account);
 			match worker_info.state {
 				WorkerStateEnum::MiningPending => {
@@ -813,6 +842,11 @@ impl<T: Trait> Module<T> {
 				Self::deposit_event(RawEvent::WorkerStateUpdated(account.clone()));
 			}
 		}
+		// Handle PendingExitingDelta
+		let exit_delta = PendingExitingDelta::take();
+		delta += exit_delta.num_worker;
+		power_delta += exit_delta.num_power;
+		// New stats
 		let new_online = (OnlineWorkers::get() as i32 + delta) as u32;
 		OnlineWorkers::put(new_online);
 		let new_total_power = ((TotalPower::get() as i32) + power_delta) as u32;

--- a/pallets/phala/src/lib.rs
+++ b/pallets/phala/src/lib.rs
@@ -808,7 +808,7 @@ impl<T: Trait> Module<T> {
 		for account in dirty_accounts.iter() {
 			let mut updated = false;
 			if !WorkerState::<T>::contains_key(&account) {
-				// The worker just disappeared by force quite. In this case, the stats delta is
+				// The worker just disappeared by force quit. In this case, the stats delta is
 				// caught by PendingExitingDelta
 				continue;
 			}

--- a/pallets/phala/src/tests.rs
+++ b/pallets/phala/src/tests.rs
@@ -6,7 +6,7 @@ use secp256k1;
 use sp_runtime::traits::BadOrigin;
 
 use crate::{Error, mock::*};
-use crate::{RawEvent, types::{Transfer, TransferData, RoundStats}};
+use crate::{RawEvent, types::{Transfer, TransferData, RoundStats, WorkerStateEnum}};
 
 fn events() -> Vec<TestEvent> {
 	let evt = System::events().into_iter().map(|evt| evt.event).collect::<Vec<_>>();
@@ -240,12 +240,35 @@ fn test_force_register_worker() {
 #[test]
 fn test_mine() {
 	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		// Invalid actions
 		assert_noop!(PhalaModule::start_mining_intention(Origin::signed(1)), Error::<Test>::ControllerNotFound);
 		assert_noop!(PhalaModule::stop_mining_intention(Origin::signed(1)), Error::<Test>::ControllerNotFound);
 		assert_ok!(PhalaModule::set_stash(Origin::signed(1), 1));
 		assert_ok!(PhalaModule::force_register_worker(RawOrigin::Root.into(), 1, vec![0], vec![1]));
+		// Free <-> MiningPending
 		assert_ok!(PhalaModule::start_mining_intention(Origin::signed(1)));
+		assert_eq!(PhalaModule::worker_state(1).state, WorkerStateEnum::MiningPending);
 		assert_ok!(PhalaModule::stop_mining_intention(Origin::signed(1)));
+		assert_eq!(PhalaModule::worker_state(1).state, WorkerStateEnum::Free);
+		// MiningPending -> Mining
+		assert_ok!(PhalaModule::start_mining_intention(Origin::signed(1)));
+		assert_ok!(PhalaModule::force_next_round(RawOrigin::Root.into()));
+		PhalaModule::on_finalize(1);
+		System::finalize();
+		assert_matches!(PhalaModule::worker_state(1).state, WorkerStateEnum::Mining(_));
+		assert_eq!(PhalaModule::online_workers(), 1);  // Miner stats increased
+		// Mining -> MiningStopping
+		System::set_block_number(2);
+		assert_ok!(PhalaModule::stop_mining_intention(Origin::signed(1)));
+		assert_eq!(PhalaModule::worker_state(1).state, WorkerStateEnum::MiningStopping);
+		assert_eq!(PhalaModule::online_workers(), 1);
+		// MiningStoping -> Free
+		assert_ok!(PhalaModule::force_next_round(RawOrigin::Root.into()));
+		PhalaModule::on_finalize(2);
+		System::finalize();
+		assert_eq!(PhalaModule::worker_state(1).state, WorkerStateEnum::Free);
+		assert_eq!(PhalaModule::online_workers(), 0);  // Miner stats reduced
 	});
 }
 
@@ -459,6 +482,114 @@ fn test_force_add_fire() {
 		assert_eq!(PhalaModule::fire(1), 100);
 		assert_eq!(PhalaModule::fire(2), 200);
 	});
+}
+
+#[test]
+fn test_mining_lifecycle_force_reregister() {
+	new_test_ext().execute_with(|| {
+		let machine_id = vec![0];
+		let pubkey = vec![1];
+
+		// Block 1: register a worker at stash1 and start mining
+		System::set_block_number(1);
+		assert_ok!(PhalaModule::set_stash(Origin::signed(1), 1));
+		assert_ok!(PhalaModule::force_register_worker(
+			RawOrigin::Root.into(), 1, machine_id.clone(), pubkey.clone()));
+		assert_ok!(PhalaModule::start_mining_intention(Origin::signed(1)));
+		assert_eq!(PhalaModule::worker_state(1).state, WorkerStateEnum::MiningPending);
+		assert_ok!(PhalaModule::force_next_round(RawOrigin::Root.into()));
+		PhalaModule::on_finalize(1);
+		System::finalize();
+		assert_matches!(events().as_slice(), [
+			TestEvent::phala(RawEvent::WorkerRegistered(1, x, y)),
+			TestEvent::phala(RawEvent::WorkerStateUpdated(1)),
+			TestEvent::phala(RawEvent::RewardSeed(_)),
+			TestEvent::phala(RawEvent::MinerStarted(1, 1)),
+			TestEvent::phala(RawEvent::WorkerStateUpdated(1)),
+			TestEvent::phala(RawEvent::NewMiningRound(1))
+		] if x == &pubkey && y == &machine_id);
+		assert_matches!(PhalaModule::worker_state(1).state,
+			WorkerStateEnum::<BlockNumber>::Mining(_)
+		);
+		// We have 1 worker with 100 power
+		assert_eq!(PhalaModule::online_workers(), 1);
+		assert_eq!(PhalaModule::total_power(), 100);
+
+		// Block 2: force reregister to stash2
+		System::set_block_number(2);
+		assert_ok!(PhalaModule::set_stash(Origin::signed(2), 2));
+		assert_ok!(PhalaModule::force_register_worker(
+			RawOrigin::Root.into(), 2, machine_id.clone(), pubkey.clone()));
+		assert_ok!(PhalaModule::force_next_round(RawOrigin::Root.into()));
+		PhalaModule::on_finalize(2);
+		System::finalize();
+		assert_matches!(events().as_slice(), [
+			TestEvent::phala(RawEvent::WorkerUnregistered(1, x)),
+			TestEvent::phala(RawEvent::WorkerRegistered(2, y, z)),
+			TestEvent::phala(RawEvent::RewardSeed(_)),
+			TestEvent::phala(RawEvent::NewMiningRound(2))
+		] if x == &machine_id && y == &pubkey && z == &machine_id);
+		// WorkerState for stash1 is gone
+		assert_eq!(PhalaModule::worker_state(1).state, WorkerStateEnum::Empty);
+		// Stash2 now have one worker registered
+		assert_eq!(PhalaModule::worker_state(2).state, WorkerStateEnum::Free);
+		// We should have zero worker with 0 power
+		assert_eq!(PhalaModule::online_workers(), 0);
+		assert_eq!(PhalaModule::total_power(), 0);
+	});
+}
+
+#[test]
+fn test_mining_lifecycle_renew() {
+	new_test_ext().execute_with(|| {
+		let machine_id = vec![0];
+		let pubkey = vec![1];
+
+		// Block 1: register a worker at stash1 and start mining
+		System::set_block_number(1);
+		assert_ok!(PhalaModule::set_stash(Origin::signed(1), 1));
+		assert_ok!(PhalaModule::force_register_worker(
+			RawOrigin::Root.into(), 1, machine_id.clone(), pubkey.clone()));
+		assert_ok!(PhalaModule::start_mining_intention(Origin::signed(1)));
+		assert_eq!(PhalaModule::worker_state(1).state, WorkerStateEnum::MiningPending);
+		assert_ok!(PhalaModule::force_next_round(RawOrigin::Root.into()));
+		PhalaModule::on_finalize(1);
+		System::finalize();
+		assert_matches!(events().as_slice(), [
+			TestEvent::phala(RawEvent::WorkerRegistered(1, x, y)),
+			TestEvent::phala(RawEvent::WorkerStateUpdated(1)),
+			TestEvent::phala(RawEvent::RewardSeed(_)),
+			TestEvent::phala(RawEvent::MinerStarted(1, 1)),
+			TestEvent::phala(RawEvent::WorkerStateUpdated(1)),
+			TestEvent::phala(RawEvent::NewMiningRound(1))
+		] if x == &pubkey && y == &machine_id);
+		assert_matches!(PhalaModule::worker_state(1).state,
+			WorkerStateEnum::<BlockNumber>::Mining(_)
+		);
+		// We have 1 worker with 100 power
+		assert_eq!(PhalaModule::online_workers(), 1);
+		assert_eq!(PhalaModule::total_power(), 100);
+
+		// Block 2: force reregister to stash2
+		System::set_block_number(2);
+		assert_ok!(PhalaModule::force_register_worker(
+			RawOrigin::Root.into(), 1, machine_id.clone(), pubkey.clone()));
+		assert_ok!(PhalaModule::force_next_round(RawOrigin::Root.into()));
+		PhalaModule::on_finalize(2);
+		System::finalize();
+		assert_matches!(events().as_slice(), [
+			TestEvent::phala(RawEvent::WorkerRenewed(1, x)),
+			TestEvent::phala(RawEvent::RewardSeed(_)),
+			TestEvent::phala(RawEvent::NewMiningRound(2))
+		] if x == &machine_id);
+		assert_matches!(PhalaModule::worker_state(1).state,
+			WorkerStateEnum::<BlockNumber>::Mining(_)
+		);
+		// Same as the last block
+		assert_eq!(PhalaModule::online_workers(), 1);
+		assert_eq!(PhalaModule::total_power(), 100);
+	});
+
 }
 
 fn ecdsa_load_sk(raw_key: &[u8]) -> secp256k1::SecretKey {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 19,
+	spec_version: 20,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Fix the inconsistent state when a miner registers more than once

Tested:
unit tests