### PR TITLE
pruntime: Add benchmark score in api:get_info.

### DIFF
--- a/standalone/pruntime/enclave/src/benchmark.rs
+++ b/standalone/pruntime/enclave/src/benchmark.rs
@@ -85,6 +85,7 @@ fn est_score(since: u64, start: u64) -> u64 {
     if now <= since {
         return 0;
     }
+    // Normalize to 6s (standard block time)
     (ITERATION_COUNTER.load(Ordering::Relaxed) - start) * 6 / (now - since)
 }
 

--- a/standalone/pruntime/enclave/src/benchmark.rs
+++ b/standalone/pruntime/enclave/src/benchmark.rs
@@ -10,8 +10,8 @@ const UNIT: usize = 1;
 const MAX_NUM: u128 = 65536 * 128;
 
 static ITERATION_COUNTER: AtomicU64 = AtomicU64::new(0);
-static COUNT_SINCE: AtomicU64 = AtomicU64::new(0);
 static PAUSED: AtomicBool = AtomicBool::new(false);
+static SCORE: AtomicU64 = AtomicU64::new(0);
 
 fn is_prime(num: u128) -> bool {
     let tmp = num - 1;
@@ -34,17 +34,21 @@ fn count_prime(max: u128) -> usize {
 }
 
 pub fn run() {
+    let since = now();
+    let start = iteration_counter();
     loop {
         for _ in 0..UNIT {
             let _ = black_box(count_prime(black_box(MAX_NUM)));
         }
         let count = ITERATION_COUNTER.fetch_add(1, Ordering::Relaxed);
         if count % 100 == 0 {
+            let score = est_score(since, start);
             debug!(
                 "Benchmark counnter increased to {}, est score={}",
                 count,
-                est_score()
+                score,
             );
+            SCORE.store(score, Ordering::Relaxed);
         }
         if PAUSED.load(Ordering::Relaxed) {
             return;
@@ -58,9 +62,6 @@ pub fn iteration_counter() -> u64 {
 
 pub fn reset_iteration_counter() {
     ITERATION_COUNTER.store(0, Ordering::Relaxed);
-    if debugging() {
-        COUNT_SINCE.store(now(), Ordering::Relaxed);
-    }
 }
 
 pub fn puase() {
@@ -75,13 +76,16 @@ pub fn puasing() -> bool {
     PAUSED.load(Ordering::Relaxed)
 }
 
-fn est_score() -> u64 {
-    let since = COUNT_SINCE.load(Ordering::Relaxed);
+pub fn score() -> u64 {
+    SCORE.load(Ordering::Relaxed)
+}
+
+fn est_score(since: u64, start: u64) -> u64 {
     let now = now();
     if now <= since {
         return 0;
     }
-    ITERATION_COUNTER.load(Ordering::Relaxed) / (now - since)
+    (ITERATION_COUNTER.load(Ordering::Relaxed) - start) * 6 / (now - since)
 }
 
 fn debugging() -> bool {

--- a/standalone/pruntime/enclave/src/lib.rs
+++ b/standalone/pruntime/enclave/src/lib.rs
@@ -1420,6 +1420,8 @@ fn get_info(_input: &Map<String, Value>) -> Result<Value, Value> {
     };
     drop(runtime_state);
 
+    let score = benchmark::score();
+
     Ok(json!({
         "initialized": initialized,
         "public_key": pubkey,
@@ -1430,6 +1432,7 @@ fn get_info(_input: &Map<String, Value>) -> Result<Value, Value> {
         "machine_id": machine_id,
         "dev_mode": dev_mode,
         "pending_messages": pending_messages,
+        "score": score,
     }))
 }
 


### PR DESCRIPTION
Added benchmark score in the enclave api `get_info`.

Usage example:
```shell
curl -d '{"input": {}, "nonce": {}}' -H "Content-Type: application/json"  http://localhost:8000/get_info 2>/dev/null | jq -r .payload | jq .score
```