### PR TITLE
Check worker status before start mining

### DIFF
--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -151,6 +151,7 @@ impl stakepool::Config for Test {
 	type MaxPoolWorkers = MaxPoolWorkers;
 	type OnSlashed = ();
 	type MiningSwitchOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type BackfillOrigin = frame_system::EnsureRoot<Self::AccountId>;
 }
 
 impl ott::Config for Test {

--- a/pallets/phala/src/stakepool.rs
+++ b/pallets/phala/src/stakepool.rs
@@ -691,7 +691,7 @@ pub mod pallet {
 				//    in issue 518, because it should be either fixed in another fix, or the record
 				//    is already overwritten.
 
-				let mut pool_info = Self::ensure_pool(pid).expect("Stake pool must exist; qed.");
+				let mut pool_info = Self::ensure_pool(pid)?;
 
 				let returned = orig_stake - slashed;
 				if slashed != Zero::zero() {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1121,6 +1121,7 @@ impl pallet_stakepool::Config for Runtime {
 	type MaxPoolWorkers = MaxPoolWorkers;
 	type OnSlashed = Treasury;
 	type MiningSwitchOrigin = EnsureRootOrHalfCouncil;
+	type BackfillOrigin = EnsureRootOrHalfCouncil;
 }
 impl pallet_ott::Config for Runtime {
 	type Event = Event;


### PR DESCRIPTION
Partially fixes #500 

The root case of the issue is that some functions doesn't check the existing storage before inserting a new value, causing unexpected overwriting.

- [x] Fix #500 by checking miner CD state before starting mining
- [x] Check all the storage insertion. Make sure there's no unexpected overwriting
- [x] Code to reconcile the missing releasing stake in the past
- [x] Examine if other storage migration is required