### PR TITLE
enclave: Adjust heap & stack size

### DIFF
--- a/standalone/pruntime/enclave/Enclave.config.dev.xml
+++ b/standalone/pruntime/enclave/Enclave.config.dev.xml
@@ -2,8 +2,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x4000000</StackMaxSize>
-  <HeapMaxSize>0x10000000</HeapMaxSize>
+  <StackMaxSize>0x800000</StackMaxSize>
+  <HeapMaxSize>0x40000000</HeapMaxSize>
   <TCSNum>32</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/standalone/pruntime/enclave/Enclave.config.prod.xml
+++ b/standalone/pruntime/enclave/Enclave.config.prod.xml
@@ -2,8 +2,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x4000000</StackMaxSize>
-  <HeapMaxSize>0x10000000</HeapMaxSize>
+  <StackMaxSize>0x800000</StackMaxSize>
+  <HeapMaxSize>0x40000000</HeapMaxSize>
   <TCSNum>32</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>1</DisableDebug>


### PR DESCRIPTION
# Changes made
Stack size:  64MB x 32 -> 8MB x 32
Heap size:  256MB -> 1024MB
Total: 2304MB -> 1280MB

# For stask size
The default app stack size of most linux desktop distribution is 8MB, some embed system is 2MB. The stack size of linux kernel threads is 16**KB**.
So 8MB of stack size is adequate for most real world applications. There is no stack cost codes in our app.

# For heap size
We already have encountered OOM when sync header with batch size of 1000. So the current heap size would be not enough for future business.