### PR TITLE
pherry: Add HTTP header "Connection: close"

### DIFF
--- a/standalone/pherry/src/pruntime_client.rs
+++ b/standalone/pherry/src/pruntime_client.rs
@@ -34,6 +34,7 @@ impl RequestClient for RpcRequest {
         let url = format!("{}/prpc/{}", self.base_url, path);
         let res = reqwest::Client::new()
             .post(url)
+            .header("Connection", "close")
             .body(body)
             .send()
             .await


### PR DESCRIPTION
To suppress the log in pRuntime:
```
[2021-08-15T05:39:07Z DEBUG hyper::server] ioerror in keepalive loop = Custom { kind: UnexpectedEof, error: "end of stream before headers finished" }
```