### PR TITLE
gk: implement Repair V

### DIFF
--- a/crates/phactory/src/system/gk.rs
+++ b/crates/phactory/src/system/gk.rs
@@ -609,6 +609,24 @@ where
                     );
                 }
             }
+            GatekeeperEvent::RepairV => {
+                if origin.is_pallet() {
+                    info!("Repairing V");
+                    // Fixup the V for those workers that have been slashed due to the initial tokenomic parameters
+                    // not being applied.
+                    //
+                    // See below links for more detail:
+                    // https://github.com/Phala-Network/phala-blockchain/issues/489
+                    // https://github.com/Phala-Network/phala-blockchain/issues/495
+                    // https://forum.phala.network/t/topic/2753#timeline
+                    // https://forum.phala.network/t/topic/2909
+                    self.state.workers.values_mut().for_each(|w| {
+                        if w.state.mining_state.is_some() && w.tokenomic.v < w.tokenomic.v_init {
+                            w.tokenomic.v = w.tokenomic.v_init;
+                        }
+                    })
+                }
+            }
         }
     }
 

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -467,6 +467,7 @@ pub mod messaging {
     pub enum GatekeeperEvent {
         NewRandomNumber(RandomNumberEvent),
         TokenomicParametersChanged(TokenomicParameters),
+        RepairV,
     }
 
     impl GatekeeperEvent {


### PR DESCRIPTION
Let remember the operation order this time:

1. Upgrade GKs' pruntime.
2. Then send RepairV message after **ALL** GKs get upgraded.

Otherwise the GKs will run into inconsistent state which is a disaster.