### PR TITLE
Fix #487: remove dust in stake & share calc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5749,7 +5749,7 @@ dependencies = [
 
 [[package]]
 name = "phala-pallets"
-version = "3.2.6"
+version = "3.3.0"
 dependencies = [
  "assert_matches",
  "base64 0.11.0",

--- a/pallets/phala/Cargo.toml
+++ b/pallets/phala/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ['Phala Network']
 edition = '2018'
 name = 'phala-pallets'
-version = "3.2.6"
+version = "3.3.0"
 license = "Apache 2.0"
 homepage = "https://phala.network/"
 repository = "https://github.com/Phala-Network/phala-blockchain"

--- a/pallets/phala/src/lib.rs
+++ b/pallets/phala/src/lib.rs
@@ -13,6 +13,9 @@
 #[cfg(target_arch = "wasm32")]
 extern crate webpki_wasm as webpki;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 // Re-export
 use utils::{accumulator, attestation, balance_convert, constants, fixed_point};
 

--- a/pallets/phala/src/stakepool.rs
+++ b/pallets/phala/src/stakepool.rs
@@ -230,7 +230,7 @@ pub mod pallet {
 			w += T::DbWeight::get().reads(1);
 
 			if old == 0 {
-				super::migrations::migrate_to_v1::<T>();
+				w += super::migrations::migrate_to_v1::<T>();
 				STORAGE_VERSION.put::<super::Pallet<T>>();
 				w += T::DbWeight::get().writes(1);
 			}

--- a/pallets/phala/src/stakepool.rs
+++ b/pallets/phala/src/stakepool.rs
@@ -750,20 +750,6 @@ pub mod pallet {
 
 			while is_positive_balance(pool_info.free_stake) {
 				if let Some(mut withdraw) = pool_info.withdraw_queue.front().cloned() {
-					// Backfill to #487
-					// There are dust withdrawal requests left in the queues, which are safe to
-					// ignore for now. However the goal is to not leave any withdrawal requests
-					// with dust in the queue at all. So we can remove the backfill once all the
-					// withdrawal queue are clean.
-					if balance_close_to_zero(withdraw.shares) {
-						pool_info.withdraw_queue.pop_front();
-						continue;
-					}
-					#[cfg(test)]
-					{
-						println!(">> pool: {:?}", pool_info);
-						println!(">> withdraw: {:?}", withdraw);
-					}
 					// Must clear the pending reward before any stake change
 					let info_key = (pool_info.pid, withdraw.user.clone());
 					let mut user_info = Self::pool_stakers(&info_key).unwrap();

--- a/pallets/phala/src/stakepool/migrations.rs
+++ b/pallets/phala/src/stakepool/migrations.rs
@@ -145,7 +145,7 @@ where
 				// Shares
 				let (shares, shares_dust) = extract_dust(user.shares);
 				user.shares = shares;
-				// Accumulate the dust to the table to ensure shares invarant
+				// Accumulate the dust to the table to ensure shares invariant
 				if shares_dust > Zero::zero() {
 					let v = share_dust_removed
 						.get(&pid)

--- a/pallets/phala/src/stakepool/migrations.rs
+++ b/pallets/phala/src/stakepool/migrations.rs
@@ -189,7 +189,7 @@ where
 			}
 			// Remove dust in withdraw request
 			pool.withdraw_queue
-				.retain(|withdraw| is_positive_balance(withdraw.shares));
+				.retain(|withdraw| is_nondust_balance(withdraw.shares));
 
 			num_reads += 1;
 			num_writes += 1;

--- a/pallets/phala/src/stakepool/migrations.rs
+++ b/pallets/phala/src/stakepool/migrations.rs
@@ -1,0 +1,191 @@
+use super::*;
+
+use crate::balance_convert::FixedPointConvert;
+use log::info;
+use sp_std::collections::btree_map::BTreeMap;
+use sp_std::fmt::Display;
+use sp_std::marker::PhantomData;
+use sp_std::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
+pub(super) fn migrate_to_v1<T: Config>()
+where
+	T: crate::mining::Config<Currency = <T as Config>::Currency>,
+	BalanceOf<T>: FixedPointConvert + Display,
+{
+	Migration::<T>::migrate_fix487();
+}
+
+/// Indicating now it's pre or post migration
+enum Stage {
+	PreMigration,
+	PostMigration,
+}
+
+/// Migration for bug 487 fix
+struct Migration<T: Config>(PhantomData<T>);
+
+impl<T: Config> Migration<T>
+where
+	T: crate::mining::Config<Currency = <T as Config>::Currency>,
+	BalanceOf<T>: FixedPointConvert + Display,
+{
+	/// Fix bug #487
+	pub fn migrate_fix487() {
+		info!("== migrate_fix487: Pre-Migration ==");
+		Self::print_pool_details(Stage::PreMigration);
+		let result = Self::backfill_487_maybe_remove_pool_dust();
+		info!("== migrate_fix487: Post-Migration ==");
+		Self::print_pool_details(Stage::PostMigration);
+		info!("== migrate_fix487: {:?} ==", result);
+	}
+
+	fn print_pool_details(stage: Stage) {
+		#[cfg(feature = "std")]
+		let _ = Self::maybe_dump_pool_details(stage);
+	}
+
+	fn log_pool_details() -> Result<(), ()> {
+		info!("[PoolStakers]");
+		info!("pid\tuser\tlocked\tshares");
+		for ((pid, _account), user) in PoolStakers::<T>::iter() {
+			info!("{}\t{:?}\t{}\t{}", pid, user.user, user.locked, user.shares);
+		}
+		info!("[StakePools]");
+		info!("pid\ttotal_shares\ttotal_stake\tfree_stake\treleasing_stake\twithdraw_queue");
+		for (pid, pool) in StakePools::<T>::iter() {
+			let withdraw_queue_display = pool
+				.withdraw_queue
+				.iter()
+				.map(|w| w.shares.to_string())
+				.collect::<Vec<_>>()
+				.join(",");
+
+			info!(
+				"{}\t{}\t{}\t{}\t{}\t{}",
+				pid,
+				pool.total_shares,
+				pool.total_stake,
+				pool.free_stake,
+				pool.releasing_stake,
+				withdraw_queue_display
+			);
+		}
+		Ok(())
+	}
+
+	#[cfg(feature = "std")]
+	fn maybe_dump_pool_details(stage: Stage) -> Result<(), ()> {
+		use std::fs::File;
+		use std::io::prelude::*;
+
+		let path = match std::env::var("DUMP_MIGRATION_PATH") {
+			Ok(path) => path,
+			_ => return Ok(()),
+		};
+		let prefix = match stage {
+			Stage::PreMigration => "pre",
+			Stage::PostMigration => "post",
+		};
+
+		let mut file_users = File::create(format!("{}/{}-users.tsv", path, prefix))
+			.expect("failed to open users output file");
+		let mut file_pools = File::create(format!("{}/{}-pools.tsv", path, prefix))
+			.expect("failed to open pools output file");
+
+		write!(file_users, "pid\tuser\tlocked\tshares\n").or(Err(()))?;
+		for ((pid, _account), user) in PoolStakers::<T>::iter() {
+			write!(
+				file_users,
+				"{}\t{:?}\t{}\t{}\n",
+				pid, user.user, user.locked, user.shares
+			)
+			.or(Err(()))?;
+		}
+		write!(
+			file_pools,
+			"pid\ttotal_shares\ttotal_stake\tfree_stake\treleasing_stake\twithdraw_queue\n"
+		)
+		.or(Err(()))?;
+		for (pid, pool) in StakePools::<T>::iter() {
+			let withdraw_queue_display = pool
+				.withdraw_queue
+				.iter()
+				.map(|w| w.shares.to_string())
+				.collect::<Vec<_>>()
+				.join(",");
+
+			write!(
+				file_pools,
+				"{}\t{}\t{}\t{}\t{}\t{}\n",
+				pid,
+				pool.total_shares,
+				pool.total_stake,
+				pool.free_stake,
+				pool.releasing_stake,
+				withdraw_queue_display
+			)
+			.or(Err(()))?;
+		}
+		Ok(())
+	}
+
+	// Removes the dust shares and stake in a pool.
+	fn backfill_487_maybe_remove_pool_dust() -> Result<(), ()> {
+		// BTreeMap is chosen for its slightly lower memory footprint
+		let mut share_dust_removed = BTreeMap::<u64, BalanceOf<T>>::new();
+
+		// Remove dust in stakers and collect dust shares that will be removed in stake pools
+		// later.
+		PoolStakers::<T>::translate(
+			|key: (u64, T::AccountId), mut user: UserStakeInfo<T::AccountId, BalanceOf<T>>| {
+				let (pid, account) = key;
+				// Shares
+				let (shares, shares_dust) = extract_dust(user.shares);
+				user.shares = shares;
+				// Accumulate the dust to the table to ensure shares invarant
+				if shares_dust > Zero::zero() {
+					let v = share_dust_removed
+						.get(&pid)
+						.cloned()
+						.unwrap_or(Zero::zero());
+					share_dust_removed.insert(pid, v + shares_dust);
+				}
+				// Locked
+				let (locked, stake_dust) = extract_dust(user.locked);
+				user.locked = locked;
+				// Remove the dust in `locked` by slashing to treasury
+				if stake_dust > Zero::zero() {
+					info!("dust stake removed: {:?} {}", account, stake_dust);
+					Pallet::<T>::ledger_reduce(&account, Zero::zero(), stake_dust);
+				}
+				Some(user)
+			},
+		);
+
+		info!("share_dust_removed: {:#?}", share_dust_removed);
+
+		// Remove dust in stake pools.
+		StakePools::<T>::translate_values(|mut pool: PoolInfo<T::AccountId, BalanceOf<T>>| {
+			let pid = pool.pid;
+			// Maintain total_shares invarant
+			if let Some(dust) = share_dust_removed.get(&pid) {
+				pool.total_shares -= *dust;
+			}
+			// Remove dust from total_stake by NOP
+			let (total_stake, _) = extract_dust(pool.total_stake);
+			if total_stake == Zero::zero() {
+				pool.total_stake = Zero::zero();
+				pool.free_stake = Zero::zero();
+			}
+			// Remove dust in withdraw request
+			pool.withdraw_queue
+				.retain(|withdraw| is_positive_balance(withdraw.shares));
+			Some(pool)
+		});
+
+		Ok(())
+	}
+}

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -232,5 +232,5 @@ try-runtime = [
 	"pallet-society/try-runtime",
 	"pallet-recovery/try-runtime",
 	"pallet-vesting/try-runtime",
-    "phala-pallets/try-runtime",
+	"phala-pallets/try-runtime",
 ]

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -232,4 +232,5 @@ try-runtime = [
 	"pallet-society/try-runtime",
 	"pallet-recovery/try-runtime",
 	"pallet-vesting/try-runtime",
+    "phala-pallets/try-runtime",
 ]


### PR DESCRIPTION
Fixes #487 

- Handle dust when calculating stake & shares in the following rules:
    - Dust in user's locked stake will be removed by slash
    - Dust in a user's share is removed, and always maintain the invariant: sum(user shares) == pool's total share
    - Dust in a pool's total_stake is removed
    - Dust in withdraw queue is removed
    - Dust in payout report from GK is dismissed
- Add a migration to remove all the existing dust in the storage
    - Analyzed with `try_runtime`, and with state dumped for offline analysis

## Tested

Unit test with grcov:

![image](https://user-images.githubusercontent.com/1343470/135992583-42563571-7157-40cc-af4b-398a9c806e00.png)


