### PR TITLE
Correctly apply withdraw grace period

### DIFF
--- a/e2e/tests/typeoverride.js
+++ b/e2e/tests/typeoverride.js
@@ -2,7 +2,7 @@ const types = {
     "Address": "MultiAddress",
     "LookupSource": "MultiAddress",
     "RawSolution": "RawSolutionWith24",
-    "ChainId": "u8",
+    "BridgeChainId": "u8",
     "ResourceId": "[u8; 32]",
     "TokenId": "u256",
     "DepositNonce": "u64",

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1088,6 +1088,7 @@ impl pallet_mining::Config for Runtime {
 	type OnReward = PhalaStakePool;
 	type OnUnbound = PhalaStakePool;
 	type OnReclaim = PhalaStakePool;
+	type OnStopped = PhalaStakePool;
 }
 impl pallet_stakepool::Config for Runtime {
 	type Event = Event;


### PR DESCRIPTION
Fixes #334 

- `PoolInfo::releasing_stake` to account the releasing stake due to force shutdown
- Shut down a pool by force if releasing_stake cannot cover the request after the grace period
- (Accurately) predict the stake return and slashed amount when stopping a miner