### PR TITLE
Add script to dump metadata

### DIFF
--- a/scripts/dump-metadata.py
+++ b/scripts/dump-metadata.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import json
+import codecs
+import argparse
+
+try:
+    # Python2
+    import urllib2 as request
+except ImportError:
+    # Python3
+    import urllib.request as request
+
+
+DEFAULT_URL = 'http://localhost:9933'
+
+
+def rpc(url, method, params):
+    # post json data
+    data = {
+        "jsonrpc": "2.0",
+        "id":1,
+        "method": method,
+        "params": params,
+    }
+    data = json.dumps(data).encode('utf-8')
+    req = request.Request(url, data)
+    req.add_header('Content-Type', 'application/json; charset=utf-8')
+    resp = request.urlopen(req)
+    return json.loads(resp.read().decode('utf-8'))
+
+
+def get_metadata(url):
+    response = rpc(url, 'state_getMetadata', [])
+    if 'result' not in response:
+        raise Exception(response['error'])
+    result = response['result']
+    return codecs.decode(result[2:], 'hex')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Dump metadata from a running substrate node')
+    parser.add_argument('--url', default=DEFAULT_URL, help='HTTP RPC address of the substrate node')
+    parser.add_argument('output', nargs='?', default='metadata.scale', help='output file')
+    args = parser.parse_args()
+    data = get_metadata(args.url)
+    open(args.output, 'wb').write(data)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Usage:
```
$ ./dump-metadata.py -h
usage: dump-metadata.py [-h] [--url URL] [output]

Dump metadata from a running substrate node

positional arguments:
  output      output file

optional arguments:
  -h, --help  show this help message and exit
  --url URL   HTTP RPC address of the substrate node
```

Example:
```bash
$ ./dump-metadata.py --url http://localhost:9933 kusama_metadata.scale
$ ./dump-metadata.py --url http://localhost:9934 khala_metadata.scale
$ ll kusama_metadata.scale 
-rw-rw-r-- 1 kvin kvin 146284 11月 25 09:55 kusama_metadata.scale
```