### PR TITLE
Integrate pruntime compiling and e2e testing for CI

### DIFF
--- a/.github/actions/install_toolchain/action.yml
+++ b/.github/actions/install_toolchain/action.yml
@@ -1,0 +1,9 @@
+runs:
+  using: "composite"
+  steps: 
+    - name: Install System Level Dependencies
+      run: sudo apt-get install build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev git cmake perl pkg-config curl llvm-10 clang-10 libclang-10-dev
+    - name: Download Intel SGX SDK
+      run: wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.12.100.3.bin
+    - name: Install Intel SGX SDK
+      run: chmod +x ./sgx_linux_x64_sdk_2.12.100.3.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build and Test
 
 on:
   push:
@@ -10,7 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-core-blockchain:
+    name: build-core-blockchain
     runs-on: ubuntu-20.04
     steps:
     - name: Install latest nightly
@@ -19,17 +20,147 @@ jobs:
           toolchain: nightly-2021-05-11
           override: true
           target: wasm32-unknown-unknown
-    - name: Install llvm-10
-      run: sudo apt-get install llvm-10 clang-10
+    - name: Install System Level Dependencies
+      run: sudo apt-get install build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev git cmake perl pkg-config curl llvm-10 clang-10 libclang-10-dev
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
-    - name: Build
+        
+    - name: Build core blockchain
       run: cargo build --verbose --release
-    - name: Save binaries
-      uses: actions/upload-artifact@v1
+    - name: Save core-blockchain binaries
+      uses: actions/upload-artifact@v2
       with:
-        name: binaries
-        path: target/release/phala-node
-    - name: Tests
+        name: core-blockchain-binaries
+        path: ./target/release/phala-node
+    - name: Save pherry binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: pherry-binaries
+        path: ./target/release/pherry
+        
+  build-pruntime:
+    name: build-pruntime
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly-2021-05-11
+          override: true
+          target: wasm32-unknown-unknown
+    - name: Install System Level Dependencies
+      run: sudo apt-get install build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev git cmake perl pkg-config curl llvm-10 clang-10 libclang-10-dev
+    - name: Download Intel SGX SDK
+      run: wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.12.100.3.bin
+    - name: Install Intel SGX SDK
+      run: chmod +x ./sgx_linux_x64_sdk_2.12.100.3.bin && echo -e 'no\n/opt/intel' | sudo ./sgx_linux_x64_sdk_2.12.100.3.bin
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v2.4.0
+      with:
+        node-version: 14.x
+    - name: Install yarn 2
+      run: sudo npm install -g yarn && yarn set version berry
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    
+    - name: Build pRuntime
+      run: source /opt/intel/sgxsdk/environment && cd ./standalone/pruntime/ && SGX_MODE=SW make
+    - name: Save pruntime binaries [./bin/app]
+      uses: actions/upload-artifact@v2
+      with:
+        name: pruntime-binaries-app
+        path: ./standalone/pruntime/bin/app
+    - name: Save pruntime binaries [./bin/enclave.signed.so]
+      uses: actions/upload-artifact@v2
+      with:
+        name: pruntime-binaries-enclave
+        path: ./standalone/pruntime/bin/enclave.signed.so
+    - name: Save pruntime binaries [./bin/Rocket.toml]
+      uses: actions/upload-artifact@v2
+      with:
+        name: pruntime-binaries-rocket
+        path: ./standalone/pruntime/bin/Rocket.toml
+  
+  e2e-test:
+    name: e2e-test
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly-2021-05-11
+          override: true
+          target: wasm32-unknown-unknown
+    - name: Install System Level Dependencies
+      run: sudo apt-get install build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev git cmake perl pkg-config curl llvm-10 clang-10 libclang-10-dev
+    - name: Download Intel SGX SDK
+      run: wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.12.100.3.bin
+    - name: Install Intel SGX SDK
+      run: chmod +x ./sgx_linux_x64_sdk_2.12.100.3.bin && echo -e 'no\n/opt/intel' | sudo ./sgx_linux_x64_sdk_2.12.100.3.bin
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v2.4.0
+      with:
+        node-version: 14.x
+    - name: Install yarn 2
+      run: sudo npm install -g yarn && yarn set version berry
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    
+    - name: Remove folders
+      run: rm -rf ./target/release/phala-node ./target/release/pherry ./standalone/pruntime/bin/app ./standalone/pruntime/bin/enclave.signed.so ./standalone/pruntime/bin/Rocket.toml
+    - name: Download core-blockchain binaries
+      uses: actions/download-artifact@v2.0.10
+      with:
+        name: core-blockchain-binaries
+        path: ./target/release
+    - name: Download pherry binaries
+      uses: actions/download-artifact@v2.0.10
+      with:
+        name: pherry-binaries
+        path: ./target/release
+    - name: Download pruntime binaries app
+      uses: actions/download-artifact@v2.0.10
+      with:
+        name: pruntime-binaries-app
+        path: ./standalone/pruntime/bin
+    - name: Download pruntime binaries enclave
+      uses: actions/download-artifact@v2.0.10
+      with:
+        name: pruntime-binaries-enclave
+        path: ./standalone/pruntime/bin
+    - name: Download pruntime binaries rocket
+      uses: actions/download-artifact@v2.0.10
+      with:
+        name: pruntime-binaries-rocket
+        path: ./standalone/pruntime/bin
+    - name: Change permission
+      run: chmod 777 ./target/release/phala-node ./target/release/pherry ./standalone/pruntime/bin/app ./standalone/pruntime/bin/enclave.signed.so ./standalone/pruntime/bin/Rocket.toml
+    
+    - name: E2E Tests
+      run: echo "/opt/intel/sgxsdk/lib64/" | sudo tee /etc/ld.so.conf.d/intel-libsgx.conf | sudo ldconfig && source /opt/intel/sgxsdk/environment && yarn set version berry && cd ./e2e/ && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn && yarn test
+    needs: [build-core-blockchain, build-pruntime]
+    
+      
+  cargo-tests:
+    name: cargo-tests
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly-2021-05-11
+          override: true
+          target: wasm32-unknown-unknown
+    - name: Install System Level Dependencies
+      run: sudo apt-get install build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev git cmake perl pkg-config curl llvm-10 clang-10 libclang-10-dev
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    
+    - name: Cargo Tests
       run: cargo test --verbose --workspace  --exclude node-executor --exclude phala-node
+    
+  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,12 +49,6 @@ jobs:
       with:
         submodules: 'true'
     - uses: ./.github/actions/install_toolchain
-    - name: Setup Node.js environment
-      uses: actions/setup-node@v2.4.0
-      with:
-        node-version: 14.x
-    - name: Install yarn 2
-      run: sudo npm install -g yarn && yarn set version berry
     
     - name: Build pRuntime
       run: source /opt/intel/sgxsdk/environment && cd ./standalone/pruntime/ && SGX_MODE=SW make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,6 @@ jobs:
     - name: Install yarn 2
       run: sudo npm install -g yarn && yarn set version berry
     
-    - name: Remove folders
-      run: rm -rf ./target/release/phala-node ./target/release/pherry ./standalone/pruntime/bin/app ./standalone/pruntime/bin/enclave.signed.so ./standalone/pruntime/bin/Rocket.toml
     - name: Download core-blockchain binaries
       uses: actions/download-artifact@v2.0.10
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-core-blockchain:
-    name: build-core-blockchain
+    name: Build core blockchain
     runs-on: ubuntu-20.04
     steps:
     - name: Install latest nightly
@@ -20,8 +20,7 @@ jobs:
           toolchain: nightly-2021-05-11
           override: true
           target: wasm32-unknown-unknown
-    - name: Install System Level Dependencies
-      run: sudo apt-get install build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev git cmake perl pkg-config curl llvm-10 clang-10 libclang-10-dev
+    - uses: .github/actions/install_toolchain@v1
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
@@ -40,7 +39,7 @@ jobs:
         path: ./target/release/pherry
         
   build-pruntime:
-    name: build-pruntime
+    name: Build pruntime
     runs-on: ubuntu-20.04
     steps:
     - name: Install latest nightly
@@ -49,12 +48,7 @@ jobs:
           toolchain: nightly-2021-05-11
           override: true
           target: wasm32-unknown-unknown
-    - name: Install System Level Dependencies
-      run: sudo apt-get install build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev git cmake perl pkg-config curl llvm-10 clang-10 libclang-10-dev
-    - name: Download Intel SGX SDK
-      run: wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.12.100.3.bin
-    - name: Install Intel SGX SDK
-      run: chmod +x ./sgx_linux_x64_sdk_2.12.100.3.bin && echo -e 'no\n/opt/intel' | sudo ./sgx_linux_x64_sdk_2.12.100.3.bin
+    - uses: .github/actions/install_toolchain@v1
     - name: Setup Node.js environment
       uses: actions/setup-node@v2.4.0
       with:
@@ -84,7 +78,7 @@ jobs:
         path: ./standalone/pruntime/bin/Rocket.toml
   
   e2e-test:
-    name: e2e-test
+    name: Run E2E tests
     runs-on: ubuntu-20.04
     steps:
     - name: Install latest nightly
@@ -93,12 +87,7 @@ jobs:
           toolchain: nightly-2021-05-11
           override: true
           target: wasm32-unknown-unknown
-    - name: Install System Level Dependencies
-      run: sudo apt-get install build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev git cmake perl pkg-config curl llvm-10 clang-10 libclang-10-dev
-    - name: Download Intel SGX SDK
-      run: wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.12.100.3.bin
-    - name: Install Intel SGX SDK
-      run: chmod +x ./sgx_linux_x64_sdk_2.12.100.3.bin && echo -e 'no\n/opt/intel' | sudo ./sgx_linux_x64_sdk_2.12.100.3.bin
+    - uses: .github/actions/install_toolchain@v1
     - name: Setup Node.js environment
       uses: actions/setup-node@v2.4.0
       with:
@@ -139,13 +128,13 @@ jobs:
     - name: Change permission
       run: chmod 777 ./target/release/phala-node ./target/release/pherry ./standalone/pruntime/bin/app ./standalone/pruntime/bin/enclave.signed.so ./standalone/pruntime/bin/Rocket.toml
     
-    - name: E2E Tests
+    - name: Run E2E tests
       run: echo "/opt/intel/sgxsdk/lib64/" | sudo tee /etc/ld.so.conf.d/intel-libsgx.conf | sudo ldconfig && source /opt/intel/sgxsdk/environment && yarn set version berry && cd ./e2e/ && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn && yarn test
     needs: [build-core-blockchain, build-pruntime]
     
       
   cargo-tests:
-    name: cargo-tests
+    name: Run cargo tests
     runs-on: ubuntu-20.04
     steps:
     - name: Install latest nightly
@@ -154,13 +143,12 @@ jobs:
           toolchain: nightly-2021-05-11
           override: true
           target: wasm32-unknown-unknown
-    - name: Install System Level Dependencies
-      run: sudo apt-get install build-essential ocaml ocamlbuild automake autoconf libtool wget python libssl-dev git cmake perl pkg-config curl llvm-10 clang-10 libclang-10-dev
+    - uses: .github/actions/install_toolchain@v1
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
     
-    - name: Cargo Tests
+    - name: Run cargo tests
       run: cargo test --verbose --workspace  --exclude node-executor --exclude phala-node
     
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           toolchain: nightly-2021-05-11
           override: true
           target: wasm32-unknown-unknown
-    - uses: .github/actions/install_toolchain@v1
+    - uses: ./.github/actions/install_toolchain@v1
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
@@ -48,7 +48,7 @@ jobs:
           toolchain: nightly-2021-05-11
           override: true
           target: wasm32-unknown-unknown
-    - uses: .github/actions/install_toolchain@v1
+    - uses: ./.github/actions/install_toolchain@v1
     - name: Setup Node.js environment
       uses: actions/setup-node@v2.4.0
       with:
@@ -87,7 +87,7 @@ jobs:
           toolchain: nightly-2021-05-11
           override: true
           target: wasm32-unknown-unknown
-    - uses: .github/actions/install_toolchain@v1
+    - uses: ./.github/actions/install_toolchain@v1
     - name: Setup Node.js environment
       uses: actions/setup-node@v2.4.0
       with:
@@ -143,7 +143,7 @@ jobs:
           toolchain: nightly-2021-05-11
           override: true
           target: wasm32-unknown-unknown
-    - uses: .github/actions/install_toolchain@v1
+    - uses: ./.github/actions/install_toolchain@v1
     - uses: actions/checkout@v2
       with:
         submodules: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
         path: ./standalone/pruntime/bin
    
     - name: Change permission
-      run: chmod 777 ./target/release/phala-node ./target/release/pherry ./standalone/pruntime/bin/app ./standalone/pruntime/bin/enclave.signed.so ./standalone/pruntime/bin/Rocket.toml
+      run: chmod +x ./target/release/phala-node ./target/release/pherry ./standalone/pruntime/bin/app
     
     - name: Run E2E tests
       run: echo "/opt/intel/sgxsdk/lib64/" | sudo tee /etc/ld.so.conf.d/intel-libsgx.conf | sudo ldconfig && source /opt/intel/sgxsdk/environment && yarn set version berry && cd ./e2e/ && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn && yarn test


### PR DESCRIPTION
This PR tries to deliver #58: Enable E2E test in CI

What this PR achieves:
1. Compiling `pruntime` by Github Actions.
2. Run E2E Testing in Github Actions.
3. Paralleling building and testing to minimize the execution time. Currently there are in total 4 jobs implemented: `build-core-blockchain`, `build-pruntime`, `cargo-test` and `e2e-test`, where the first 3 jobs will be executed in parallel and the `e2e-test` task will be executed after finishing `build-core-blockchain` and `build-pruntime` jobs.

What this PR lacks:
While this PR has all necessary configurations for CI to compile and test (e.g. link shared library, add environment variables, handle artifacts exchanging, etc.), currently this workflow will likely to be fail due to some type errors in `e2e/tests/typeoverride.js` as following:

```
  A full stack
2021-08-07 19:42:24        REGISTRY: Unknown signed extensions CheckMqSequence found, treating them as no-effect
2021-08-07 19:42:24        REGISTRY: Unable to resolve type ChainId, it will fail on construction
2021-08-07 19:42:24        API/INIT: Error: FATAL: Unable to initialize the API: createType(ChainId):: Cannot construct unknown type ChainId
    at EventEmitter.value (/home/runner/work/phala-blockchain/phala-blockchain/e2e/node_modules/@polkadot/api/base/Init.cjs:88:25)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at runNextTicks (internal/process/task_queues.js:64:3)
    at processImmediate (internal/timers.js:437:9)
```

From the error info, it seems that it is caused by a un-stated type `ChainId`. In fact, I can confirm that after I adding a `ChainId: u8` to the `e2e/tests/typeoverride.js`, this error will be dismissed. However,  me appending `ChainId: u8` was just to validate my assumption, and since I generally know little about phala's system design, I believe that this issue should not be fixed in this PR.

Consequently, despite of this issue, I think this PR will meet the requirements set by #58. Any possible improvement on this PR are welcomed and appreciated!