### PR TITLE
Refactor the side task

### DIFF
--- a/crates/phactory/src/contracts/mod.rs
+++ b/crates/phactory/src/contracts/mod.rs
@@ -1,6 +1,4 @@
-use crate::secret_channel::{
-    storage_prefix_for_topic_pubkey, KeyPair, Peeler, PeelingReceiver, SecretMessageChannel,
-};
+use crate::secret_channel::{KeyPair, Peeler, PeelingReceiver, SecretMessageChannel};
 use std::convert::TryFrom as _;
 use std::fmt::Debug;
 
@@ -33,8 +31,6 @@ fn account_id_from_hex(s: &str) -> Result<AccountId> {
 
 pub use support::*;
 mod support {
-    use core::convert::TryInto;
-
     use super::pink::group::GroupKeeper;
     use super::*;
     use crate::types::BlockInfo;
@@ -158,20 +154,14 @@ mod support {
             req: OpaqueQuery,
             context: &mut QueryContext,
         ) -> Result<OpaqueReply, OpaqueError> {
-            let response = self.contract.handle_query(origin, deopaque_query(req)?, context);
+            let response = self
+                .contract
+                .handle_query(origin, deopaque_query(req)?, context);
             Ok(response.encode())
         }
 
         fn process_messages(&mut self, env: &mut ExecuteEnv) {
-            let storage = env.block.storage;
-            let key_map = |topic: &[u8]| {
-                // TODO.kevin: query contract pubkey for contract topic's when the feature in GK is available.
-                storage
-                    .get(&storage_prefix_for_topic_pubkey(topic))
-                    .map(|v| v.try_into().ok())
-                    .flatten()
-            };
-            let secret_mq = SecretMessageChannel::new(&self.ecdh_key, &self.send_mq, &key_map);
+            let secret_mq = SecretMessageChannel::new(&self.ecdh_key, &self.send_mq);
             let mut context = NativeContext {
                 block: env.block,
                 mq: &self.send_mq,

--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -40,15 +40,10 @@ impl Pink {
         input_data: Vec<u8>,
         salt: Vec<u8>,
     ) -> Result<Self> {
-        let instance =
-            pink::Contract::new(storage, origin.clone(), wasm_bin, input_data, salt)
-                .map_err(|err| {
-                    anyhow!(
-                        "Instantiate contract failed: {:?} origin={:?}",
-                        err,
-                        origin,
-                    )
-                })?;
+        let instance = pink::Contract::new(storage, origin.clone(), wasm_bin, input_data, salt)
+            .map_err(
+                |err| anyhow!("Instantiate contract failed: {:?} origin={:?}", err, origin,),
+            )?;
         Ok(Self { group, instance })
     }
 }
@@ -181,12 +176,12 @@ pub mod group {
 
 pub mod messaging {
     use parity_scale_codec::{Decode, Encode};
-    use phala_crypto::{ecdh::EcdhPublicKey, sr25519::Sr25519SecretKey};
-    use phala_mq::{bind_topic, ContractGroupId, ContractId};
+    use phala_crypto::sr25519::Sr25519SecretKey;
+    use phala_mq::{bind_topic, ContractGroupId};
     use phala_types::WorkerPublicKey;
     use pink::types::AccountId;
 
-    pub use phala_types::messaging::{WorkerPinkReport, ContractInfo};
+    pub use phala_types::messaging::{ContractInfo, WorkerPinkReport};
 
     bind_topic!(WorkerPinkRequest, b"phala/pink/worker/request");
     #[derive(Encode, Decode, Debug)]

--- a/crates/phactory/src/light_validation/mod.rs
+++ b/crates/phactory/src/light_validation/mod.rs
@@ -396,18 +396,4 @@ pub mod utils {
         bytes.extend(&encoded);
         bytes
     }
-
-    /// Calculates the Substrate storage key prefix for a StorageMap
-    pub fn storage_map_prefix_blake2_128_concat(
-        module: &[u8],
-        storage_item: &[u8],
-        key: &impl Encode,
-    ) -> Vec<u8> {
-        let mut bytes = sp_core::twox_128(module).to_vec();
-        bytes.extend(&sp_core::twox_128(storage_item)[..]);
-        let encoded = key.encode();
-        bytes.extend(&sp_core::blake2_128(&encoded));
-        bytes.extend(&encoded);
-        bytes
-    }
 }

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -624,13 +624,13 @@ impl<Platform: pal::Platform> Phactory<Platform> {
                         parity_scale_codec::Decode::decode(&mut &$msg.payload[..]);
                     match event {
                         Ok(event) => {
-                            info!(
+                            debug!(target: "mq",
                                 "mq dispatching message: sender={} dest={:?} payload={:?}",
                                 $msg.sender, $msg.destination, event
                             );
                         }
                         Err(_) => {
-                            info!("mq dispatching message (decode failed): {:?}", $msg);
+                            debug!(target: "mq", "mq dispatching message (decode failed): {:?}", $msg);
                         }
                     }
                 }};
@@ -639,7 +639,10 @@ impl<Platform: pal::Platform> Phactory<Platform> {
             if message.destination.path() == &SystemEvent::topic() {
                 log_message!(message, SystemEvent);
             } else {
-                info!("mq dispatching message: sender={}, dest={:?}", message.sender, message.destination);
+                debug!(target: "mq",
+                    "mq dispatching message: sender={}, dest={:?}",
+                    message.sender, message.destination
+                );
             }
             state.recv_mq.dispatch(message);
         }

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -682,6 +682,7 @@ impl<Platform: pal::Platform> Phactory<Platform> {
             .ok_or_else(|| from_display("Runtime not initialized"))?;
         let context = side_task::PollContext {
             block_number,
+            send_mq: &state.send_mq,
             storage: &state.chain_storage,
         };
         self.side_task_man.poll(&context);

--- a/crates/phactory/src/system/gk.rs
+++ b/crates/phactory/src/system/gk.rs
@@ -278,9 +278,9 @@ where
                 };
 
                 let tmp_key = crate::new_sr25519_key().derive_ecdh_key().unwrap();
-                let secret_mq = SecretMessageChannel::new(&tmp_key, &self.egress, &|_| None);
-                
-                secret_mq.push_message(&message, Some(&worker.0));
+                let secret_mq = SecretMessageChannel::new(&tmp_key, &self.egress);
+
+                secret_mq.bind_remote_key(Some(&worker.0)).push_message(&message);
             }
         }
     }

--- a/crates/phactory/src/system/side_tasks/geo_probe.rs
+++ b/crates/phactory/src/system/side_tasks/geo_probe.rs
@@ -112,7 +112,7 @@ pub fn process_block(
             [secret_channel.prepare_message_to(&message, &topic[..])]
         };
 
-        side_task_man.add_async_task_finish_at(block_number + duration, default_messages,  async move {
+        side_task_man.add_async_task(block_number, duration, default_messages, async move {
             // 1. we load the database first, so that in case where the database not exists,
             // we can just return an error without emits any http request.
             let geo_db_buf = std::fs::read(geoip_city_db).or(Err(GeoProbeError::DBNotFound))?;

--- a/crates/phactory/src/system/side_tasks/geo_probe.rs
+++ b/crates/phactory/src/system/side_tasks/geo_probe.rs
@@ -1,7 +1,7 @@
 use chain::BlockNumber;
+use phala_mq::traits::MessagePrepareChannel;
 use phala_mq::SignedMessageChannel;
 
-use crate::side_task::async_side_task::AsyncSideTask;
 use crate::side_task::SideTaskManager;
 
 use std::str::FromStr;
@@ -13,7 +13,7 @@ use phala_types::messaging::{Geocoding, GeolocationCommand};
 use maxminddb::geoip2;
 use std::net::IpAddr;
 
-use crate::secret_channel::SecretMessageChannel;
+use crate::secret_channel;
 use phala_crypto::sr25519::KDF;
 use sp_core::{hashing::blake2_256, sr25519, Pair};
 use std::convert::TryInto;
@@ -37,7 +37,6 @@ pub enum GeoProbeError {
     DBNotValid,
     IPNotValid,
     NoRecord,
-    UnknownError,
 }
 
 impl fmt::Display for GeoProbeError {
@@ -50,7 +49,6 @@ impl fmt::Display for GeoProbeError {
             GeoProbeError::DBNotValid => write!(f, "geolite DB is probably broken"),
             GeoProbeError::IPNotValid => write!(f, "fetched IP address not valid for parsing"),
             GeoProbeError::NoRecord => write!(f, "no record found in DB"),
-            GeoProbeError::UnknownError => write!(f, "unknown error"),
         }
     }
 }
@@ -86,7 +84,9 @@ pub fn process_block(
     let pkh = blake2_256(raw_pubkey);
     let (pkh_first_32_bits, _) = pkh.split_at(std::mem::size_of::<u32>());
     let worker_magic = u32::from_be_bytes(
-        pkh_first_32_bits.try_into().expect("Should never fail with valid worker pubkey; qed."),
+        pkh_first_32_bits
+            .try_into()
+            .expect("Should never fail with valid worker pubkey; qed."),
     ) % BLOCK_INTERVAL;
     if block_number % BLOCK_INTERVAL == worker_magic {
         log::info!(
@@ -97,85 +97,74 @@ pub fn process_block(
 
         let egress = egress.clone();
         let duration = PROBE_DURATION;
-        let task = AsyncSideTask::spawn(
-            block_number,
-            duration,
-            async {
-                // 1. we load the database first, so that in case where the database not exists,
-                // we can just return an error without emits any http request.
-                let geo_db_buf =
-                    std::fs::read(geoip_city_db).or(Err(GeoProbeError::DBNotFound))?;
 
-                // 2. get IP address.
-                let mut resp = surf::get(IP_PROBE_URL)
-                    .send()
-                    .await
-                    .or(Err(GeoProbeError::FailedToGetPublicIPAddress))?;
-                let pub_ip = resp
-                    .body_string()
-                    .await
-                    .or(Err(GeoProbeError::FailedToGetPublicIPAddress))?;
-                log::info!("public IP address: {}", pub_ip);
+        let topic = contract::command_topic(contract::id256(contract::GEOLOCATION));
+        let my_ecdh_key = identity_key
+            .derive_ecdh_key()
+            .expect("Should never failed with valid identity key; qed.");
+        // TODO: currently assume contract key equals to local ecdh key
+        let remote_pubkey = my_ecdh_key.clone().public();
 
-                // 3. Look up geolocation info in maxmind database.
-                let reader = maxminddb::Reader::from_source(geo_db_buf)
-                    .or(Err(GeoProbeError::DBNotValid))?;
-                let ip: IpAddr =
-                    FromStr::from_str(&pub_ip).or(Err(GeoProbeError::IPNotValid))?;
+        let default_messages = {
+            let message = GeolocationCommand::update_geolocation(None);
+            let secret_channel =
+                secret_channel::bind_remote(&egress, &my_ecdh_key, Some(&remote_pubkey));
+            [secret_channel.prepare_message_to(&message, &topic[..])]
+        };
 
-                let city_general_data: geoip2::City =
-                    reader.lookup(ip).or(Err(GeoProbeError::NoRecord))?;
-                let region_name =
-                    db_query_region_name(&city_general_data).ok_or(GeoProbeError::NoRecord)?;
+        side_task_man.add_async_task_finish_at(block_number + duration, default_messages,  async move {
+            // 1. we load the database first, so that in case where the database not exists,
+            // we can just return an error without emits any http request.
+            let geo_db_buf = std::fs::read(geoip_city_db).or(Err(GeoProbeError::DBNotFound))?;
 
-                let location = city_general_data
-                    .location
-                    .clone()
-                    .ok_or(GeoProbeError::NoRecord)?;
-                let latitude = location.latitude.ok_or(GeoProbeError::NoRecord)?;
-                let longitude = location.longitude.ok_or(GeoProbeError::NoRecord)?;
+            // 2. get IP address.
+            let mut resp = surf::get(IP_PROBE_URL)
+                .send()
+                .await
+                .or(Err(GeoProbeError::FailedToGetPublicIPAddress))?;
+            let pub_ip = resp
+                .body_string()
+                .await
+                .or(Err(GeoProbeError::FailedToGetPublicIPAddress))?;
+            log::info!("public IP address: {}", pub_ip);
 
-                info!(
-                    "look-up geolocation: {}, {}, {}",
-                    latitude, longitude, region_name
-                );
+            // 3. Look up geolocation info in maxmind database.
+            let reader =
+                maxminddb::Reader::from_source(geo_db_buf).or(Err(GeoProbeError::DBNotValid))?;
+            let ip: IpAddr = FromStr::from_str(&pub_ip).or(Err(GeoProbeError::IPNotValid))?;
 
-                let geocoding = Geocoding {
-                    latitude: (latitude * 10000f64) as i32,
-                    longitude: (longitude * 10000f64) as i32,
-                    region_name: region_name.to_string(),
-                };
+            let city_general_data: geoip2::City =
+                reader.lookup(ip).or(Err(GeoProbeError::NoRecord))?;
+            let region_name =
+                db_query_region_name(&city_general_data).ok_or(GeoProbeError::NoRecord)?;
 
-                Ok(geocoding)
-            },
-            move |result, _context| {
-                // 4. construct the confidential contract command.
-                let result = result.unwrap_or(Err(GeoProbeError::UnknownError));
-                if let Err(err) = &result {
-                    info!("geo_probe sidetask error: {}", err);
-                }
-                let msg = GeolocationCommand::update_geolocation(result.ok());
+            let location = city_general_data
+                .location
+                .clone()
+                .ok_or(GeoProbeError::NoRecord)?;
+            let latitude = location.latitude.ok_or(GeoProbeError::NoRecord)?;
+            let longitude = location.longitude.ok_or(GeoProbeError::NoRecord)?;
 
-                // 5. construct the secret message channel
-                let my_ecdh_key = identity_key
-                    .derive_ecdh_key()
-                    .expect("Should never failed with valid identity key; qed.");
-                // TODO: currently assume contract key equals to local ecdh key
-                let public_contract_ecdh_key = my_ecdh_key.clone().public();
-                // TODO: currently is a fake key map.
-                let key_map = |topic: &[u8]| Some(public_contract_ecdh_key);
-                let secret_egress = SecretMessageChannel::new(&my_ecdh_key, &egress, &key_map);
-                let topic = contract::command_topic(contract::id256(contract::GEOLOCATION));
-                log::info!(
-                    "send msg [{:?}] to topic [{:?}]",
-                    &msg,
-                    String::from_utf8_lossy(&topic)
-                );
+            info!(
+                "look-up geolocation: {}, {}, {}",
+                latitude, longitude, region_name
+            );
 
-                // 6. send the command
-                secret_egress.push_message_to(topic, &msg, Some(&public_contract_ecdh_key));
-            },
-        );
-        side_task_man.add_task(task);
+            let geocoding = Geocoding {
+                latitude: (latitude * 10000f64) as i32,
+                longitude: (longitude * 10000f64) as i32,
+                region_name: region_name.to_string(),
+            };
+
+            // 4. construct the confidential contract command.
+            let msg = GeolocationCommand::update_geolocation(Some(geocoding));
+
+            // 5. construct the secret message channel
+            let secret_channel =
+                secret_channel::bind_remote(&egress, &my_ecdh_key, Some(&remote_pubkey));
+            let topic = contract::command_topic(contract::id256(contract::GEOLOCATION));
+            //6. send the command
+            Ok([secret_channel.prepare_message_to(&msg, topic)])
+        });
     }
 }

--- a/crates/phala-mq/Cargo.toml
+++ b/crates/phala-mq/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = "0.4.14"
 hex = { version =  "0.4.3", default-features = false, features = ['alloc'] }
 derive_more = { version = "0.99", default-features = false, features = ["display"] }
 parity-scale-codec = { version = "2.1", default-features = false, features = ["derive"] }

--- a/crates/phala-mq/src/lib.rs
+++ b/crates/phala-mq/src/lib.rs
@@ -46,7 +46,7 @@ mod alias {
 pub mod traits {
     use parity_scale_codec::Encode;
 
-    use crate::{BindTopic, Path};
+    use crate::{BindTopic, Path, SigningMessage};
 
     pub trait MessageChannel {
         fn push_data(&self, data: alloc::vec::Vec<u8>, to: impl Into<Path>);
@@ -57,5 +57,17 @@ pub mod traits {
             self.push_message_to(message, M::topic())
         }
         fn set_dummy(&self, _dummy: bool) {}
+    }
+
+    pub trait MessagePrepareChannel {
+        type Signer;
+
+        fn prepare_with_data(&self, data: alloc::vec::Vec<u8>, to: impl Into<Path>) -> SigningMessage<Self::Signer>;
+        fn prepare_message_to(&self, message: &impl Encode, to: impl Into<Path>) -> SigningMessage<Self::Signer> {
+            self.prepare_with_data(message.encode(), to)
+        }
+        fn prepare_message<M: Encode + BindTopic>(&self, message: &M) -> SigningMessage<Self::Signer> {
+            self.prepare_message_to(message, M::topic())
+        }
     }
 }

--- a/crates/phala-mq/src/send_queue.rs
+++ b/crates/phala-mq/src/send_queue.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Message, MessageOrigin, MessageSigner, MessageToBeSigned, Mutex, SenderId, SignedMessage,
-    SigningMessage,
+    Message, MessageOrigin, MessageSigner, Mutex, SenderId, SignedMessage, SigningMessage,
 };
 use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
@@ -160,5 +159,4 @@ mod msg_channel {
             self.prepare_with_data(payload, to)
         }
     }
-
 }

--- a/crates/phala-mq/src/send_queue.rs
+++ b/crates/phala-mq/src/send_queue.rs
@@ -122,8 +122,7 @@ mod msg_channel {
                 }
                 .encode();
                 let signature = signer.sign(&be_signed);
-                // TODO.kevin: log
-                // info!("send msg: data[{}], sig[{}], seq={}", be_signed.len(), signature.len(), sequence);
+                log::info!("Sending message, from={}, to={:?}, seq={}", message.sender, message.destination, sequence);
                 SignedMessage {
                     message,
                     sequence,

--- a/crates/phala-mq/src/send_queue.rs
+++ b/crates/phala-mq/src/send_queue.rs
@@ -35,7 +35,7 @@ impl MessageSendQueue {
         let entry = inner.entry(sender).or_default();
         if !entry.dummy {
             let message = constructor(entry.sequence);
-            log::info!(
+            log::info!(target: "mq",
                 "Sending message, from={}, to={:?}, seq={}",
                 message.message.sender,
                 message.message.destination,

--- a/crates/phala-mq/src/send_queue.rs
+++ b/crates/phala-mq/src/send_queue.rs
@@ -138,7 +138,7 @@ mod msg_channel {
             let signing = self.prepare_with_data(payload, to);
             self.queue
                 .enqueue_message(self.sender.clone(), move |sequence| {
-                    signing.to_signed(sequence)
+                    signing.sign(sequence)
                 })
         }
 

--- a/crates/phala-mq/src/types.rs
+++ b/crates/phala-mq/src/types.rs
@@ -288,7 +288,7 @@ impl<'a> MessageToBeSigned<'a> {
     }
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encode, Decode, Debug, Clone)]
 pub struct SigningMessage<Signer> {
     pub message: Message,
     pub signer: Signer,

--- a/crates/phala-mq/src/types.rs
+++ b/crates/phala-mq/src/types.rs
@@ -295,7 +295,7 @@ pub struct SigningMessage<Signer> {
 }
 
 impl<Signer: MessageSigner> SigningMessage<Signer> {
-    pub fn to_signed(self, sequence: u64) -> SignedMessage {
+    pub fn sign(self, sequence: u64) -> SignedMessage {
         let data = MessageToBeSigned {
             message: &self.message,
             sequence,

--- a/crates/phala-mq/src/types.rs
+++ b/crates/phala-mq/src/types.rs
@@ -1,16 +1,18 @@
-use alloc::vec::Vec;
 use alloc::string::String;
+use alloc::vec::Vec;
 use core::hash::{Hash, Hasher};
 
+use derive_more::Display;
 use parity_scale_codec::{Decode, Encode};
 use sp_core::crypto::{AccountId32, UncheckedFrom};
-use derive_more::Display;
 
 pub type Path = Vec<u8>;
 pub type SenderId = MessageOrigin;
 pub use primitive_types::H256 as ContractId;
 pub use primitive_types::H256 as AccountId;
 pub use primitive_types::H256 as ContractGroupId;
+
+use crate::MessageSigner;
 
 pub fn contract_id256(id: u32) -> ContractId {
     ContractId::from_low_u64_be(id as u64)
@@ -283,5 +285,26 @@ pub(crate) struct MessageToBeSigned<'a> {
 impl<'a> MessageToBeSigned<'a> {
     pub(crate) fn raw_data(&self) -> Vec<u8> {
         self.encode()
+    }
+}
+
+#[derive(Encode, Decode, Debug)]
+pub struct SigningMessage<Signer> {
+    pub message: Message,
+    pub signer: Signer,
+}
+
+impl<Signer: MessageSigner> SigningMessage<Signer> {
+    pub fn to_signed(self, sequence: u64) -> SignedMessage {
+        let data = MessageToBeSigned {
+            message: &self.message,
+            sequence,
+        };
+        let signature = self.signer.sign(&data.raw_data());
+        SignedMessage {
+            message: self.message,
+            sequence,
+            signature,
+        }
     }
 }

--- a/crates/phala-mq/tests/tests.rs
+++ b/crates/phala-mq/tests/tests.rs
@@ -4,6 +4,7 @@ use phala_mq::traits::MessageChannel;
 #[cfg(feature = "queue")]
 #[test]
 fn test_send_message() {
+    #[derive(Clone)]
     struct TestSigner(Vec<u8>);
 
     impl MessageSigner for TestSigner {

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -5,7 +5,6 @@ pub mod contract;
 
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
-use core::convert::{TryFrom, TryInto};
 use core::fmt::Debug;
 use sp_core::H256;
 


### PR DESCRIPTION
The previous side task implementation did not consider pRuntime snapshoting. This PR fixes it. 

Major changes:
- Refactor phala-mq to be able to make SigningMessage without giving it a sequence and without pushing it into the queue.
- Better secret channel API. Now it impl phala_mq::traits::MessageChannel as well. 
- Refactor the side-task.
    -  Constraint the number of mq messages it emits.
    -  To be snapshot friendly, default messages must be supplied when adding new side-tasks. The default messages are replacement when the async task does not finish successfully and can be stored in the pRuntime snapshot.
    -  Simplify the async task API, check the [new demo](https://github.com/Phala-Network/phala-blockchain/commit/side-task-demo3).