### PR TITLE
Port Subxt jsonrpsee 0.3.0 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,34 +2969,23 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7275601ba6f9f6feaa82d3c66b51e34d190e75f1cf23d5c40f7801f3a7610a6"
+checksum = "52819604ca75933e88f51a31ef2e963fc5e3b0e67c5e4e7cd1bcf866e28b6af2"
 dependencies = [
  "async-trait",
  "fnv",
+ "futures 0.3.16",
  "hyper",
  "hyper-rustls",
- "jsonrpsee-types 0.2.0",
+ "jsonrpsee-types",
  "jsonrpsee-utils",
  "log",
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
  "url 2.2.2",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4c85cfa6767333f3e5f3b2f2f765dad2727b0033ee270ae07c599bf43ed5ae"
-dependencies = [
- "Inflector",
- "proc-macro-crate 1.0.0",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
 ]
 
 [[package]]
@@ -3011,24 +3000,6 @@ dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
  "syn 1.0.74",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cf7bd4e93b3b56e59131de7f24afbea871faf914e97bcdd942c86927ab0172"
-dependencies = [
- "async-trait",
- "beef",
- "futures-channel",
- "futures-util",
- "hyper",
- "log",
- "serde",
- "serde_json",
- "soketto 0.5.0",
- "thiserror",
 ]
 
 [[package]]
@@ -3051,37 +3022,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-utils"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47554ecaacb479285da68799d9b6afc258c32b332cc8b85829c6a9304ee98776"
+checksum = "0df2c313adda0418a281cea99d1b9e3c22714d2b9139e9adb1543b4a40ee0458"
 dependencies = [
  "futures-util",
  "hyper",
- "jsonrpsee-types 0.2.0",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec51150965544e1a4468f372bdab8545243a1b045d4ab272023aac74c60de32"
-dependencies = [
- "async-trait",
- "fnv",
- "futures 0.3.16",
- "jsonrpsee-types 0.2.0",
- "log",
- "pin-project 1.0.8",
- "rustls",
- "rustls-native-certs",
- "serde",
- "serde_json",
- "soketto 0.5.0",
- "thiserror",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "url 2.2.2",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -3093,7 +3040,7 @@ dependencies = [
  "async-trait",
  "fnv",
  "futures 0.3.16",
- "jsonrpsee-types 0.3.0",
+ "jsonrpsee-types",
  "log",
  "pin-project 1.0.8",
  "rustls",
@@ -6666,8 +6613,8 @@ name = "remote-externalities"
 version = "0.10.0-dev"
 dependencies = [
  "env_logger 0.9.0",
- "jsonrpsee-proc-macros 0.3.0",
- "jsonrpsee-ws-client 0.3.0",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-ws-client",
  "log",
  "parity-scale-codec",
  "serde",
@@ -8278,21 +8225,6 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4919971d141dbadaa0e82b5d369e2d7666c98e4625046140615ca363e50d4daa"
-dependencies = [
- "base64 0.13.0",
- "bytes 1.0.1",
- "futures 0.3.16",
- "httparse",
- "log",
- "rand 0.8.4",
- "sha-1 0.9.7",
-]
-
-[[package]]
-name = "soketto"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74e48087dbeed4833785c2f3352b59140095dc192dce966a3bfc155020a439f"
@@ -9119,9 +9051,9 @@ dependencies = [
  "futures 0.3.16",
  "hex",
  "jsonrpsee-http-client",
- "jsonrpsee-proc-macros 0.2.0",
- "jsonrpsee-types 0.2.0",
- "jsonrpsee-ws-client 0.2.0",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "jsonrpsee-ws-client",
  "log",
  "num-traits",
  "pallet-indices",

--- a/subxt/Cargo.toml
+++ b/subxt/Cargo.toml
@@ -29,10 +29,10 @@ codec = { package = "parity-scale-codec", version = "2.1", default-features = fa
 dyn-clone = "1.0.4"
 futures =  "0.3.16"
 hex = "0.4.3"
-jsonrpsee-proc-macros = "0.2.0"
-jsonrpsee-ws-client = { version = "0.2.0", default-features = false }
-jsonrpsee-http-client = { version = "0.2.0", default-features = false }
-jsonrpsee-types = "0.2.0"
+jsonrpsee-proc-macros = "0.3.0"
+jsonrpsee-ws-client = { version = "0.3.0", default-features = false }
+jsonrpsee-http-client = { version = "0.3.0", default-features = false }
+jsonrpsee-types = "0.3.0"
 log = "0.4.14"
 num-traits = { version = "0.2.14", default-features = false }
 serde = { version = "1.0.124", features = ["derive"] }

--- a/subxt/client/Cargo.toml
+++ b/subxt/client/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["parity", "substrate", "blockchain"]
 async-std = "1.8.0"
 futures = { version = "0.3.9", features = ["compat"], package = "futures" }
 futures01 = { package = "futures", version = "0.1.29" }
-jsonrpsee-types = "0.2.0"
+jsonrpsee-types = "0.3.0"
 log = "0.4.13"
 serde_json = "1.0.61"
 thiserror = "1.0.23"

--- a/subxt/src/error.rs
+++ b/subxt/src/error.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-subxt.  If not, see <http://www.gnu.org/licenses/>.
 
-use jsonrpsee_ws_client::Error as RequestError;
+use jsonrpsee_types::Error as RequestError;
 use sp_core::crypto::SecretStringError;
 use sp_runtime::{
     transaction_validity::TransactionValidityError, TokenError, ArithmeticError,

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -52,10 +52,8 @@ use codec::{
 };
 use futures::future;
 use jsonrpsee_http_client::HttpClientBuilder;
-use jsonrpsee_ws_client::{
-    Subscription,
-    WsClientBuilder,
-};
+use jsonrpsee_types::Subscription;
+use jsonrpsee_ws_client::WsClientBuilder;
 use sp_core::{
     storage::{
         StorageChangeSet,


### PR DESCRIPTION
Port https://github.com/paritytech/substrate-subxt/pull/289 to our fork, Substrate itself already use 0.3.0 for long time, this helps remove old jsonrpsee dependency