### PR TITLE
Minor amending to #248

### DIFF
--- a/pallets/phala/src/registry.rs
+++ b/pallets/phala/src/registry.rs
@@ -188,6 +188,11 @@ pub mod pallet {
 							pubkey: pruntime_info.pubkey.clone(),
 							session_id: worker_info.session_id,
 						});
+						let now = T::UnixTime::now().as_secs().saturated_into::<u64>();
+						Self::push_message(SystemEvent::BenchStart {
+							pubkey: pruntime_info.pubkey,
+							start_time: now,
+						});
 					}
 					None => {
 						// Case 2 - New worker register

--- a/standalone/pruntime/app/src/main.rs
+++ b/standalone/pruntime/app/src/main.rs
@@ -479,11 +479,14 @@ fn main() {
     for i in 0..bench_cores {
         let child = thread::spawn(move || {
             set_thread_idle_policy();
-            let result = unsafe {
-                ecall_bench_run(eid, &mut retval, i)
-            };
-            if result != sgx_status_t::SGX_SUCCESS {
-                panic!("Init bench thread {} failed", i);
+            loop {
+                let result = unsafe {
+                    ecall_bench_run(eid, &mut retval, i)
+                };
+                if result != sgx_status_t::SGX_SUCCESS {
+                    panic!("Run benchmark {} failed", i);
+                }
+                std::thread::sleep(std::time::Duration::from_millis(200));
             }
         });
         v.push(child);

--- a/standalone/pruntime/enclave/src/lib.rs
+++ b/standalone/pruntime/enclave/src/lib.rs
@@ -867,6 +867,8 @@ fn init_secret_keys(
 pub extern "C" fn ecall_init() -> sgx_status_t {
     env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
+    benchmark::reset_iteration_counter();
+
     let mut local_state = LOCAL_STATE.lock().unwrap();
     match init_secret_keys(&mut local_state, None) {
         Err(e) if e.is::<sgx_status_t>() => e.downcast::<sgx_status_t>().unwrap(),

--- a/standalone/pruntime/enclave/src/lib.rs
+++ b/standalone/pruntime/enclave/src/lib.rs
@@ -878,8 +878,11 @@ pub extern "C" fn ecall_init() -> sgx_status_t {
 
 #[no_mangle]
 pub extern "C" fn ecall_bench_run(index: u32) -> sgx_status_t {
-    info!("[{}] Benchmark thread started", index);
-    benchmark::run()
+    if !benchmark::puasing() {
+        info!("[{}] Benchmark thread started", index);
+        benchmark::run();
+    }
+    sgx_status_t::SGX_SUCCESS
 }
 
 // --------------------------------

--- a/standalone/pruntime/enclave/src/system/mod.rs
+++ b/standalone/pruntime/enclave/src/system/mod.rs
@@ -213,7 +213,9 @@ impl System {
         }
         drop(event_handler);
         if let Some(BenchState { block, time }) = self.bench_state {
-            if block_number - block >= 5 {
+            const BENCH_DURATION: u32 = 8;
+            if block_number - block >= BENCH_DURATION {
+                benchmark::puase();
                 let report = RegistryEvent::BenchReport {
                     start_time: time,
                     iterations: benchmark::iteration_counter(),
@@ -293,7 +295,8 @@ impl<'a> EventHandler<'a> {
                         block: block_number,
                         time: *start_time,
                     });
-                    crate::benchmark::reset_iteration_counter();
+                    benchmark::reset_iteration_counter();
+                    benchmark::resume();
                 }
             }
             Event::WorkerAttached { pubkey, session_id } => {


### PR DESCRIPTION
1. pallet-registry: Redo benchmark each time worker registered.
2. pRuntime: log estimated bench score.