### PR TITLE
Cap the removing stake by user locked amount

### DIFF
--- a/pallets/phala/src/stakepool.rs
+++ b/pallets/phala/src/stakepool.rs
@@ -1197,8 +1197,8 @@ pub mod pallet {
 			let price = self.share_price()?;
 			let amount = bmul(shares, &price);
 			// In case `amount` is a little bit larger than `free_stake` or `user.locked`. Note
-            // that it should never really exceed `user.locked` because we ask the caller to ensure
-            // the share to remove is not greater than user's shares.
+			// that it should never really exceed `user.locked` because we ask the caller to ensure
+			// the share to remove is not greater than user's shares.
 			let amount = amount.min(self.free_stake).min(user.locked);
 			// Remove shares and stake from the user record
 			let user_shares = user.shares.checked_sub(&shares)?;

--- a/pallets/phala/src/stakepool.rs
+++ b/pallets/phala/src/stakepool.rs
@@ -1196,9 +1196,10 @@ pub mod pallet {
 			// deposit it to the Treasury.
 			let price = self.share_price()?;
 			let amount = bmul(shares, &price);
-			// In case `amount` is a little bit larger than `free_stake`. It also implies that
-			// amount will never exceed user.stake.
-			let amount = amount.min(self.free_stake);
+			// In case `amount` is a little bit larger than `free_stake` or `user.locked`. Note
+            // that it should never really exceed `user.locked` because we ask the caller to ensure
+            // the share to remove is not greater than user's shares.
+			let amount = amount.min(self.free_stake).min(user.locked);
 			// Remove shares and stake from the user record
 			let user_shares = user.shares.checked_sub(&shares)?;
 			let (user_shares, shares_dust) = extract_dust(user_shares);


### PR DESCRIPTION
Fixes #527

In `remove_stake()`, the PHA amount to remove is calculated on-the-fly based on the share and the share price. It introduces the precision problem. Even the share doesn't exceed the user's share, the calculated amount can be a little bit higher than both `pool.free_stake` and `user.locked`. We didn't check the later case. As a result, it may cause a panic in the downstream code.