### PR TITLE
chain: introduce CheckMqSequence to manage mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5786,6 +5786,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
  "phala-node-runtime",
+ "phala-pallets",
  "platforms",
  "rand 0.7.3",
  "regex",

--- a/pallets/bridge_transfer/src/mock.rs
+++ b/pallets/bridge_transfer/src/mock.rs
@@ -120,7 +120,18 @@ impl Config for Test {
 }
 
 impl mq::Config for Test {
+	type CallMatcher = MqCallMatcher;
 	type QueueNotifyConfig = ();
+}
+
+pub struct MqCallMatcher;
+impl mq::CallMatcher<Test> for MqCallMatcher {
+	fn match_call(call: &Call) -> Option<&mq::Call<Test>> {
+		match call {
+			Call::PhalaMq(mq_call) => Some(mq_call),
+			_ => None,
+		}
+	}
 }
 
 impl reg::Config for Test {

--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -33,7 +33,7 @@ frame_support::construct_runtime!(
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		// Pallets to test
-		PhalaMq: mq::{Pallet},
+		PhalaMq: mq::{Pallet, Call},
 		PhalaRegistry: registry::{Pallet, Event, Storage, Config<T>},
 		PhalaMining: mining::{Pallet, Event<T>, Storage, Config},
 		PhalaStakePool: stakepool::{Pallet, Event<T>},
@@ -101,6 +101,17 @@ pub const CENTS: Balance = DOLLARS / 100;
 
 impl mq::Config for Test {
 	type QueueNotifyConfig = ();
+	type CallMatcher = MqCallMatcher;
+}
+
+pub struct MqCallMatcher;
+impl mq::CallMatcher<Test> for MqCallMatcher {
+	fn match_call(call: &Call) -> Option<&mq::Call<Test>> {
+		match call {
+			Call::PhalaMq(mq_call) => Some(mq_call),
+			_ => None,
+		}
+	}
 }
 
 impl registry::Config for Test {

--- a/pallets/phala/src/mq.rs
+++ b/pallets/phala/src/mq.rs
@@ -20,9 +20,9 @@ pub mod pallet {
 	use sp_std::vec::Vec;
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
-		// config
+	pub trait Config: frame_system::Config + crate::registry::Config {
 		type QueueNotifyConfig: QueueNotifyConfig;
+		type CallMatcher: CallMatcher<Self>;
 	}
 
 	#[pallet::pallet]
@@ -158,6 +158,13 @@ pub mod pallet {
 	}
 	impl QueueNotifyConfig for () {}
 
+	/// Needs an extrenal helper struct to extract MqCall from all callables
+	pub trait CallMatcher<T: Config> {
+		fn match_call(call: &T::Call) -> Option<&Call<T>>
+		where
+			<T as frame_system::Config>::AccountId: IntoH256;
+	}
+
 	pub trait IntoH256 {
 		fn into_h256(self) -> H256;
 	}
@@ -203,3 +210,7 @@ pub mod pallet {
 		}
 	}
 }
+
+/// Provides `SignedExtension` to check message sequence.
+mod check_seq;
+pub use check_seq::CheckMqSequence;

--- a/pallets/phala/src/mq/check_seq.rs
+++ b/pallets/phala/src/mq/check_seq.rs
@@ -1,0 +1,172 @@
+use super::{Call, CallMatcher, Config, IntoH256, OffchainIngress};
+
+use codec::{Decode, Encode};
+use frame_support::weights::DispatchInfo;
+use sp_runtime::traits::{DispatchInfoOf, Dispatchable, SignedExtension};
+use sp_runtime::transaction_validity::{
+	InvalidTransaction, TransactionLongevity, TransactionValidity, TransactionValidityError,
+	ValidTransaction,
+};
+use sp_std::{marker::PhantomData, vec};
+
+/// Requires a message queue message must has correct sequence id.
+///
+/// We only care about `sync_offchain_message` call.
+///
+/// When a message comes to the transaction pool, we drop it immediately if its sequence is
+/// less than the expected one. Otherwise we keep the message in the pool for a while, hoping there
+/// will be a sequence of continuous messages to be included in the future block.
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+pub struct CheckMqSequence<T>(PhantomData<T>);
+
+impl<T> CheckMqSequence<T> {
+	pub fn new() -> Self {
+		Self(Default::default())
+	}
+}
+
+impl<T: Config> sp_std::fmt::Debug for CheckMqSequence<T> {
+	#[cfg(feature = "std")]
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		write!(f, "CheckMqSequence()")
+	}
+
+	#[cfg(not(feature = "std"))]
+	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		Ok(())
+	}
+}
+
+impl<T: Config> SignedExtension for CheckMqSequence<T>
+where
+	T::Call: Dispatchable<Info = DispatchInfo>,
+	T: Send + Sync,
+	T::AccountId: IntoH256,
+{
+	const IDENTIFIER: &'static str = "CheckMqSequence";
+	type AccountId = T::AccountId;
+	type Call = T::Call;
+	type AdditionalSigned = ();
+	type Pre = ();
+
+	fn additional_signed(&self) -> sp_std::result::Result<(), TransactionValidityError> {
+		Ok(())
+	}
+
+	fn pre_dispatch(
+		self,
+		_who: &Self::AccountId,
+		call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> Result<(), TransactionValidityError> {
+		let signed_message = match T::CallMatcher::match_call(call) {
+			Some(Call::sync_offchain_message(signed_message)) => signed_message,
+			_ => return Ok(()),
+		};
+		let sender = &signed_message.message.sender;
+		let sequence = signed_message.sequence;
+		let expected_seq = OffchainIngress::<T>::get(sender).unwrap_or(0);
+		// Strictly require the message to include must match the expected sequence id
+		if sequence != expected_seq {
+			return Err(if sequence < expected_seq {
+				InvalidTransaction::Stale
+			} else {
+				InvalidTransaction::Future
+			}
+			.into());
+		}
+		Ok(())
+	}
+
+	fn validate(
+		&self,
+		_who: &Self::AccountId,
+		call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> TransactionValidity {
+		let signed_message = match T::CallMatcher::match_call(call) {
+			Some(Call::sync_offchain_message(signed_message)) => signed_message,
+			_ => return Ok(ValidTransaction::default()),
+		};
+		let sender = &signed_message.message.sender;
+		let sequence = signed_message.sequence;
+		let expected_seq = OffchainIngress::<T>::get(sender).unwrap_or(0);
+		// Drop the stale message immediately
+		if sequence < expected_seq {
+			return InvalidTransaction::Stale.into();
+		}
+		// Otherwise build a dependency graph based on (sender, sequence), hoping that it can be
+		// included later
+		let provides = vec![Encode::encode(&(sender, sequence))];
+		let requires = if sequence > expected_seq {
+			vec![Encode::encode(&(sender, sequence - 1))]
+		} else {
+			vec![]
+		};
+
+		Ok(ValidTransaction {
+			priority: 0,
+			requires,
+			provides,
+			longevity: TransactionLongevity::max_value(),
+			propagate: true,
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::{new_test_ext, worker_pubkey, Call as TestCall, Test};
+	use frame_support::{assert_noop, assert_ok, weights::DispatchInfo};
+	use phala_types::messaging::{Message, MessageOrigin, SignedMessage, Topic};
+
+	#[test]
+	fn test_check_mq_seq_works() {
+		new_test_ext().execute_with(|| {
+			OffchainIngress::<Test>::insert(&MessageOrigin::Worker(worker_pubkey(1)), 1);
+			OffchainIngress::<Test>::insert(&MessageOrigin::Worker(worker_pubkey(2)), 2);
+			let info = DispatchInfo::default();
+			let len = 0_usize;
+			// stale
+			assert_noop!(
+				extra().validate(&1, &sync_msg_call(1, 0), &info, len),
+				InvalidTransaction::Stale
+			);
+			assert_noop!(
+				extra().pre_dispatch(&1, &sync_msg_call(1, 0), &info, len),
+				InvalidTransaction::Stale
+			);
+			// correct
+			assert_ok!(extra().validate(&1, &sync_msg_call(1, 1), &info, len));
+			assert_ok!(extra().pre_dispatch(&1, &sync_msg_call(1, 1), &info, len));
+			// future
+			assert_ok!(extra().validate(&1, &sync_msg_call(1, 2), &info, len));
+			assert_noop!(
+				extra().pre_dispatch(&1, &sync_msg_call(1, 2), &info, len),
+				InvalidTransaction::Future
+			);
+			// no cross dependency
+			assert_ok!(extra().validate(&1, &sync_msg_call(2, 2), &info, len));
+			assert_ok!(extra().pre_dispatch(&1, &sync_msg_call(2, 2), &info, len));
+		})
+	}
+
+	fn extra() -> CheckMqSequence<Test> {
+		CheckMqSequence::<Test>::new()
+	}
+
+	fn sync_msg_call(i: u8, seq: u64) -> TestCall {
+		TestCall::PhalaMq(Call::<Test>::sync_offchain_message(SignedMessage {
+			message: Message::new(
+				MessageOrigin::Worker(worker_pubkey(i)),
+				Topic::new(*b""),
+				Vec::new(),
+			),
+			sequence: seq,
+			signature: Vec::new(),
+		}))
+	}
+}

--- a/pallets/phala/src/stakepool.rs
+++ b/pallets/phala/src/stakepool.rs
@@ -22,7 +22,7 @@ pub mod pallet {
 		traits::{Saturating, TrailingZeroInput, Zero},
 		Permill, SaturatedConversion,
 	};
-	use sp_std::{vec, collections::vec_deque::VecDeque, fmt::Display, prelude::*};
+	use sp_std::{collections::vec_deque::VecDeque, fmt::Display, prelude::*, vec};
 
 	use phala_types::{messaging::SettleInfo, WorkerPublicKey};
 

--- a/standalone/node/Cargo.toml
+++ b/standalone/node/Cargo.toml
@@ -111,6 +111,8 @@ wasm-bindgen-futures = { version = "0.4.18", optional = true }
 browser-utils = { package = "substrate-browser-utils", path = "../../substrate/utils/browser", optional = true }
 libp2p-wasm-ext = { version = "0.28", features = ["websocket"], optional = true }
 
+phala-pallets = { path = "../../pallets/phala" }
+
 [target.'cfg(target_arch="x86_64")'.dependencies]
 node-executor = { version = "2.0.0", path = "../executor", features = [ "wasmtime" ] }
 sc-cli = { optional = true, path = "../../substrate/client/cli", features = [ "wasmtime" ] }

--- a/standalone/node/src/service.rs
+++ b/standalone/node/src/service.rs
@@ -806,6 +806,7 @@ mod tests {
 				let check_era = frame_system::CheckEra::from(Era::Immortal);
 				let check_nonce = frame_system::CheckNonce::from(index);
 				let check_weight = frame_system::CheckWeight::new();
+				let check_mq_sequence = phala_pallets::mq::CheckMqSequence::new();
 				let payment = pallet_transaction_payment::ChargeTransactionPayment::from(0);
 				let extra = (
 					check_spec_version,
@@ -814,12 +815,13 @@ mod tests {
 					check_era,
 					check_nonce,
 					check_weight,
+					check_mq_sequence,
 					payment,
 				);
 				let raw_payload = SignedPayload::from_raw(
 					function,
 					extra,
-					(spec_version, transaction_version, genesis_hash, genesis_hash, (), (), ())
+					(spec_version, transaction_version, genesis_hash, genesis_hash, (), (), (), ())
 				);
 				let signature = raw_payload.using_encoded(|payload|	{
 					signer.sign(payload)


### PR DESCRIPTION
Fixes #232 

This change will introduce a new `SignedExtension` called `CheckMqSequence`. It does two things:

1. Reject any message with its sequence lower than expected early (from being included to a mempool or broadcasted to the p2p network)
2. Keep all the messages from the same sender in a topological order in the mempool, and only include the expected messages in block

This change will ensure no gas burning for redundant or out-of-order messages. Companion changes in `pherry` may be necessary to protect it from crashing when syncing redundant messages.

Note that in principle we should add the corresponding logic of a `SignedExtension` to all the Substrate clients (i.e. Polkadot.js, subxt). However since `CheckMqSequence` doesn't attach any data to a transaction, it can be treated as no-op safely. Polkadot.js and subxt noticed the extension, but fortunately they didn't refuse to work. It may not be the case in the future.

Tested:

- Unit test (coverage)
- E2E