### PR TITLE
Refactor the chain storage synchronizing code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,13 +1362,14 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.14"
+version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7b9cef1e351660e5443924e4f43ab25fbbed3e9a5f052df3677deb4d6b320"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version 0.3.3",
  "syn",
 ]
 
@@ -1526,6 +1527,7 @@ name = "enclave-api"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
+ "derive_more",
  "frame-system",
  "parity-scale-codec",
  "phala-node-runtime",
@@ -6365,6 +6367,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]

--- a/standalone/pruntime/app/Cargo.lock
+++ b/standalone/pruntime/app/Cargo.lock
@@ -759,13 +759,14 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derive_more"
-version = "0.99.14"
+version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7b9cef1e351660e5443924e4f43ab25fbbed3e9a5f052df3677deb4d6b320"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "convert_case",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
+ "rustc_version 0.3.3",
  "syn 1.0.73",
 ]
 
@@ -886,6 +887,7 @@ name = "enclave-api"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
+ "derive_more",
  "frame-system",
  "parity-scale-codec",
  "phala-node-runtime",
@@ -3071,6 +3073,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3773,7 +3784,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -3809,7 +3829,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -3866,7 +3886,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -3874,6 +3903,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -5080,6 +5118,12 @@ name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"

--- a/standalone/pruntime/enclave-api/Cargo.toml
+++ b/standalone/pruntime/enclave-api/Cargo.toml
@@ -17,6 +17,7 @@ sp-runtime = { path = "../../../substrate/primitives/runtime", default-features 
 trie-storage = { path = "../../../crates/trie-storage", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"], default-features = false }
 base64 = { version = "0.13" }
+derive_more = "0.99.16"
 
 [features]
 default = ["std"]

--- a/standalone/pruntime/enclave-api/src/lib.rs
+++ b/standalone/pruntime/enclave-api/src/lib.rs
@@ -166,7 +166,6 @@ pub mod block_feeders {
     #[derive(Display)]
     pub enum Error {
         EmptyRequest,
-        CodecError,
         MissingJustification,
         IncorrectHeaderOrder,
         HeaderValidateFailed,
@@ -273,6 +272,8 @@ pub mod block_feeders {
     }
 
     impl BlockFeeder {
+
+        /// Feed a block and apply changes to storage if it's valid.
         fn feed_block(
             &mut self,
             block: &BlockHeaderWithEvents,
@@ -380,7 +381,7 @@ pub mod block_feeders {
 
             check_headers_hash(&headers)?;
 
-            // All checks passed, record the state roots
+            // All checks passed, enqueue the state roots for storage validation.
             for hdr in headers.iter().rev() {
                 self.block_feeder.state_roots.push_back(hdr.state_root);
             }

--- a/standalone/pruntime/enclave-api/src/lib.rs
+++ b/standalone/pruntime/enclave-api/src/lib.rs
@@ -213,7 +213,11 @@ pub mod storage_sync {
     pub struct BlockSyncState<Validator> {
         validator: Validator,
         main_bridge: u64,
+        /// The next block number of header to be sync.
         header_number_next: chain::BlockNumber,
+        /// The next block number of storage to be sync.
+        /// Note: in parachain mode the `block_number_next` is for the parachain and the
+        /// header_number_next is for the relaychain.
         block_number_next: chain::BlockNumber,
     }
 
@@ -418,11 +422,11 @@ pub mod storage_sync {
 
             let last_hdr = headers.last().ok_or(Error::EmptyRequest)?;
 
-            let state_root = if let Some(root) = &self.last_relaychain_state_root {
-                root.clone()
-            } else {
-                return Err(Error::RelaychainHeaderNotSynced);
-            };
+            let state_root = self
+                .last_relaychain_state_root
+                .as_ref()
+                .cloned()
+                .ok_or(Error::RelaychainHeaderNotSynced)?;
 
             // 1. validate storage proof
             self.sync_state.validator.validate_storage_proof(

--- a/standalone/pruntime/enclave/Cargo.lock
+++ b/standalone/pruntime/enclave/Cargo.lock
@@ -567,13 +567,14 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.14"
+version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7b9cef1e351660e5443924e4f43ab25fbbed3e9a5f052df3677deb4d6b320"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote 1.0.9",
+ "rustc_version 0.3.3",
  "syn 1.0.73",
 ]
 
@@ -728,6 +729,7 @@ name = "enclave-api"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more",
  "frame-system",
  "parity-scale-codec 2.2.0",
  "phala-node-runtime",
@@ -2115,6 +2117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "phala-crypto"
 version = "0.1.0"
 dependencies = [
@@ -2542,7 +2553,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -2570,7 +2590,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -2638,7 +2658,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -2646,6 +2675,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -3615,6 +3653,12 @@ dependencies = [
  "quote 1.0.9",
  "syn 1.0.73",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"

--- a/standalone/pruntime/enclave/src/light_validation/mod.rs
+++ b/standalone/pruntime/enclave/src/light_validation/mod.rs
@@ -419,6 +419,15 @@ pub mod utils {
     }
 
     /// Calculates the Substrate storage key prefix for a StorageMap
+    pub fn storage_map_prefix(module: &str, storage_item: &str, item_key: &[u8]) -> Vec<u8> {
+        let mut bytes = storage_prefix(module, storage_item);
+        let hash = sp_core::twox_64(&item_key);
+        bytes.extend(&hash);
+        bytes.extend(item_key);
+        bytes
+    }
+
+    /// Calculates the Substrate storage key prefix for a StorageMap
     pub fn storage_map_prefix_twox_64_concat(module: &[u8], storage_item: &[u8], key: &impl Encode) -> Vec<u8> {
         let mut bytes = sp_core::twox_128(module).to_vec();
         bytes.extend(&sp_core::twox_128(storage_item)[..]);

--- a/standalone/pruntime/enclave/src/storage_sync.rs
+++ b/standalone/pruntime/enclave/src/storage_sync.rs
@@ -1,0 +1,34 @@
+use crate::light_validation::LightValidation;
+use enclave_api::storage_sync::{BlockValidator, Error as SyncError, Result};
+use parity_scale_codec::Decode;
+
+impl BlockValidator for LightValidation<chain::Runtime> {
+    fn submit_finalized_headers(
+        &mut self,
+        bridge_id: u64,
+        header: chain::Header,
+        ancestry_proof: sp_application_crypto::Vec<chain::Header>,
+        grandpa_proof: sp_application_crypto::Vec<u8>,
+        auhtority_set_change: Option<enclave_api::blocks::AuthoritySetChange>,
+    ) -> Result<()> {
+        self.submit_finalized_headers(
+            bridge_id,
+            header,
+            ancestry_proof,
+            grandpa_proof,
+            auhtority_set_change,
+        )
+        .map_err(|_| SyncError::HeaderValidateFailed)
+    }
+
+    fn validate_storage_proof(
+        &self,
+        state_root: chain::Hash,
+        mut proof: &[u8],
+        items: &[(&[u8], &[u8])],
+    ) -> Result<()> {
+        let proof = Decode::decode(&mut proof).map_err(|_| SyncError::CodecError)?;
+        self.validate_storage_proof(state_root, proof, items)
+            .map_err(|_| SyncError::HeaderValidateFailed)
+    }
+}

--- a/standalone/pruntime/enclave/src/system/mod.rs
+++ b/standalone/pruntime/enclave/src/system/mod.rs
@@ -407,7 +407,7 @@ impl System {
         }
     }
 
-    pub fn process_messages(&mut self, block: &BlockInfo, storage: &Storage) -> anyhow::Result<()> {
+    pub fn process_messages(&mut self, block: &BlockInfo) -> anyhow::Result<()> {
         loop {
             match self.ingress.try_next() {
                 Ok(Some((_, event, sender))) => {
@@ -436,7 +436,7 @@ impl System {
         // if pRuntime possesses master key but is not registered on chain
         // TODO.shelven: this does not hold after we enable master key rotation
         if self.gatekeeper.possess_master_key()
-            || crate::identity::is_gatekeeper(&self.worker_state.pubkey, storage)
+            || crate::identity::is_gatekeeper(&self.worker_state.pubkey, block.storage)
         {
             self.gatekeeper.process_messages(block);
 


### PR DESCRIPTION
The sync_header and part of dispatch_block code was splitted to a seperate crate for better flexibility.
Later, parachain syncing codes will based on the PR.