### PR TITLE
Set SKIP_WASM_BUILD by .cargo/config.toml

### DIFF
--- a/standalone/pruntime/enclave/.cargo/config.toml
+++ b/standalone/pruntime/enclave/.cargo/config.toml
@@ -1,0 +1,5 @@
+[unstable]
+configurable-env = true
+
+[env]
+SKIP_WASM_BUILD = "1"

--- a/standalone/pruntime/enclave/Makefile
+++ b/standalone/pruntime/enclave/Makefile
@@ -42,9 +42,9 @@ all: $(Rust_Enclave_Name)
 
 $(Rust_Enclave_Name): $(Rust_Enclave_Files)
 ifeq ($(XARGO_SGX), 1)
-	RUST_TARGET_PATH=$(Rust_Target_Path) SKIP_WASM_BUILD=1 xargo build --target x86_64-unknown-linux-sgx --release
+	RUST_TARGET_PATH=$(Rust_Target_Path) xargo build --target x86_64-unknown-linux-sgx --release
 	cp ./target/x86_64-unknown-linux-sgx/release/libenclaveapp.a ../lib/libenclave.a
 else
-	SKIP_WASM_BUILD=1 cargo build --release
+	cargo build --release
 	cp ./target/release/libenclaveapp.a ../lib/libenclave.a
 endif


### PR DESCRIPTION
Much better than putting it to a Makefile, because now it should be recognized by all the toolchains