### PR TITLE
bridge: add extra storage to save transfer events

### DIFF
--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -57,7 +57,7 @@ pub mod pallet {
 	}
 
 	#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-	pub enum TransferType {
+	pub enum BridgeEvent {
 		FungibleTransfer(BridgeChainId, DepositNonce, ResourceId, U256, Vec<u8>),
 		NonFungibleTransfer(
 			BridgeChainId,
@@ -249,7 +249,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn bridge_events)]
-	pub type BridgeEvents<T> = StorageValue<_, Vec<TransferType>, ValueQuery>;
+	pub type BridgeEvents<T> = StorageValue<_, Vec<BridgeEvent>, ValueQuery>;
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
@@ -632,7 +632,7 @@ pub mod pallet {
 			);
 			let nonce = Self::bump_nonce(dest_id);
 			let mut t = BridgeEvents::<T>::get();
-			t.push(TransferType::FungibleTransfer(
+			t.push(BridgeEvent::FungibleTransfer(
 				dest_id,
 				nonce,
 				resource_id,
@@ -664,7 +664,7 @@ pub mod pallet {
 			);
 			let nonce = Self::bump_nonce(dest_id);
 			let mut t = BridgeEvents::<T>::get();
-			t.push(TransferType::NonFungibleTransfer(
+			t.push(BridgeEvent::NonFungibleTransfer(
 				dest_id,
 				nonce,
 				resource_id,
@@ -696,7 +696,7 @@ pub mod pallet {
 			);
 			let nonce = Self::bump_nonce(dest_id);
 			let mut t = BridgeEvents::<T>::get();
-			t.push(TransferType::GenericTransfer(
+			t.push(BridgeEvent::GenericTransfer(
 				dest_id,
 				nonce,
 				resource_id,

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -13,8 +13,7 @@ pub use pallet::*;
 pub mod pallet {
 	use codec::{Decode, Encode, EncodeLike};
 	pub use frame_support::{
-		pallet_prelude::*, weights::GetDispatchInfo, PalletId, Parameter,
-		traits::StorageVersion,
+		pallet_prelude::*, traits::StorageVersion, weights::GetDispatchInfo, PalletId, Parameter,
 	};
 	use frame_system::{self as system, pallet_prelude::*};
 	pub use sp_core::U256;
@@ -631,15 +630,13 @@ pub mod pallet {
 				Error::<T>::ChainNotWhitelisted
 			);
 			let nonce = Self::bump_nonce(dest_id);
-			let mut t = BridgeEvents::<T>::get();
-			t.push(BridgeEvent::FungibleTransfer(
+			BridgeEvents::<T>::append(BridgeEvent::FungibleTransfer(
 				dest_id,
 				nonce,
 				resource_id,
 				amount,
 				to.clone(),
 			));
-			BridgeEvents::<T>::put(&t);
 			Self::deposit_event(Event::FungibleTransfer(
 				dest_id,
 				nonce,
@@ -663,8 +660,7 @@ pub mod pallet {
 				Error::<T>::ChainNotWhitelisted
 			);
 			let nonce = Self::bump_nonce(dest_id);
-			let mut t = BridgeEvents::<T>::get();
-			t.push(BridgeEvent::NonFungibleTransfer(
+			BridgeEvents::<T>::append(BridgeEvent::NonFungibleTransfer(
 				dest_id,
 				nonce,
 				resource_id,
@@ -672,7 +668,6 @@ pub mod pallet {
 				to.clone(),
 				metadata.clone(),
 			));
-			BridgeEvents::<T>::put(&t);
 			Self::deposit_event(Event::NonFungibleTransfer(
 				dest_id,
 				nonce,
@@ -695,14 +690,12 @@ pub mod pallet {
 				Error::<T>::ChainNotWhitelisted
 			);
 			let nonce = Self::bump_nonce(dest_id);
-			let mut t = BridgeEvents::<T>::get();
-			t.push(BridgeEvent::GenericTransfer(
+			BridgeEvents::<T>::append(BridgeEvent::GenericTransfer(
 				dest_id,
 				nonce,
 				resource_id,
 				metadata.clone(),
 			));
-			BridgeEvents::<T>::put(&t);
 			Self::deposit_event(Event::GenericTransfer(
 				dest_id,
 				nonce,

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -112,7 +112,7 @@ pub mod pallet {
 		}
 	}
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]

--- a/scripts/js/src/filterBridgeEvents.js
+++ b/scripts/js/src/filterBridgeEvents.js
@@ -6,7 +6,6 @@ const { ApiPromise, WsProvider } = require('@polkadot/api');
 const phala_typedefs = require('@phala/typedefs').phalaDev;
 
 const getTransferEvents = async (api, blockHash) => {
-    // console.log(`api.query = ${JSON.stringify(api.query, null, 4)}`);
     return (await api.query.chainBridge.bridgeEvents.at(blockHash)).toJSON();
 }
 

--- a/scripts/js/src/filterBridgeEvents.js
+++ b/scripts/js/src/filterBridgeEvents.js
@@ -1,0 +1,53 @@
+// USAGE:
+//   ENDPOINT=ws://127.0.0.1:9944 node filterBridgeEvents.js
+require('dotenv').config();
+
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+const phala_typedefs = require('@phala/typedefs').phalaDev;
+
+const getTransferEvents = async (api, blockHash) => {
+    // console.log(`api.query = ${JSON.stringify(api.query, null, 4)}`);
+    return (await api.query.chainBridge.bridgeEvents.at(blockHash)).toJSON();
+}
+
+const main = async () => {
+    const api = await ApiPromise.create({
+        provider: new WsProvider(process.env.ENDPOINT),
+        types: {...phala_typedefs, ...{
+            TransferType: {
+                _enum: {
+                    FungibleTransfer: "(BridgeChainId, DepositNonce, ResourceId, U256, Vec<u8>)",
+                    NonFungibleTransfer: "(BridgeChainId, DepositNonce, ResourceId, Vec<u8>, Vec<u8>, Vec<u8>)",
+                    GenericTransfer: "(BridgeChainId, DepositNonce, ResourceId, Vec<u8>)"
+                }
+            }
+        }}
+    });
+
+    const unsubscribe = await api.rpc.chain.subscribeFinalizedHeads(async (header) => {
+        console.log(`Bridge Transfer within block[${header.number}]: ${JSON.stringify(await getTransferEvents(api, header.hash), null, 4)}`)
+    });
+
+    const exitHandler = (options, exitCode) => {
+        unsubscribe();
+        if (options.cleanup) console.log('do cleanup');
+        if (exitCode || exitCode === 0) console.log(exitCode);
+        if (options.exit) process.exit();
+    }
+
+    process.stdin.resume();//so the program will not close instantly
+
+    // Following copy from: https://stackoverflow.com/questions/14031763/doing-a-cleanup-action-just-before-node-js-exits/14032965#14032965
+    // do something when app is closing
+    process.on('exit', exitHandler.bind(null,{cleanup:true}));
+    //catches ctrl+c event
+    process.on('SIGINT', exitHandler.bind(null, {exit:true}));
+    // catches "kill pid" (for example: nodemon restart)
+    process.on('SIGUSR1', exitHandler.bind(null, {exit:true}));
+    process.on('SIGUSR2', exitHandler.bind(null, {exit:true}));
+    //catches uncaught exceptions
+    process.on('uncaughtException', exitHandler.bind(null, {exit:true}));
+}
+
+main();
+// main().catch(console.error).finally(() => process.exit())

--- a/scripts/js/src/filterBridgeEvents.js
+++ b/scripts/js/src/filterBridgeEvents.js
@@ -13,7 +13,7 @@ const main = async () => {
     const api = await ApiPromise.create({
         provider: new WsProvider(process.env.ENDPOINT),
         types: {...phala_typedefs, ...{
-            TransferType: {
+            BridgeEvent: {
                 _enum: {
                     FungibleTransfer: "(BridgeChainId, DepositNonce, ResourceId, U256, Vec<u8>)",
                     NonFungibleTransfer: "(BridgeChainId, DepositNonce, ResourceId, Vec<u8>, Vec<u8>, Vec<u8>)",


### PR DESCRIPTION
Introduce custom event storage  to save bridge transfer events of every block, thus on relayer side, we don't need to decode events that not relevant with bridge. This could save us a lot of work to adopt new event types once upstream(substrate) was updated.

- [x] Add custom storage in bridge pallet
- [x] Check and test storage data with a js script
- [x] Reimplement relayer block parser to read events from custom storage