### PR TITLE
Fix mining state inconsistency + data migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-phala"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "assert_matches",
  "base64 0.11.0",

--- a/common/types/src/lib.rs
+++ b/common/types/src/lib.rs
@@ -86,7 +86,7 @@ impl<BlockNumber> Default for WorkerStateEnum<BlockNumber> {
 	}
 }
 
-#[derive(Encode, Decode, Default)]
+#[derive(Encode, Decode, Debug, Default)]
 pub struct WorkerInfo<BlockNumber> {
 	// identity
 	pub machine_id: Vec<u8>,
@@ -110,7 +110,7 @@ pub struct PayoutPrefs<AccountId: Default> {
 	pub target: AccountId,
 }
 
-#[derive(Encode, Decode, Default, Clone)]
+#[derive(Encode, Decode, Debug, Default, Clone)]
 pub struct Score {
 	pub overall_score: u32,
 	pub features: Vec<u32>

--- a/pallets/phala/Cargo.toml
+++ b/pallets/phala/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ['Phala Network']
 edition = '2018'
 name = 'pallet-phala'
-version = "2.0.0"
+version = "3.0.0"
 license = "Apache 2.0"
 homepage = "https://phala.network/"
 repository = "https://github.com/Phala-Network/phala-blockchain"

--- a/pallets/phala/src/migrations_3_0_0.rs
+++ b/pallets/phala/src/migrations_3_0_0.rs
@@ -1,6 +1,6 @@
 //! Migrate to version [`3.0.0`]
 //!
-//! Referece PR: <>
+//! Referece PR: <https://github.com/paritytech/substrate/pull/7040>
 
 use codec::FullCodec;
 use frame_support::{

--- a/pallets/phala/src/migrations_3_0_0.rs
+++ b/pallets/phala/src/migrations_3_0_0.rs
@@ -1,0 +1,121 @@
+//! Migrate to version [`3.0.0`]
+//!
+//! Referece PR: <>
+
+use codec::FullCodec;
+use frame_support::{
+	Blake2_128Concat,
+	debug,
+	storage::types::{StorageMap, StorageValue},
+	traits::{GetPalletVersion, PalletVersion},
+	weights::Weight,
+};
+
+use types::{
+	WorkerStateEnum,
+	WorkerInfo,
+	MinerStatsDelta,
+};
+
+/// Trait to implement to give information about types used for migration
+pub trait V2ToV3 {
+	type Module: GetPalletVersion;
+	type AccountId: 'static + FullCodec;
+	type BlockNumber: 'static + FullCodec;
+}
+
+// Pallet: PhalaModule
+struct __PhalaPallet;
+struct __PhalaPalletInfo;
+impl frame_support::traits::PalletInfo for __PhalaPalletInfo {
+	fn index<P: 'static>() -> Option<usize> { Some(0) }
+	fn name<P: 'static>() -> Option<&'static str> { Some("PhalaModule") }
+}
+
+// State: WorkerState
+struct __WorkerState;
+impl frame_support::traits::StorageInstance for __WorkerState {
+	type Pallet = __PhalaPallet;
+	type PalletInfo = __PhalaPalletInfo;
+	const STORAGE_PREFIX: &'static str = "WorkerState";
+}
+#[allow(type_alias_bounds)]
+type WorkerState<T: V2ToV3> = StorageMap<
+	__WorkerState, Blake2_128Concat,
+	T::AccountId, WorkerInfo<T::BlockNumber>
+>;
+
+// State: OnlineWorkers
+struct __OnlineWorkers;
+impl frame_support::traits::StorageInstance for __OnlineWorkers {
+	type Pallet = __PhalaPallet;
+	type PalletInfo = __PhalaPalletInfo;
+	const STORAGE_PREFIX: &'static str = "OnlineWorkers";
+}
+#[allow(type_alias_bounds)]
+type OnlineWorkers = StorageValue<__OnlineWorkers, u32>;
+
+// State: TotalPower
+struct __TotalPower;
+impl frame_support::traits::StorageInstance for __TotalPower {
+	type Pallet = __PhalaPallet;
+	type PalletInfo = __PhalaPalletInfo;
+	const STORAGE_PREFIX: &'static str = "TotalPower";
+}
+#[allow(type_alias_bounds)]
+type TotalPower = StorageValue<__TotalPower, u32>;
+
+// State: PendingExitingDelta
+struct __PendingExitingDelta;
+impl frame_support::traits::StorageInstance for __PendingExitingDelta {
+	type Pallet = __PhalaPallet;
+	type PalletInfo = __PhalaPalletInfo;
+	const STORAGE_PREFIX: &'static str = "PendingExitingDelta";
+}
+#[allow(type_alias_bounds)]
+type PendingExitingDelta = StorageValue<__PendingExitingDelta, MinerStatsDelta>;
+
+fn reconcile_online_workers<T: V2ToV3>() {
+	debug::info!("Entered `reconcile_online_workers`");
+	// Remove all corrupted worker entries
+	WorkerState::<T>::translate(
+		|_k, v: WorkerInfo<T::BlockNumber>| -> Option<WorkerInfo<T::BlockNumber>>
+	{
+		if v.machine_id.len() == 0 { None }
+		else { Some(v) }
+	});
+	// Rescan all workers for the stats
+	let mut total_power = 0u32;
+	let online_workers = WorkerState::<T>::iter().filter(|(_k, v)|
+		v.score.is_some() && match v.state {
+			WorkerStateEnum::Mining(_) | WorkerStateEnum::MiningStopping => true,
+			_ => false
+		}
+	).map(|(_k, v)| {
+		let score = v.score.as_ref().unwrap().overall_score;
+		total_power += score;
+		()
+	}).count();
+	// Clean PendingExitingDelta at the same time
+	let exit_delta = PendingExitingDelta::take().unwrap_or_default();
+	debug::info!("  - exit_delta.num_worker = {}", exit_delta.num_worker);
+	debug::info!("  - exit_delta.num_power = {}", exit_delta.num_power);
+	debug::info!("  - online_workers = {}", online_workers);
+	debug::info!("  - total_power = {}", total_power);
+	OnlineWorkers::put((online_workers as i32 + exit_delta.num_worker) as u32);
+	TotalPower::put((total_power as i32 + exit_delta.num_power) as u32);
+	debug::info!("End `reconcile_online_workers`");
+}
+
+pub fn apply<T: V2ToV3>() -> Weight {
+	debug::RuntimeLogger::init();
+
+	let maybe_storage_version = <T::Module as GetPalletVersion>::storage_version();
+	match maybe_storage_version {
+		Some(version) if version == PalletVersion::new(2, 0, 0) => {
+			reconcile_online_workers::<T>();
+			Weight::max_value()
+		}
+		_ => 0,
+	}
+}

--- a/pallets/phala/src/migrations_3_0_0.rs
+++ b/pallets/phala/src/migrations_3_0_0.rs
@@ -108,11 +108,10 @@ fn reconcile_online_workers<T: V2ToV3>() {
 }
 
 pub fn apply<T: V2ToV3>() -> Weight {
-	debug::RuntimeLogger::init();
-
 	let maybe_storage_version = <T::Module as GetPalletVersion>::storage_version();
 	match maybe_storage_version {
 		Some(version) if version == PalletVersion::new(2, 0, 0) => {
+			debug::RuntimeLogger::init();
 			reconcile_online_workers::<T>();
 			Weight::max_value()
 		}

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -27,7 +27,7 @@ pallet-session = { version = "2.0.0", default-features = false, features = ["his
 pallet-authorship = { version = "2.0.0", default-features = false, path = "../../substrate/frame/authorship" }
 sp-application-crypto = { version = "2.0.0", default-features = false, path = "../../substrate/primitives/application-crypto" }
 
-pallet-phala = { version = "2.0.0", default-features = false, path = "../phala" }
+pallet-phala = { version = "3.0.0", default-features = false, path = "../phala" }
 
 # Optional imports for benchmarking
 frame-benchmarking = { version = "2.0.0", default-features = false, path = "../../substrate/frame/benchmarking", optional = true }

--- a/pruntime/enclave/Cargo.lock
+++ b/pruntime/enclave/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-phala"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "base64 0.11.0",
  "blake2-rfc",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -79,7 +79,7 @@ pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0", default-featur
 pallet-vesting = { version = "2.0.0", default-features = false, path = "../substrate/frame/vesting" }
 
 pallet-staking = { version = "2.0.0", default-features = false, path = "../pallets/staking", package = "phala-staking" }
-pallet-phala = { version = "2.0.0", default-features = false, path = "../pallets/phala", package = "pallet-phala" }
+pallet-phala = { version = "3.0.0", default-features = false, path = "../pallets/phala", package = "pallet-phala" }
 pallet-claim = { version = "2.0.0", default-features = false, path = "../pallets/claim", package = "pallet-claim" }
 
 native-nostd-hasher = { version = "2.0.0", path = "../native-nostd-hasher", optional = true }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 20,
+	spec_version: 21,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/scripts/js/dumpPhalaModuleStates.js
+++ b/scripts/js/dumpPhalaModuleStates.js
@@ -1,0 +1,49 @@
+require('dotenv').config();
+
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+
+const typedefs = require('../../e2e/typedefs.json');
+
+async function main () {
+    const wsProvider = new WsProvider(process.env.ENDPOINT);
+    const api = await ApiPromise.create({ provider: wsProvider, types: typedefs });
+
+    const workerState = {};
+    const entries = await api.query.phalaModule.workerState.entries();
+    for (let [k, v] of entries) {
+        console.log(`${k.args.map(k => k.toHuman())} =>`, v.toHuman());
+        workerState[k.args[0].toHuman()] = v.toHuman();
+    }
+
+    const [onlineWorkers, totalPower] = await Promise.all([
+        api.query.phalaModule.onlineWorkers(),
+        api.query.phalaModule.totalPower(),
+    ]);
+
+    console.log({onchainData: {
+        onlineWorkers: onlineWorkers.toNumber(),
+        totalPower: totalPower.toNumber(),
+    }});
+
+    const statsFromWorkerState = {
+        numWorkers: Object.keys(workerState).length,
+        numOnlineWorkers: Object.entries(workerState).filter(([_, v]) => !!v.state.Mining).length,
+        numWorkerWithScore:
+            Object.entries(workerState).filter(([_, v]) => !!v.score).length,
+        numStartingWorkers:
+            Object.entries(workerState).filter(([_, v]) => 'MiningPending' in v.state).length,
+        numStoppingWorkers:
+            Object.entries(workerState).filter(([_, v]) => 'MiningStopping' in v.state).length,
+        totalPower: Object.entries(workerState)
+            .filter(([_, v]) => !!v.state.Mining)
+            .map(([_, v]) => v.score && parseInt(v.score.overallScore) || 0)
+            .reduce((a, x) => a + x, 0),
+        maxCores: Object.entries(workerState)
+            .map(([_, v]) => v.score && parseInt(v.score.features[0]) || 0)
+            .reduce((a, x) => Math.max(a, x), 0),
+    }
+    console.log({statsFromWorkerState});
+}
+
+main().catch(console.error).finally(() => process.exit());
+

--- a/scripts/js/dumpPhalaModuleStates.js
+++ b/scripts/js/dumpPhalaModuleStates.js
@@ -1,18 +1,22 @@
 require('dotenv').config();
 
 const { ApiPromise, WsProvider } = require('@polkadot/api');
+const { decodeAddress } = require('@polkadot/keyring');
+const { u8aToHex } = require('@polkadot/util');
+
 
 const typedefs = require('../../e2e/typedefs.json');
 
 async function main () {
     const wsProvider = new WsProvider(process.env.ENDPOINT);
     const api = await ApiPromise.create({ provider: wsProvider, types: typedefs });
+    const shouldDumpFullWorkers = (process.env.FULL_DUMP === '1');
 
     const workerState = {};
     const entries = await api.query.phalaModule.workerState.entries();
     for (let [k, v] of entries) {
-        console.log(`${k.args.map(k => k.toHuman())} =>`, v.toHuman());
-        workerState[k.args[0].toHuman()] = v.toHuman();
+        console.log(`${k.args.map(k => k.toHuman())} =>`, v.toJSON());
+        workerState[k.args[0].toHuman()] = v.toJSON();
     }
 
     const [onlineWorkers, totalPower] = await Promise.all([
@@ -28,14 +32,18 @@ async function main () {
     const statsFromWorkerState = {
         numWorkers: Object.keys(workerState).length,
         numOnlineWorkers: Object.entries(workerState).filter(([_, v]) => !!v.state.Mining).length,
-        numWorkerWithScore:
-            Object.entries(workerState).filter(([_, v]) => !!v.score).length,
         numStartingWorkers:
             Object.entries(workerState).filter(([_, v]) => 'MiningPending' in v.state).length,
         numStoppingWorkers:
             Object.entries(workerState).filter(([_, v]) => 'MiningStopping' in v.state).length,
+        numWorkerWithScore:
+            Object.entries(workerState).filter(([_, v]) => !!v.score).length,
+        numWorkerWithMachineId:
+            Object.entries(workerState).filter(([_, v]) => !!v.machineId).length,
+        numWorkerWithoutMachineIdAndMining:
+            Object.entries(workerState).filter(([_, v]) => !v.machineId && !!v.state.Mining).length,
         totalPower: Object.entries(workerState)
-            .filter(([_, v]) => !!v.state.Mining)
+            .filter(([_, v]) => (!!v.state.Mining || 'MiningStopping' in v.state) && !!v.machineId)
             .map(([_, v]) => v.score && parseInt(v.score.overallScore) || 0)
             .reduce((a, x) => a + x, 0),
         maxCores: Object.entries(workerState)
@@ -43,6 +51,18 @@ async function main () {
             .reduce((a, x) => Math.max(a, x), 0),
     }
     console.log({statsFromWorkerState});
+
+    if (shouldDumpFullWorkers) {
+        const fs = require('fs');
+        let tsv = Object.entries(workerState)
+            .map(([k, v]) => [
+                k, u8aToHex(decodeAddress(k)),
+                JSON.stringify(v.state), v.score.overallScore,
+                JSON.stringify(v.score.features)].join('\t'))
+            .join('\n');
+        tsv = ['ss58', 'hex', 'state', 'score', 'feature'].join('\t') + '\n' + tsv;
+        fs.writeFileSync('./tmp/full_workers.tsv', tsv, {encoding: 'utf-8'});
+    }
 }
 
 main().catch(console.error).finally(() => process.exit());


### PR DESCRIPTION
As a dependency of computation tasks, we want to make sure the storage `online_worker` is consistent with the actual online worker (i.e. "Mining" or "MiningStopping"), so that the pRuntime can validate the number of the storage map entries matches the synced data (i.e. no skipped entry).

In order to do that, we first added a js script to check phala on-chain data consistency, found the problem, fixed in another commit, and we are going to perform a storage migration to fix the inconsistency.

This PR will upgrade the runtime to v21.

Storage migration:
- Cleanup incorrect worker state (missing machine_id)
- Reconcile online_worker and total_power

Tested:
x-validated by: dumpPhalaModuleState.js