### PR TITLE
Properly manage account nonce

### DIFF
--- a/standalone/pherry/src/msg_sync.rs
+++ b/standalone/pherry/src/msg_sync.rs
@@ -4,8 +4,9 @@ use log::{error, info};
 use std::time::Duration;
 
 use crate::chain_client::fetch_mq_ingress_seq;
+use subxt::Signer;
 
-use super::{runtimes, update_signer_nonce, PrClient, SrSigner, XtClient};
+use super::{chain_client::update_signer_nonce, runtimes, PrClient, SrSigner, XtClient};
 
 /// Hold everything needed to sync some egress messages back to the blockchain
 pub struct MsgSync<'a> {
@@ -57,10 +58,11 @@ impl<'a> MsgSync<'a> {
                     continue;
                 }
                 let msg_info = format!(
-                    "sender={:?} seq={} dest={}",
+                    "sender={:?} seq={} dest={} nonce={:?}",
                     sender,
                     message.sequence,
-                    String::from_utf8_lossy(&message.message.destination.path()[..])
+                    String::from_utf8_lossy(&message.message.destination.path()[..]),
+                    self.signer.nonce()
                 );
                 info!("Submitting message: {}", msg_info);
                 let extrinsic = self

--- a/subxt/src/frame/system.rs
+++ b/subxt/src/frame/system.rs
@@ -54,7 +54,7 @@ pub trait System {
     /// transactions associated with a sender account.
     type Index: Parameter
         + Member
-        + MaybeSerialize
+        + MaybeSerializeDeserialize
         + Debug
         + Default
         + MaybeDisplay

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -423,6 +423,14 @@ impl<T: Runtime> Rpc<T> {
         Ok(self.client.request("system_syncState", &[]).await?)
     }
 
+    /// Fetch account next nonce
+    pub async fn system_account_next_index(
+        &self, account: &T::AccountId
+    ) -> Result<T::Index, Error> {
+        let params = &[to_json_value(account)?];
+        Ok(self.client.request("system_accountNextIndex", params).await?)
+    }
+
     /// Get a header
     pub async fn header(
         &self,


### PR DESCRIPTION
Fixes #378 

- Add `system_accountNextIndex` rpc to subxt
- Read nonce from txpool instead of managing an increasing series

Tested: e2e, testnet

In the past design, `pherry` always track the nonce of the sender account locally. Everytime tie send a transaction, the nonce increases. However this assumes all the transaction will be eventually included in a block. This is not always guaranteed, and it's especially bad after #372.

So in this PR, we read the next nonce from the full node txpool instead. The full node always returns the best next nonce to use. We do this all the time before we want to send transactions.

Note that is has to be handled carefully. The next nonce returned by the full node can be higher than the actual good nonce. An example is that we send the same message repeatedly. In this case, the txpool cannot determine the redundant messages are bad before the first message is included in a block. So the suggested nonce we got can grow up for a while.

Fortunately this is not a problem to us. We just ensure to:

1. all the pending messages will not be stuck: the nonce we got is never stale, so all the transaction we build is acceptable, or future acceptable
2. the account nonce will not be stuck: when a nonce is not used by a transaction already included in a block or in the txpool, the node should return it to `pherry` eventually

There could be redundant transaction with the same nonce, but as long as this nonce is considered to be the next to use, only one transaction will be chosen, and the rests will be dropped immediately, effectively invalidating all the conflicting transactions.

There could also be redundant messages with different nonce. However as long as the first occurance of the message is included in a block, all the rests will be invalidated immedately by `pre_dispatch()`.