### PR TITLE
enclave: Add memory usage stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "opaque-debug 0.3.0",
 ]
 
@@ -843,7 +843,7 @@ checksum = "ea8756167ea0aca10e066cdbe7813bd71d2f24e69b0bc7b50509590cef2ce0b9"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "zeroize",
 ]
 
@@ -1002,6 +1002,15 @@ name = "cpufeatures"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
@@ -1514,7 +1523,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "zeroize",
 ]
 
@@ -3139,9 +3148,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libloading"
@@ -3234,7 +3243,7 @@ dependencies = [
  "rand 0.7.3",
  "ring 0.16.20",
  "rw-stream-sink",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.7.0",
@@ -3305,7 +3314,7 @@ dependencies = [
  "prost-build 0.8.0",
  "rand 0.7.3",
  "regex",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "smallvec",
  "unsigned-varint 0.7.0",
  "wasm-timer",
@@ -3345,7 +3354,7 @@ dependencies = [
  "prost 0.8.0",
  "prost-build 0.8.0",
  "rand 0.7.3",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "smallvec",
  "uint",
  "unsigned-varint 0.7.0",
@@ -3407,7 +3416,7 @@ dependencies = [
  "prost 0.8.0",
  "prost-build 0.8.0",
  "rand 0.8.4",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -3643,7 +3652,7 @@ dependencies = [
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "typenum",
 ]
 
@@ -3662,7 +3671,7 @@ dependencies = [
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "typenum",
 ]
 
@@ -4053,7 +4062,7 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "sha3",
  "unsigned-varint 0.5.1",
 ]
@@ -4067,7 +4076,7 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "unsigned-varint 0.7.0",
 ]
 
@@ -5527,6 +5536,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "phala-allocator"
+version = "0.1.0"
+
+[[package]]
 name = "phala-async-executor"
 version = "0.1.0"
 dependencies = [
@@ -5957,7 +5970,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fcffab1f78ebbdf4b93b68c1ffebc24037eedf271edaca795732b24e5e4e349"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -5969,7 +5982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ba6a405ef63530d6cb12802014b22f9c5751bd17cdcddbe9e46d5c8ae83287"
 dependencies = [
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -8052,7 +8065,7 @@ checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -8071,13 +8084,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.2.1",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -8195,7 +8208,7 @@ dependencies = [
  "rand_core 0.6.3",
  "ring 0.16.20",
  "rustc_version 0.3.3",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "subtle 2.4.1",
  "x25519-dalek",
 ]
@@ -8456,7 +8469,7 @@ dependencies = [
  "schnorrkel",
  "secrecy",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -9394,7 +9407,7 @@ dependencies = [
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "thiserror",
  "unicode-normalization",
  "zeroize",
@@ -10210,7 +10223,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "toml",
  "winapi 0.3.9",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
 	"crates/phactory/pal",
 	"crates/phala-types",
 	"crates/phala-async-executor",
+	"crates/phala-allocator",
 	"pallets/phala",
 	"pallets/phala/mq-runtime-api",
 	"pallets/bridge",

--- a/crates/phactory/pal/src/lib.rs
+++ b/crates/phactory/pal/src/lib.rs
@@ -20,11 +20,21 @@ pub trait RA {
     fn create_attestation_report(&self, data: &[u8]) -> Result<(String, String, String), Self::Error>;
 }
 
+pub struct MemoryUsage {
+    pub total_peak_used: usize,
+    pub rust_used: usize,
+    pub rust_peak_used: usize,
+}
+
+pub trait MemoryStats {
+    fn memory_usage(&self) -> MemoryUsage;
+}
+
 pub trait Machine {
     fn machine_id(&self) -> Vec<u8>;
     fn cpu_core_num(&self) -> u32;
     fn cpu_feature_level(&self) -> u32;
 }
 
-pub trait Platform: Sealing + RA + Machine + Clone {}
-impl<T: Sealing + RA + Machine + Clone> Platform for T {}
+pub trait Platform: Sealing + RA + Machine + MemoryStats + Clone {}
+impl<T: Sealing + RA + Machine + MemoryStats + Clone> Platform for T {}

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -93,6 +93,7 @@ impl<Platform: pal::Platform> Phactory<Platform> {
         };
 
         let score = benchmark::score();
+        let m_usage = self.platform.memory_usage();
 
         pb::PhactoryInfo {
             initialized,
@@ -111,6 +112,11 @@ impl<Platform: pal::Platform> Phactory<Platform> {
             version: self.args.version.clone(),
             git_revision: self.args.git_revision.clone(),
             running_side_tasks: self.side_task_man.tasks_count() as _,
+            memory_usage: Some(pb::MemoryUsage {
+                rust_used: m_usage.rust_used as _,
+                rust_peak_used: m_usage.rust_peak_used as _,
+                total_peak_used: m_usage.total_peak_used as _,
+            }),
         }
     }
 

--- a/crates/phala-allocator/Cargo.toml
+++ b/crates/phala-allocator/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "phala-allocator"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/phala-allocator/src/lib.rs
+++ b/crates/phala-allocator/src/lib.rs
@@ -1,0 +1,89 @@
+#![no_std]
+use core::alloc::{GlobalAlloc, Layout};
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+pub struct StatSizeAllocator<T> {
+    inner: T,
+    current_used: AtomicUsize,
+    peak_used: AtomicUsize,
+}
+
+#[derive(Debug)]
+pub struct Stats {
+    /// The current heap usage of the allocator.
+    pub current_used: usize,
+    /// The peak heap usage of the allocator.
+    pub peak_used: usize,
+}
+
+impl<T> StatSizeAllocator<T> {
+    pub const fn new(inner: T) -> Self {
+        Self {
+            inner,
+            current_used: AtomicUsize::new(0),
+            peak_used: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn stats(&self) -> Stats {
+        Stats {
+            current_used: self.current_used.load(Ordering::Relaxed),
+            peak_used: self.peak_used.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl<T: GlobalAlloc> StatSizeAllocator<T> {
+    fn add_alloced_size(&self, size: usize) {
+        let prev = self.current_used.fetch_add(size, Ordering::SeqCst);
+        let total_size = prev + size;
+        let mut peak = self.peak_used.load(Ordering::SeqCst);
+        loop {
+            if total_size <= peak {
+                break;
+            }
+            match self.peak_used.compare_exchange(
+                peak,
+                total_size,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Err(new) => {
+                    peak = new;
+                    continue;
+                }
+                Ok(_) => {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+unsafe impl<T: GlobalAlloc> GlobalAlloc for StatSizeAllocator<T> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.add_alloced_size(layout.size());
+        self.inner.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.current_used.fetch_sub(layout.size(), Ordering::SeqCst);
+        self.inner.dealloc(ptr, layout)
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        self.add_alloced_size(layout.size());
+        self.inner.alloc_zeroed(layout)
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if new_size > layout.size() {
+            let difference = new_size - layout.size();
+            self.add_alloced_size(difference);
+        } else if new_size < layout.size() {
+            let difference = layout.size() - new_size;
+            self.current_used.fetch_sub(difference, Ordering::SeqCst);
+        }
+        self.inner.realloc(ptr, layout, new_size)
+    }
+}

--- a/standalone/pruntime/enclave/Cargo.lock
+++ b/standalone/pruntime/enclave/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "phactory",
  "phactory-api",
  "phactory-pal",
+ "phala-allocator",
  "phala-async-executor",
  "ppv-lite86",
  "rand 0.7.3",
@@ -2744,6 +2745,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
 ]
+
+[[package]]
+name = "phala-allocator"
+version = "0.1.0"
 
 [[package]]
 name = "phala-async-executor"

--- a/standalone/pruntime/enclave/Cargo.toml
+++ b/standalone/pruntime/enclave/Cargo.toml
@@ -28,6 +28,7 @@ phactory = { path = "../../../crates/phactory" }
 phactory-pal = { path = "../../../crates/phactory/pal" }
 phactory-api = { path = "../../../crates/phactory/api" }
 phala-async-executor = { path = "../../../crates/phala-async-executor", features = ['no-thread'] }
+phala-allocator = { path = "../../../crates/phala-allocator" }
 
 http_req    = { git = "https://github.com/Phala-Network/http_req-sgx.git", branch = "phala", default-features = false, features = ["rust-tls"]}
 ppv-lite86 = { version = "0.2", features = ["phala-sgx"] }


### PR DESCRIPTION
Currently, It statistics the global heap usage and peak usage in `Rust` with an custom Rust Allocator.
Anthor bonus is the `g_peak_heap_used` export by sgx-sdk providing the global enclave heap peak usage.