### PR TITLE
Backfill scripts to fix #500 

### DIFF
--- a/scripts/js/bugfix-tools/b500-check-fix-compete.js
+++ b/scripts/js/bugfix-tools/b500-check-fix-compete.js
@@ -1,0 +1,132 @@
+require('dotenv').config();
+
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+const BN = require('bn.js');
+const { Decimal } = require('decimal.js');
+
+const { balanceBnToDec, calculateReturnSlash } = require('../src/utils/palletUtils');
+const { loadJson } = require('../src/utils/common');
+const { FixedPointConverter } = require('../src/utils/fixedUtils');
+const fp = new FixedPointConverter();
+
+const typedefs = require('@phala/typedefs').khalaDev;
+
+const bn0 = new BN(0);
+// const bn64b = new BN(2).pow(new BN(64));
+const bn1e12 = new BN(10).pow(new BN(12));
+const bnEps = new BN(100);
+
+function bnCmp(a, b) {
+    if (a.gt(b.add(bnEps))) {
+        return 1;
+    } else if (b.gt(a.add(bnEps))) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+async function main() {
+    const wsProvider = new WsProvider(process.env.ENDPOINT);
+    const api = await ApiPromise.create({ provider: wsProvider, types: typedefs });
+
+    const reconciling = loadJson('./tmp/issue500Reconciling.json');
+    const h = await api.rpc.chain.getBlockHash(reconciling.latestBlock);
+    const apiAt = await api.at(h);
+
+    let pools = await apiAt.query.phalaStakePool.stakePools.entries();
+    pools = pools
+        .map(([key, value]) => [key.args[0].toNumber(), value.unwrap()])
+        .filter(([_, value]) => value.releasingStake.gt(bn0));
+
+    const minerPreimages = reconciling.preimage;
+
+    // Dump stakers & miners
+    let stakes = await apiAt.query.phalaMining.stakes.entries();
+    stakes = stakes.map(([key, value]) => [key.args[0].toString(), value.unwrap()]);
+    let miners = await apiAt.query.phalaMining.miners.entries();
+    miners = miners.map(([key, value]) => [key.args[0].toString(), value.unwrap()]);
+
+    // All the CD miners => their releasing stake
+    const stakesMap = stakes.reduce((map, [k, v]) => {
+        map[k] = v;
+        return map;
+    }, {});
+    const cdMinerReleasing = miners
+        .filter(([_, info]) => info.state.toString() == 'MiningCoolingDown')
+        .map(([miner, info]) => {
+            const [returned, slashed] = calculateReturnSlash(info, stakesMap[miner]);
+            return [miner, {returned, slashed}];
+        }, {});
+
+    const poolKnownReleasing = cdMinerReleasing.reduce((map, [miner, releasing]) => {
+        if (!(miner in minerPreimages)) {
+            console.warn('Miner not found', miner);
+        } else {
+            const { pid } = minerPreimages[miner];
+            const n = map[pid] || bn0;
+            map[pid] = n.add(releasing.returned);
+        }
+        return map;
+    }, {});
+
+    const diff = pools.flatMap(([pid, pool]) => {
+        const knownReleasing = poolKnownReleasing[pid] || bn0;
+        if (bnCmp(pool.releasingStake, knownReleasing) != 0) {
+            return [{
+                pid,
+                cdSum: knownReleasing.toString(),
+                poolReleasing: pool.releasingStake.toString(),
+            }];
+        } else {
+            return [];
+        }
+    });
+
+    console.log('---- Before reconcile ----')
+    console.log(diff);
+    console.log(`Diff: ${diff.length}`);
+
+    // pool => stake(BN)
+
+    console.log('---- Reconciled ----')
+
+    const poolMissingStake = reconciling.missingStake
+        .map(s => [s.pid, new BN(s.returned)])
+        .reduce((map, [pid, returned]) => {
+            map[pid] = (map[pid] || bn0).add(returned);
+            return map;
+        }, {});
+
+    const diffReconciled = pools.flatMap(([pid, pool]) => {
+        let missed, hasMissed;
+        if (poolMissingStake[pid]) {
+            missed = poolMissingStake[pid];
+            hasMissed = true;
+        } else {
+            missed = bn0;
+            hasMissed = false;
+        }
+        const present = poolKnownReleasing[pid] || bn0;
+        const known = missed.add(present);
+        if (bnCmp(pool.releasingStake, known) != 0) {
+            const decCdSum = balanceBnToDec(known);
+            const poolReleasing = balanceBnToDec(pool.releasingStake);
+
+            return [{
+                pid,
+                cdSum: known.toString(),
+                poolReleasing: pool.releasingStake.toString(),
+                diff: poolReleasing.sub(decCdSum).toString(),
+                hasMissed,
+            }];
+        } else {
+            return [];
+        }
+    });
+
+    console.log(diffReconciled);
+    console.log(`Diff: ${diffReconciled.length}`);
+}
+
+main().catch(console.error).finally(() => process.exit());

--- a/scripts/js/bugfix-tools/b500-check-post-missing.js
+++ b/scripts/js/bugfix-tools/b500-check-post-missing.js
@@ -1,0 +1,59 @@
+require('dotenv').config();
+
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+
+const { poolSubAccount } = require('../src/utils/palletUtils');
+
+const typedefs = require('@phala/typedefs').khalaDev;
+
+async function printMiner(api, pid, worker, checks) {
+    const miner = poolSubAccount(api, pid, worker);
+
+    async function print(n) {
+        const h = await api.rpc.chain.getBlockHash(n);
+        const apiAt = await api.at(h);
+        const m = await apiAt.query.phalaMining.miners(miner);
+        const worker = await apiAt.query.phalaMining.minerBindings(miner);
+        const stake = await apiAt.query.phalaMining.stakes(miner);
+        const pool = await apiAt.query.phalaStakePool.stakePools(pid);
+        console.log({
+            n,
+            miner: m.toHuman(),
+            worker: worker.toHuman(),
+            stake: stake.toHuman(),
+            pool: pool.toHuman(),
+        });
+    }
+    for (const [tag, n] of checks) {
+        console.log(tag);
+        await print(n);
+    }
+}
+
+async function main() {
+    const wsProvider = new WsProvider(process.env.ENDPOINT);
+    const api = await ApiPromise.create({ provider: wsProvider, types: typedefs });
+
+    await printMiner(
+        api, 311, '0x042fd1d8359700b729adc8a58f4208baac2d4d41a33cfb73bc557ec661fa211a', [
+            ['added', 505552],
+            ['started', 505622],
+            ['stopped-1', 513876-1],
+            ['stopped', 513876],
+            ['wiped-1', 513903-1],
+            ['wiped', 513903],
+        ]
+    );
+
+    await printMiner(
+        api, 311, '0xa4ca6a09e40d692707b5e34e52850399c650e338143a7fae6bc38b28e0cc8609', [
+            ['added', 431747],
+            ['started', 431853],
+            ['stopped-1', 505505-1],
+            ['stopped', 505505],
+            ['stopped+50', 505505+50],
+        ]
+    );
+}
+
+main().catch(console.error).finally(() => process.exit());

--- a/scripts/js/bugfix-tools/b500-dump-events.js
+++ b/scripts/js/bugfix-tools/b500-dump-events.js
@@ -1,0 +1,59 @@
+require('dotenv').config();
+
+const fs = require('fs');
+
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+
+const typedefs = require('@phala/typedefs').khalaDev;
+
+const interested = [
+    'phalaStakePool.PoolWorkerAdded',
+    'phalaMining.MinerReclaimed',
+    'phalaMining.MinerStarted',
+    'phalaMining.MinerStopped',
+];
+
+async function main() {
+    const wsProvider = new WsProvider(process.env.ENDPOINT);
+    const api = await ApiPromise.create({ provider: wsProvider, types: typedefs });
+
+
+    const since = parseInt(process.env.SINCE || '411774');
+    const until = parseInt(process.env.UNTIL || '570248');
+    const outfile = fs.openSync(process.env.OUT || './tmp/issue500events.json', 'a');
+
+    const lastHash = await api.rpc.chain.getBlockHash(until);
+    let header = await api.rpc.chain.getHeader(lastHash);
+    while(header.number.toNumber() > since) {
+        const h = header.hash;
+        const blockNumber = header.number.toNumber();
+
+        if (blockNumber % 100 == 0) {
+            console.log(blockNumber);
+        }
+
+        const events = await api.query.system.events.at(h);
+        const targetsRev = events
+            .map(event => {
+                event.display = `${event.event.section}.${event.event.method}`;
+                return event;
+            })
+            .filter(event => interested.includes(event.display))
+            .map(event => ({
+                blockNumber,
+                event: event.display,
+                data: event.event.data.map(d => d.toString())
+            }))
+            .reverse();
+        for (let record of targetsRev) {
+            const d = JSON.stringify(record)
+            fs.writeSync(outfile, d);
+            fs.writeSync(outfile, '\n');
+        }
+        fs.fdatasyncSync(outfile);
+        header = await api.rpc.chain.getHeader(header.parentHash);
+    }
+    fs.closeSync(outfile);
+}
+
+main().catch(console.error).finally(() => process.exit());

--- a/scripts/js/bugfix-tools/b500-gen-reconcile.js
+++ b/scripts/js/bugfix-tools/b500-gen-reconcile.js
@@ -1,0 +1,29 @@
+require('dotenv').config();
+
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+const { loadJson } = require('../src/utils/common');
+
+const typedefs = require('@phala/typedefs').khalaDev;
+
+function propose(api, call) {
+    const lenthBound = call.toU8a().length + 10;
+    return api.tx.council.propose(3, call, lenthBound);
+}
+
+async function main() {
+    const wsProvider = new WsProvider(process.env.ENDPOINT);
+    const api = await ApiPromise.create({ provider: wsProvider, types: typedefs });
+
+    const reconciling = loadJson('./tmp/issue500Reconciling.json');
+
+    const tx = api.tx.phalaStakePool.backfillIssue500Reclaim(
+        reconciling.missingStake.map(
+            ({pid, worker, origStake, slashed}) =>
+            [pid, worker, origStake, slashed]
+        )
+    );
+    const proposalTx = propose(api, tx);
+    console.log(proposalTx.toHex());
+}
+
+main().catch(console.error).finally(() => process.exit());

--- a/scripts/js/bugfix-tools/b500-preprocess.js
+++ b/scripts/js/bugfix-tools/b500-preprocess.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+const { poolSubAccount } = require('../src/utils/palletUtils');
+
+const typedefs = require('@phala/typedefs').khalaDev;
+
+const PoolWorkerAdded = 'phalaStakePool.PoolWorkerAdded';   // (pid, worker)
+const MinerStarted = 'phalaMining.MinerStarted';    // (miner)
+const MinerStopped = 'phalaMining.MinerStopped';    // (miner)
+const MinerReclaimed = 'phalaMining.MinerReclaimed';    // (miner, returned, slashed)
+
+async function main() {
+    const wsProvider = new WsProvider(process.env.ENDPOINT);
+    const api = await ApiPromise.create({ provider: wsProvider, types: typedefs });
+
+    const filein = fs.readFileSync('./tmp/issue500events.json', {encoding: 'utf-8'});
+    const events = filein.split('\n').filter(x => !!x).map(JSON.parse).reverse();
+
+    const preimage = {};
+    const minerEvents = {};
+    for (const ev of events) {
+        if (ev.event == PoolWorkerAdded) {
+            const [pid, worker] = ev.data;
+            const miner = poolSubAccount(api, pid, worker).toString();
+            preimage[miner] = {pid, worker};
+            if (!minerEvents[miner]) {
+                minerEvents[miner] = {
+                    pid, worker,
+                    events: [],
+                };
+            }
+            minerEvents[miner].events.push({
+                blockNumber: ev.blockNumber,
+                event: ev.event,
+            });
+        } else if (ev.event == MinerStarted || ev.event == MinerStopped || ev.event == MinerReclaimed) {
+            const miner = ev.data[0];
+            minerEvents[miner].events.push({
+                blockNumber: ev.blockNumber,
+                event: ev.event,
+            })
+        }
+    }
+
+    const outJson = JSON.stringify(minerEvents, undefined, 2);
+    fs.writeFileSync('./tmp/issue500minerEvents.json', outJson, {encoding: 'utf-8'});
+}
+
+main().catch(console.error).finally(() => process.exit());

--- a/scripts/js/bugfix-tools/b500-reconstruct-error.js
+++ b/scripts/js/bugfix-tools/b500-reconstruct-error.js
@@ -1,0 +1,198 @@
+require('dotenv').config();
+
+const fs = require('fs');
+
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+const BN = require('bn.js');
+
+const { poolSubAccount, calculateReturnSlash } = require('../src/utils/palletUtils');
+const { FixedPointConverter } = require('../src/utils/fixedUtils');
+const fp = new FixedPointConverter();
+
+const typedefs = require('@phala/typedefs').khalaDev;
+const Decimal = require('decimal.js').default;
+
+const bn1e12 = new BN(10).pow(new BN(12));
+const dec1 = new Decimal(1);
+const dec1e12 = new Decimal(bn1e12.toString());
+
+const PoolWorkerAdded = 'phalaStakePool.PoolWorkerAdded';   // (pid, worker)
+const MinerStarted = 'phalaMining.MinerStarted';    // (miner)
+const MinerStopped = 'phalaMining.MinerStopped';    // (miner)
+const MinerReclaimed = 'phalaMining.MinerReclaimed';    // (miner, returned, slashed)
+
+async function getApiAt(api, at) {
+    const h = await api.rpc.chain.getBlockHash(at);
+    const apiAt = await api.at(h);
+    return apiAt;
+}
+
+async function minerStateAt(api, miner) {
+    const r = await api.query.phalaMining.miners(miner);
+    return r.unwrap();
+}
+
+function findAffectedWorkers(minerEvents) {
+    // State machine:
+    //                  |--------------[Relcaim]-------------|
+    //                  v                                    |
+    //  None -[Add]-> Ready -[Start]-> Mining -[Stop]-> CoolingDown
+    //               /   ^                                   |
+    //      [re-Add] \---|----------[Add (b500!)]------------|
+
+    const b500Error = [];
+    for (const [miner, info] of Object.entries(minerEvents)) {
+        let state = 'None';
+        let addedAt, stoppedAt;
+        for (const ev of info.events) {
+            const wrongState = () => {
+                console.warn('wrong state', {
+                    blockNumber: ev.blockNumber,
+                    miner,
+                    from: state,
+                    event: ev.event,
+                });
+            }
+            if (state == 'None') {
+                if (ev.event == PoolWorkerAdded) {
+                    state = 'Ready';
+                    addedAt = ev.blockNumber;
+                    stoppedAt = undefined;
+                } else {
+                    wrongState();
+                }
+            } else if (state == 'Ready') {
+                if (ev.event == MinerStarted) {
+                    state = 'Mining';
+                } else if (ev.event == PoolWorkerAdded) {
+                    // no-op: user just removed & added back
+                    addedAt = ev.blockNumber;
+                    stoppedAt = undefined;
+                } else {
+                    wrongState();
+                }
+            } else if (state == 'Mining') {
+                if (ev.event == MinerStopped) {
+                    state = 'CoolingDown';
+                    stoppedAt = ev.blockNumber;
+                } else {
+                    wrongState();
+                }
+            } else if (state == 'CoolingDown') {
+                if (ev.event == MinerReclaimed) {
+                    state = 'Ready';
+                } else if (ev.event == PoolWorkerAdded) {
+                    // May trigger the bug!
+                    b500Error.push({
+                        blocknum: ev.blockNumber,
+                        pid: info.pid,
+                        worker: info.worker,
+                        miner: miner,
+                        addedAt,
+                        stoppedAt,
+                    });
+                    console.log('b500 candidate', miner);
+                    state = 'Ready';
+                    addedAt =  ev.blockNumber;
+                    stoppedAt = undefined;
+                } else {
+                    wrongState();
+                }
+            } else {
+                wrongState();
+            }
+        }
+    }
+    return b500Error;
+}
+
+async function main() {
+    const wsProvider = new WsProvider(process.env.ENDPOINT);
+    const api = await ApiPromise.create({ provider: wsProvider, types: typedefs });
+
+    const filein = fs.readFileSync('./tmp/issue500minerEvents.json', {encoding: 'utf-8'});
+    const minerEvents = JSON.parse(filein);
+    Object.entries(minerEvents).forEach(([_k, info]) => {
+        info.pid = parseInt(info.pid);
+    });
+
+    // run the state machine to simulate the mining process and find out the workers affected by
+    // b500
+    const potentialMissingStake = findAffectedWorkers(minerEvents);
+
+    // reconstruct real missing stake
+    const missingStake = [];
+    let skipped = 0;
+    for (const candidate of potentialMissingStake) {
+        const {stoppedAt, blocknum, pid, worker, miner} = candidate;  // blocknum
+
+        const apiAtBefore = await getApiAt(api, stoppedAt);
+        const apiAtAfter = await getApiAt(api, blocknum);
+
+        const before = await minerStateAt(apiAtBefore , miner);
+        const after = await minerStateAt(apiAtAfter, miner);
+
+        if (before.state == 'Ready' && after.state == 'Ready') {
+            skipped++;
+            continue;
+        } else if (before.state == 'MiningCoolingDown' && after.state == 'Ready') {
+            const stake = await apiAtBefore.query.phalaMining.stakes(miner);
+
+            const [returned, slashed] = calculateReturnSlash(before, stake.unwrap());
+            const item = {
+                blocknum, stoppedAt, pid, worker, miner,
+                origStake: stake.toString(),
+                returned: returned.toString(),
+                slashed: slashed.toString(),
+            };
+            missingStake.push(item);
+            console.log(`[${blocknum}] Missing stake pid=${pid} worker=${worker} returning=${returned} slashing=${slashed}`);
+        } else {
+            console.error('Unknown case', blocknum, pid, worker);
+        }
+        // console.log('------------------');
+        // console.log(before.toJSON());
+        // console.log(after.toJSON());
+    }
+    console.log(`${missingStake.length} found, ${skipped} entries skipped`);
+
+    // apply #541 special adjustment
+    const b541Hack = {
+        '43E9fDbtnPZRudbFHxDoGiid8gxoMAodJJuBaHi9qLUb9zdn': '23592649396643'
+    };
+    let numHackApplied = 0;
+    missingStake.forEach(item => {
+        if (item.miner in b541Hack) {
+            const slashed = new BN(item.slashed);
+            const returned = new BN(item.returned);
+            const toSlash = new BN(b541Hack[item.miner]);
+            item.slashed = slashed.add(toSlash).toString();
+            item.returned = returned.sub(toSlash).toString();
+            console.log('b541 hack', {
+                before: returned.toString(),
+                after: item.returned.toString(),
+            })
+            numHackApplied++;
+        }
+    });
+    console.log(`b541 hack applied: ${numHackApplied}`);
+
+    const latestBlock = 570248;
+    const preimage = Object.entries(minerEvents).reduce((map, [miner, {worker, pid}]) => {
+        map[miner] = {worker, pid};
+        return map;
+    }, {});
+    const reconciling = {
+        latestBlock,
+        preimage,
+        missingStake,
+        b541Hack,
+    }
+    fs.writeFileSync(
+        './tmp/issue500Reconciling.json',
+        JSON.stringify(reconciling, undefined, 2),
+        {'encoding': 'utf-8'}
+    );
+}
+
+main().catch(console.error).finally(() => process.exit());

--- a/scripts/js/src/utils/palletUtils.js
+++ b/scripts/js/src/utils/palletUtils.js
@@ -1,0 +1,52 @@
+const BN = require('bn.js');
+const { Decimal } = require('decimal.js');
+
+const { hexToU8a, stringToU8a, u8aToHex, u8aConcat } = require('@polkadot/util');
+const { blake2AsU8a } = require('@polkadot/util-crypto');
+
+const { FixedPointConverter } = require('./fixedUtils');
+const fp = new FixedPointConverter();
+
+const bn1e12 = new BN(10).pow(new BN(12));
+const dec1 = new Decimal(1);
+const dec1e12 = new Decimal(bn1e12.toString());
+
+function balanceDecToBn(dec) {
+    return new BN(dec.mul(dec1e12).round().toFixed());
+}
+function balanceBnToDec(bn) {
+    return new Decimal(bn.toString()).div(dec1e12);
+}
+
+function poolSubAccount(api, pid, worker) {
+    let preimage = api.createType('u64', pid).toU8a();
+    preimage = u8aConcat(preimage, hexToU8a(worker));
+
+    const hash = blake2AsU8a(preimage);
+    const data = u8aConcat(stringToU8a("spm/"), hash);
+
+    return api.createType('AccountId', u8aToHex(data));
+}
+
+function calculateReturnSlash(minerInfo, origStake) {
+    const ve = fp.fromBits(minerInfo.ve);
+    const v = fp.fromBits(minerInfo.v);
+
+    const origStakeFixed = balanceBnToDec(origStake);
+
+    const returnRate = Decimal.min(v.div(ve), dec1);
+    const returned = returnRate.mul(origStakeFixed);
+    const slashed = origStakeFixed.sub(returned);
+
+    return [
+        balanceDecToBn(returned),
+        balanceDecToBn(slashed),
+    ];
+}
+
+module.exports = {
+    poolSubAccount,
+    calculateReturnSlash,
+    balanceDecToBn,
+    balanceBnToDec,
+};


### PR DESCRIPTION
## Usage

1. Prepare a Khala Network archive full node
2. Init the js script project by `yarn` under `scripts/js`
3. Dump all the related mining events

    ```bash
    node ./bugfix-tools/b500-dump-events.js
    node ./bugfix-tools/b500-preprocess.js
    ```

    - Optionally, specify the ws api port by env var `ENDPOINT`
    - It will create some json files under `./tmp` directory as the input for the next step. Make a directory if it doesn't exist.

4. Find out the affected miners

    ```bash
    node ./bugfix-tools/b500-reconstruct-error.js
    ```

5. Double check if the generated data with the affected miners is correct.

    ```bash
    node bugfix-tools/b500-check-fix-compete.js
    ```

    - It compares the sum of the stake of all the miners in CD state with sum of the `releasingStake` in all the pools. Please note that because of #541, the two number will have some minor different, but it's acceptable.

6. Generate the backfill transaction

    ```bash
    node ./bugfix-tools/b500-gen-reconcile.js
    ```
