### PR TITLE
add msg_channel component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ tmp
 # JS scripts
 scripts/js/node_modules
 scripts/js/.env
+standalone/pruntime/start_build.sh

--- a/common/types/src/lib.rs
+++ b/common/types/src/lib.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "pruntime")]
 pub mod pruntime;
 
+pub mod message;
+
 #[derive(Encode, Decode)]
 pub struct Transfer<AccountId, Balance> {
     pub dest: AccountId,

--- a/common/types/src/message.rs
+++ b/common/types/src/message.rs
@@ -1,0 +1,74 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
+use alloc::vec::Vec;
+use codec::{Decode, Encode};
+use sp_core::ecdsa;
+use sp_core::crypto::Pair;
+use sp_core::ecdsa::Signature;
+#[cfg(feature = "enable_serde")]
+use serde::{Deserialize, Serialize};
+
+pub trait Message: Encode + Decode + Clone  {}
+impl<T: Encode + Decode + Clone > Message for T {}
+
+
+#[derive(Debug,Default)]
+#[cfg_attr(feature = "enable_serde", derive(Serialize, Deserialize))]
+pub struct SignedMessage<M: Message> {
+    pub data: M,
+    pub sequence: u64,
+    pub signature: Vec<u8>,
+}
+
+
+#[derive(Encode,Decode,Default)]
+#[cfg_attr(feature = "enable_serde", derive(Serialize, Deserialize))]
+pub struct EncodeMsg<M:Message>{
+    pub data:M,
+    pub sequence:u64
+}
+impl<M: Message> EncodeMsg<M> {
+    pub fn new(data: M, sequence: u64) -> Self {
+        let data_clone = data.clone();
+        Self {
+            data:data_clone,
+            sequence
+        }
+    }
+}
+impl<M: Message> SignedMessage<M> {
+    pub fn new(data: M, sequence: u64, keypair: &ecdsa::Pair) -> Self {
+        let data_clone = data.clone();
+        Self {
+            data,
+            sequence,
+            signature: Self::sign(sequence,data_clone, &keypair),
+        }
+    }
+    pub fn sign(sequence:u64,data: M, keypair: &ecdsa::Pair) -> Vec<u8> {
+        
+        let encode_msg = EncodeMsg{data,sequence};
+        let encode_value = &Encode::encode(&encode_msg);
+        let signature = keypair.sign(encode_value);
+        signature.0.to_vec()
+    }
+    pub fn verify(&self, keypair: &ecdsa::Pair, sequence: u64, data: M, vec_sig: Vec<u8>) -> bool {
+        let encode_msg = EncodeMsg { data, sequence };
+        let message = encode_msg.encode();
+        let public = keypair.public();
+        let mut sig_raw:[u8;65] = [0;65];
+        let mut i = 0;
+        for k in vec_sig {
+            sig_raw[i] = k;
+            i = i +1;
+        }
+        let signature: Signature = Signature::from_raw(sig_raw);
+        ecdsa::Pair::verify(&signature, message, &public)
+    }
+}
+    
+
+
+
+    

--- a/standalone/pruntime/enclave/src/lib.rs
+++ b/standalone/pruntime/enclave/src/lib.rs
@@ -64,6 +64,7 @@ mod msg_channel;
 mod system;
 mod types;
 mod rpc_types;
+mod msg;
 
 use contracts::{
     AccountIdWrapper, Contract, ContractId, DATA_PLAZA, BALANCES, ASSETS, SYSTEM, WEB3_ANALYTICS, DIEM

--- a/standalone/pruntime/enclave/src/msg/mod.rs
+++ b/standalone/pruntime/enclave/src/msg/mod.rs
@@ -1,2 +1,3 @@
 pub mod msg_trait;
+pub mod msg_channel;
 pub mod msg_tunnel;

--- a/standalone/pruntime/enclave/src/msg/mod.rs
+++ b/standalone/pruntime/enclave/src/msg/mod.rs
@@ -1,0 +1,2 @@
+pub mod msg_trait;
+pub mod msg_tunnel;

--- a/standalone/pruntime/enclave/src/msg/msg_channel.rs
+++ b/standalone/pruntime/enclave/src/msg/msg_channel.rs
@@ -1,0 +1,16 @@
+
+use crate::std::vec::Vec;
+use crate::String;
+use crate::str::FromStr;
+use serde::{Deserialize, Serialize};
+use core::fmt::Display;
+use phala_types::message::{Message,SignedMessage};
+use phala_types::{WorkerMessage};
+extern crate runtime as chain;
+
+
+#[derive(Debug,Default,Serialize, Deserialize)]
+pub struct MsgChannel<M:Message> {
+    pub sequence: u64,
+    pub queue: Vec<SignedMessage<M>>,
+}

--- a/standalone/pruntime/enclave/src/msg/msg_trait.rs
+++ b/standalone/pruntime/enclave/src/msg/msg_trait.rs
@@ -1,0 +1,9 @@
+pub trait MsgTrait<A,B,C,D,E> {
+    fn push(&mut self,a:A);
+    fn received(&mut self,b:B);
+    fn get_msgs(&mut self,c:C)->D;
+    fn get_sequence(&mut self)->E;
+    fn hello(&mut self){
+        println!("hello,world");
+    }
+}

--- a/standalone/pruntime/enclave/src/msg/msg_tunnel.rs
+++ b/standalone/pruntime/enclave/src/msg/msg_tunnel.rs
@@ -12,6 +12,7 @@ lazy_static! {
 }
 
 
+
 #[derive(Debug, Clone)]
 pub struct MsgTunnel {
     list: RefCell<Vec<MsgTypeWrapper>>
@@ -62,20 +63,6 @@ impl MsgTunnel {
             panic!("the msg_type hasn't been initialized");
         }
     }
-    pub fn get_sequence(&mut self,msg_type:MsgType)->u64{
-        let list = &self.list;
-        let  seq = 0u64;
-        for i in list.borrow_mut().iter() {
-            let iter_msg_type = i.msg_type;
-            let iter_sq =  i.msg_data.sequence.borrow_mut();
-            if msg_type == iter_msg_type {
-                return iter_sq.clone();
-            }
-        }
-        return seq;
-    }
-   
-    /// Called on received messages and drop them
     pub fn received(&mut self, msg_type: MsgType, seq: u64) {
         let list = &self.list;
         for i in list.borrow_mut().iter() {
@@ -90,6 +77,21 @@ impl MsgTunnel {
             }
         }
     }
+    pub fn get_sequence(&mut self,msg_type:MsgType)->u64{
+        let list = &self.list;
+        let  seq = 0u64;
+        for i in list.borrow_mut().iter() {
+            let iter_msg_type = i.msg_type;
+            let iter_sq =  i.msg_data.sequence.borrow_mut();
+            if msg_type == iter_msg_type {
+                return iter_sq.clone();
+            }
+        }
+        return seq;
+    }
+   
+    /// Called on received messages and drop them
+    
 
     pub fn get_msg_type_wrapper(&mut self, msg_type: MsgType) -> Option<MsgTypeWrapper> {
         let list = &self.list;

--- a/standalone/pruntime/enclave/src/msg/msg_tunnel.rs
+++ b/standalone/pruntime/enclave/src/msg/msg_tunnel.rs
@@ -1,0 +1,133 @@
+use std::cell::RefCell;
+use std::borrow::BorrowMut;
+use crate::std::vec::Vec;
+use crate::std::sync::SgxMutex;
+
+
+lazy_static! {
+    pub static ref  STATIC_MSG_TUNNEL_MUT:SgxMutex<MsgTunnel> = {
+        let  m:MsgTunnel = MsgTunnel::default();
+        SgxMutex::new(m)
+    };
+}
+
+
+#[derive(Debug, Clone)]
+pub struct MsgTunnel {
+    list: RefCell<Vec<MsgTypeWrapper>>
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MsgType {
+    BALANCE,
+    WORKER,
+}
+
+#[derive(Debug, Clone)]
+pub struct MsgTypeWrapper {
+    pub msg_type: MsgType,
+    pub msg_data: MsgData,
+}
+
+
+#[derive(Debug, Clone)]
+pub struct MsgData {
+    pub sequence: RefCell<u64>,
+    pub queue: RefCell<Vec<RefCell<MsgDetail>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MsgDetail {
+    pub msg_id: u64,
+    pub body: Vec<u8>,
+}
+
+impl MsgTunnel {
+    pub fn push(&mut self, msg_type: MsgType, message: Vec<u8>) {
+        let list = &self.list;
+        let mut insert_flag = false;
+        for i in list.borrow_mut().iter() {
+            let mut item_data = &i.msg_data;
+            let item_type = i.msg_type;
+            if msg_type == item_type {
+                let mut sequence = item_data.borrow_mut().sequence.borrow_mut();
+                let msg_id = sequence.borrow_mut().clone() + 1;
+                *sequence += 1;
+                let msg_detail = MsgDetail { msg_id, body: message.clone() };
+                item_data.borrow_mut().queue.borrow_mut().push(RefCell::new(msg_detail));
+                insert_flag = true;
+            }
+        }
+        if !insert_flag{
+            panic!("the msg_type hasn't been initialized");
+        }
+    }
+    pub fn get_sequence(&mut self,msg_type:MsgType)->u64{
+        let list = &self.list;
+        let  seq = 0u64;
+        for i in list.borrow_mut().iter() {
+            let iter_msg_type = i.msg_type;
+            let iter_sq =  i.msg_data.sequence.borrow_mut();
+            if msg_type == iter_msg_type {
+                return iter_sq.clone();
+            }
+        }
+        return seq;
+    }
+   
+    /// Called on received messages and drop them
+    pub fn received(&mut self, msg_type: MsgType, seq: u64) {
+        let list = &self.list;
+        for i in list.borrow_mut().iter() {
+            let item_data = &i.msg_data;
+            let item_type = i.msg_type;
+            if msg_type == item_type {
+                let data_sequence = &item_data.sequence;
+                if seq > *data_sequence.borrow_mut() {
+                    return;
+                }
+                item_data.queue.borrow_mut().retain(|item| item.borrow_mut().msg_id > seq);
+            }
+        }
+    }
+
+    pub fn get_msg_type_wrapper(&mut self, msg_type: MsgType) -> Option<MsgTypeWrapper> {
+        let list = &self.list;
+        for i in list.borrow_mut().iter() {
+            let item_type = i.msg_type;
+            if msg_type == item_type {
+                return Some(i.clone());
+            }
+        }
+        None
+    }
+
+    pub fn get_msg_detail_list(&mut self,msg_type:MsgType,start_sequence:u64)->Option<Vec<MsgDetail>>{
+        let wrappert_list = self.get_msg_type_wrapper(msg_type).unwrap();
+        let msg_detail_list = wrappert_list.msg_data.queue;
+        let mut v:Vec<MsgDetail> = Vec::new();
+        for  i in msg_detail_list.borrow_mut().iter(){
+            let item_msg_id = i.borrow_mut().msg_id;
+            if item_msg_id>=start_sequence{
+                v.push(i.borrow_mut().clone());
+            }
+        }
+        Some(v)
+    }
+}
+
+impl Default for MsgTunnel {
+    fn default() -> Self {
+        let msg_data = MsgData { sequence: RefCell::new(0u64), queue: RefCell::new(Vec::new()) };
+        let balance_wrapper = MsgTypeWrapper { msg_type: MsgType::BALANCE, msg_data };
+        let msg_data = MsgData { sequence: RefCell::new(0u64), queue: RefCell::new(Vec::new()) };
+        let worker_wrapper = MsgTypeWrapper { msg_type: MsgType::WORKER, msg_data };
+        let v = RefCell::new(Vec::new());
+        v.borrow_mut().push(balance_wrapper);
+        v.borrow_mut().push(worker_wrapper);
+        Self {
+            list: v,
+        }
+    }
+}
+

--- a/standalone/pruntime/enclave/src/system/mod.rs
+++ b/standalone/pruntime/enclave/src/system/mod.rs
@@ -2,14 +2,17 @@ use crate::std::prelude::v1::*;
 use serde::{Serialize, Deserialize};
 use std::collections::BTreeMap;
 
-use phala_types::{BlockRewardInfo, SignedWorkerMessage, WorkerMessagePayload};
+use phala_types::{BlockRewardInfo, SignedWorkerMessage, WorkerMessagePayload,WorkerMessage};
 use sp_core::U256;
 use sp_core::ecdsa;
+use sp_core::Pair;
 use sp_core::hashing::blake2_256;
-use parity_scale_codec::Encode;
+use parity_scale_codec::{Encode, Decode};
 
 use crate::contracts::AccountIdWrapper;
-use crate::msg_channel::MsgChannel;
+use crate::msg::msg_tunnel::{STATIC_MSG_TUNNEL_MUT,MsgType};
+
+use crate::msg::msg_trait::MsgTrait;
 
 mod comp_election;
 
@@ -18,36 +21,36 @@ type PhalaEvent = phala::RawEvent<sp_runtime::AccountId32, u128>;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum TransactionStatus {
-	Ok,
-	InsufficientBalance,
-	NoBalance,
-	UnknownError,
-	BadContractId,
-	BadCommand,
-	SymbolExist,
-	AssetIdNotFound,
-	NotAssetOwner,
+    Ok,
+    InsufficientBalance,
+    NoBalance,
+    UnknownError,
+    BadContractId,
+    BadCommand,
+    SymbolExist,
+    AssetIdNotFound,
+    NotAssetOwner,
     BadSecret,
     BadMachineId,
     FailedToSign,
-	BadAccountData,
-	BadAccountInfo,
-	BadLedgerInfo,
-	BadTrustedStateData,
-	BadTrustedState,
-	InvalidAccount,
-	BadTransactionWithProof,
-	FailedToVerify,
-	FailedToGetTransaction,
+    BadAccountData,
+    BadAccountInfo,
+    BadLedgerInfo,
+    BadTrustedStateData,
+    BadTrustedState,
+    InvalidAccount,
+    BadTransactionWithProof,
+    FailedToVerify,
+    FailedToGetTransaction,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TransactionReceipt {
-	pub account: AccountIdWrapper,
-	pub block_num: chain::BlockNumber,
-	pub contract_id: u32,
-	pub command: String,
-	pub status: TransactionStatus,
+    pub account: AccountIdWrapper,
+    pub block_num: chain::BlockNumber,
+    pub contract_id: u32,
+    pub command: String,
+    pub status: TransactionStatus,
 }
 
 #[derive(Default)]
@@ -61,15 +64,59 @@ pub struct System {
     pub comp_elected: bool,
     // Transaction
     pub receipts: BTreeMap<CommandIndex, TransactionReceipt>,
-    // Messageing
-    pub egress: MsgChannel,
 }
 
+impl MsgTrait<WorkerMessagePayload,u64,u64,Vec<SignedWorkerMessage>,u64> for System {
+    
+    fn push(&mut self,work_message_payload:WorkerMessagePayload){
+        let  mut msg_tunnel_mut = STATIC_MSG_TUNNEL_MUT.lock().unwrap();
+        let msg_type = MsgType::WORKER;
+        let sequence = msg_tunnel_mut.get_sequence(msg_type);
+        let pair = self.id_key.as_ref().expect("Id key not set in System contract");
+        let data = WorkerMessage {
+            payload: work_message_payload,
+            sequence: sequence + 1
+        };
+        let sig = pair.sign(&Encode::encode(&data));
+        let signed = SignedWorkerMessage {
+            data,
+            signature: sig.0.to_vec(),
+        };
+        let encode = signed.encode();
+        msg_tunnel_mut.push(msg_type,encode);
+    }
+    fn received(&mut self,seq:u64){
+        let  mut msg_tunnel_mut = STATIC_MSG_TUNNEL_MUT.lock().unwrap();
+        let msg_type = MsgType::WORKER;
+        msg_tunnel_mut.received(msg_type,seq);
+    }
+    fn get_msgs(&mut self,seq:u64)->Vec<SignedWorkerMessage>{
+        let  mut msg_tunnel_mut = STATIC_MSG_TUNNEL_MUT.lock().unwrap();
+        let msg_type = MsgType::WORKER;
+        let msg_detail_list = msg_tunnel_mut.get_msg_detail_list(msg_type,seq).unwrap();
+        let mut v:Vec<SignedWorkerMessage> = Vec::new();
+        for i in msg_detail_list {
+            let body_message = &i.body;
+            let c = SignedWorkerMessage::decode(&mut &body_message[..]);
+            v.push(c.unwrap());
+        }
+        v
+    }
+    fn get_sequence(&mut self)->u64{
+        let  mut msg_tunnel_mut = STATIC_MSG_TUNNEL_MUT.lock().unwrap();
+        let msg_type = MsgType::WORKER;
+        msg_tunnel_mut.get_sequence(msg_type)
+    }
+    
+}
+
+
+
 impl System {
-	pub fn new() -> Self {
+    pub fn new() -> Self {
         Default::default()
     }
-
+    
     pub fn set_id(&mut self, pair: &ecdsa::Pair) {
         let pubkey = ecdsa::Public::from(pair.clone());
         let raw_pubkey: &[u8] = pubkey.as_ref();
@@ -79,22 +126,22 @@ impl System {
         self.hashed_id = pkh.into();
         println!("System::set_id: hashed identity key: {:?}", self.hashed_id);
     }
-
+    
     pub fn set_machine_id(&mut self, machine_id: Vec<u8>) {
         self.machine_id = machine_id;
     }
-
-	pub fn add_receipt(&mut self, command_index: CommandIndex, tr: TransactionReceipt) {
-		self.receipts.insert(command_index, tr);
-	}
-
-	pub fn get_receipt(&self, command_index: CommandIndex) -> Option<&TransactionReceipt> {
-		self.receipts.get(&command_index)
+    
+    pub fn add_receipt(&mut self, command_index: CommandIndex, tr: TransactionReceipt) {
+        self.receipts.insert(command_index, tr);
     }
-
+    
+    pub fn get_receipt(&self, command_index: CommandIndex) -> Option<&TransactionReceipt> {
+        self.receipts.get(&command_index)
+    }
+    
     pub fn handle_query(&mut self, accid_origin: Option<&chain::AccountId>, req: Request)
     -> Response {
-        let inner = || -> Result<Response, Error> {
+        let mut inner = || -> Result<Response, Error> {
             match req {
                 Request::QueryReceipt { command_index } => {
                     match self.get_receipt(command_index) {
@@ -110,11 +157,7 @@ impl System {
                     }
                 },
                 Request::GetWorkerEgress { start_sequence } => {
-                    let pending_msgs: Vec<SignedWorkerMessage> = self.egress.queue
-                        .iter()
-                        .filter(|msg| msg.data.sequence >= start_sequence)
-                        .cloned()
-                        .collect();
+                    let pending_msgs: Vec<SignedWorkerMessage> = self.get_msgs(start_sequence);  
                     Ok(Response::GetWorkerEgress {
                         length: pending_msgs.len(),
                         encoded_egreee_b64: base64::encode(&pending_msgs.encode())
@@ -129,7 +172,7 @@ impl System {
             Ok(resp) => resp
         }
     }
-
+    
     pub fn feed_event(&mut self) -> EventHandler {
         EventHandler {
             system: self,
@@ -138,14 +181,14 @@ impl System {
             new_round: false,
         }
     }
-
+    
     fn handle_reward_seed(&mut self, blocknum: chain::BlockNumber, reward_info: &BlockRewardInfo)
     -> Result<(), Error> {
         println!("System::handle_reward_seed({}, {:?})", blocknum, reward_info);
         let x = self.hashed_id ^ reward_info.seed;
         let online_hit = x <= reward_info.online_target;
         let compute_hit = self.comp_elected && x <= reward_info.compute_target;
-
+        
         // Push queue when necessary
         if online_hit || compute_hit {
             println!(
@@ -155,17 +198,15 @@ impl System {
                 reward_info.compute_target,
                 self.comp_elected,
             );
-            self.egress.push(
-                WorkerMessagePayload::Heartbeat {
-                    block_num: blocknum as u32,
-                    claim_online: online_hit,
-                    claim_compute: compute_hit,
-                },
-                self.id_key.as_ref().expect("Id key not set in System contract"));
+            self.push(WorkerMessagePayload::Heartbeat {
+                block_num: blocknum as u32,
+                claim_online: online_hit,
+                claim_compute: compute_hit,
+            });
         }
         Ok(())
     }
-
+    
     fn handle_new_round(
         &mut self, seed: U256, worker_snapshot: Option<&super::OnlineWorkerSnapshot>
     ) -> Result<(), Error> {
@@ -173,100 +214,99 @@ impl System {
             println!("System::handle_new_round: new round");
             self.comp_elected = comp_election::elect(
                 seed.low_u64(), &worker_snapshot, &self.machine_id);
-        } else {
-            println!("System::handle_new_round: no snapshot found; skipping this round");
-            self.comp_elected = false;
+            } else {
+                println!("System::handle_new_round: no snapshot found; skipping this round");
+                self.comp_elected = false;
+            }
+            Ok(())
         }
-        Ok(())
     }
-}
-
-pub struct EventHandler<'a> {
-    pub system: &'a mut System,
-    seed: Option<U256>,
-    new_round: bool,
-    snapshot: Option<&'a super::OnlineWorkerSnapshot>,
-}
-
-impl<'a> EventHandler<'a> {
-    pub fn feed(
-        &mut self, block_context: &'a super::BlockHeaderWithEvents, event: &PhalaEvent
-    ) -> Result<(), Error>
-    {
-        match event {
-            // Reset the egress queue once we detected myself is re-registered
-            phala::RawEvent::WorkerRegistered(_stash, pubkey, _machine_id) => {
-                if pubkey == &self.system.id_pubkey {
-                    println!("System::handle_event: Reset MsgChannel due to WorkerRegistered");
-                    self.system.egress = Default::default();
-                }
-            },
-            phala::RawEvent::WorkerRenewed(_stash, machine_id) => {
-                // Not perfect because we only have machine_id but not pubkey here.
-                if machine_id == &self.system.machine_id {
-                    println!("System::handle_event: Reset MsgChannel due to WorkerRenewed");
-                    self.system.egress = Default::default();
-                }
-            },
-            // Handle other events
-            phala::RawEvent::WorkerMessageReceived(_stash, pubkey, seq) => {
-                println!("System::handle_event: Message confirmed (seq={})", seq);
-                // Advance the egress queue messages
-                if pubkey == &self.system.id_pubkey {
-                    self.system.egress.received(*seq);
-                }
-            },
-            phala::RawEvent::RewardSeed(reward_info) => {
-                let blocknum = block_context.block_header.number;
-                self.seed = Some(reward_info.seed);
-                self.system.handle_reward_seed(blocknum, &reward_info)?;
-            },
-            phala::RawEvent::NewMiningRound(round) => {
-                println!("System::handle_event: new mining round ({})", round);
-                // Save the snapshot for later use
-                self.snapshot = block_context.worker_snapshot.as_ref();
-                self.new_round = true;
-            },
-            _ => ()
-        };
-        Ok(())
+    
+    pub struct EventHandler<'a> {
+        pub system: &'a mut System,
+        seed: Option<U256>,
+        new_round: bool,
+        snapshot: Option<&'a super::OnlineWorkerSnapshot>,
     }
-}
-
-impl<'a> Drop for EventHandler<'a> {
-    fn drop(&mut self) {
-        if let (true, Some(seed)) = (self.new_round, self.seed) {
-            self.system.handle_new_round(seed, self.snapshot)
+    
+    impl<'a> EventHandler<'a> {
+        pub fn feed(
+            &mut self, block_context: &'a super::BlockHeaderWithEvents, event: &PhalaEvent
+        ) -> Result<(), Error>
+        {
+            match event {
+                // Reset the egress queue once we detected myself is re-registered
+                phala::RawEvent::WorkerRegistered(_stash, pubkey, _machine_id) => {
+                    if pubkey == &self.system.id_pubkey {
+                        println!("System::handle_event: Reset MsgChannel due to WorkerRegistered");
+                    }
+                },
+                phala::RawEvent::WorkerRenewed(_stash, machine_id) => {
+                    // Not perfect because we only have machine_id but not pubkey here.
+                    if machine_id == &self.system.machine_id {
+                        println!("System::handle_event: Reset MsgChannel due to WorkerRenewed");
+                    }
+                },
+                // Handle other events
+                phala::RawEvent::WorkerMessageReceived(_stash, pubkey, seq) => {
+                    println!("System::handle_event: Message confirmed (seq={})", seq);
+                    // Advance the egress queue messages
+                    if pubkey == &self.system.id_pubkey {
+                        &self.system.received(*seq);
+                    }
+                },
+                phala::RawEvent::RewardSeed(reward_info) => {
+                    let blocknum = block_context.block_header.number;
+                    self.seed = Some(reward_info.seed);
+                    self.system.handle_reward_seed(blocknum, &reward_info)?;
+                },
+                phala::RawEvent::NewMiningRound(round) => {
+                    println!("System::handle_event: new mining round ({})", round);
+                    // Save the snapshot for later use
+                    self.snapshot = block_context.worker_snapshot.as_ref();
+                    self.new_round = true;
+                },
+                _ => ()
+            };
+            Ok(())
+        }
+    }
+    
+    impl<'a> Drop for EventHandler<'a> {
+        fn drop(&mut self) {
+            if let (true, Some(seed)) = (self.new_round, self.seed) {
+                self.system.handle_new_round(seed, self.snapshot)
                 .expect("System EventHandler::drop() should never fail; qed.");
+            }
         }
     }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub enum Error {
-	NotAuthorized,
-	TxHashNotFound,
-	Other(String),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum Request {
-	QueryReceipt {
-		command_index: CommandIndex,
-    },
-    GetWorkerEgress {
-        start_sequence: u64,
-    },
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub enum Response {
-	QueryReceipt {
-		receipt: TransactionReceipt
-    },
-    GetWorkerEgress {
-        length: usize,
-        encoded_egreee_b64: String,
-    },
-	Error(Error),
-}
+    
+    #[derive(Serialize, Deserialize, Debug)]
+    pub enum Error {
+        NotAuthorized,
+        TxHashNotFound,
+        Other(String),
+    }
+    
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub enum Request {
+        QueryReceipt {
+            command_index: CommandIndex,
+        },
+        GetWorkerEgress {
+            start_sequence: u64,
+        },
+    }
+    
+    #[derive(Serialize, Deserialize, Debug)]
+    pub enum Response {
+        QueryReceipt {
+            receipt: TransactionReceipt
+        },
+        GetWorkerEgress {
+            length: usize,
+            encoded_egreee_b64: String,
+        },
+        Error(Error),
+    }
+    

--- a/standalone/pruntime/enclave/start_build.sh
+++ b/standalone/pruntime/enclave/start_build.sh
@@ -1,0 +1,2 @@
+source /opt/intel/sgxsdk/environment
+SGX_MODE=SW make


### PR DESCRIPTION
Add message tunnel component
1. All messages are maintained in global variable memory, and different message channels are distinguished by enumeration type
2. Each message channel stores a list containing multiple messages with sequence_id
3. Implement interface's related methods of msg_train when sending the message. Define the message with structure.  Encode the message o  then push it into the message channel.
4. Implement interface's related methods of msg_train   when consuming messages. after receiving the message, decode it into its own structure