### PR TITLE
pRuntime: Rollback futures-rs from 0.3.18 to 0.3.17

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "crates/phactory/api/proto"]
 	path = crates/phactory/api/proto
 	url = https://github.com/Phala-Network/prpc-protos.git
-[submodule "cryptocorrosion-sgx"]
-	path = cryptocorrosion-sgx
-	url = https://github.com/Phala-Network/cryptocorrosion-sgx.git
 [submodule "standalone/pruntime/rizin"]
 	path = standalone/pruntime/rizin
 	url = https://github.com/rizinorg/rizin

--- a/standalone/pruntime/enclave/Cargo.lock
+++ b/standalone/pruntime/enclave/Cargo.lock
@@ -13,13 +13,17 @@ dependencies = [
  "blake2-rfc",
  "cpufeatures",
  "env_logger",
+ "event-listener",
+ "futures-executor",
  "hex",
  "http_req",
+ "httparse",
  "lazy_static",
  "libc",
  "log",
  "once_cell",
  "parity-scale-codec",
+ "parking",
  "parking_lot_core",
  "phactory",
  "phactory-api",
@@ -204,7 +208,7 @@ checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
 dependencies = [
  "concurrent-queue",
  "event-listener",
- "futures-core 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -256,7 +260,7 @@ dependencies = [
  "async-channel",
  "async-dup",
  "async-std",
- "futures-core 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-types",
  "httparse",
  "log",
@@ -266,7 +270,7 @@ dependencies = [
 [[package]]
 name = "async-io"
 version = "1.6.0"
-source = "git+https://github.com/Phala-Network/async-io-sgx.git?branch=phala#1c5e760c846da561bd4c46a7e9f55794db66d137"
+source = "git+https://github.com/Phala-Network/async-io-sgx.git?branch=phala#f02e5b47dfaf411ad0c841d5e99d23d014b5502a"
 dependencies = [
  "concurrent-queue",
  "futures-lite",
@@ -311,7 +315,7 @@ dependencies = [
  "async-lock",
  "crossbeam-utils",
  "futures-channel",
- "futures-core 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-io",
  "futures-lite",
  "gloo-timers",
@@ -338,7 +342,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d85a97c4a0ecce878efd3f945f119c78a646d8975340bca0398f9bb05c30cc52"
 dependencies = [
- "futures-core 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-io",
  "rustls 0.18.1",
  "webpki 0.21.4",
@@ -351,7 +355,7 @@ version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -594,9 +598,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
+checksum = "439989e6b8c38d1b6570a384ef1e49c8848128f5a97f3914baef02920842712f"
 
 [[package]]
 name = "byteorder"
@@ -949,7 +953,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -1039,7 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "rustc_version 0.4.0",
  "syn 1.0.82",
@@ -1113,7 +1117,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -1168,7 +1172,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -1192,7 +1196,7 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 [[package]]
 name = "event-listener"
 version = "2.5.1"
-source = "git+https://github.com/Phala-Network/event-listener-sgx.git?branch=phala#af83e5498a0ed38642a02605570d6c5737ccb2c2"
+source = "git+https://github.com/Phala-Network/event-listener-sgx.git?branch=phala#b2aceade7a2f395ae59969696a6f64423618467c"
 dependencies = [
  "sgx_tstd",
 ]
@@ -1270,7 +1274,7 @@ dependencies = [
  "fixed",
  "paste",
  "proc-macro-error",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -1410,7 +1414,7 @@ version = "4.0.0-dev"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -1421,7 +1425,7 @@ version = "4.0.0-dev"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -1430,7 +1434,7 @@ dependencies = [
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -1483,57 +1487,57 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
- "futures-core 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-executor",
  "futures-io",
  "futures-sink",
- "futures-task 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
- "futures-core 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-core"
-version = "0.3.18"
-source = "git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala#22f0d0e4b43842e6ef0b238fe9ed6a74ef523848"
+version = "0.3.17"
+source = "git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala-0.3.17#6805c98390148bf4517507b5adc0d7c6619cc581"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.18"
-source = "git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala#22f0d0e4b43842e6ef0b238fe9ed6a74ef523848"
+version = "0.3.17"
+source = "git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala-0.3.17#6805c98390148bf4517507b5adc0d7c6619cc581"
 dependencies = [
- "futures-core 0.3.18 (git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala)",
- "futures-task 0.3.18 (git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala)",
- "futures-util 0.3.18 (git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala)",
+ "futures-core 0.3.17 (git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala-0.3.17)",
+ "futures-task 0.3.17 (git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala-0.3.17)",
+ "futures-util 0.3.17 (git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala-0.3.17)",
  "num_cpus",
  "sgx_tstd",
 ]
 
 [[package]]
 name = "futures-io"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-lite"
@@ -1542,7 +1546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
- "futures-core 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-io",
  "memchr",
  "parking",
@@ -1552,31 +1556,33 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
- "proc-macro2 1.0.33",
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-task"
-version = "0.3.18"
-source = "git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala#22f0d0e4b43842e6ef0b238fe9ed6a74ef523848"
+version = "0.3.17"
+source = "git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala-0.3.17#6805c98390148bf4517507b5adc0d7c6619cc581"
 
 [[package]]
 name = "futures-timer"
@@ -1586,29 +1592,33 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
+ "autocfg",
  "futures-channel",
- "futures-core 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-io",
  "futures-macro",
  "futures-sink",
- "futures-task 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr",
  "pin-project-lite",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
  "slab",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.18"
-source = "git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala#22f0d0e4b43842e6ef0b238fe9ed6a74ef523848"
+version = "0.3.17"
+source = "git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala-0.3.17#6805c98390148bf4517507b5adc0d7c6619cc581"
 dependencies = [
- "futures-core 0.3.18 (git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala)",
- "futures-task 0.3.18 (git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala)",
+ "autocfg",
+ "futures-core 0.3.17 (git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala-0.3.17)",
+ "futures-task 0.3.17 (git+https://github.com/Phala-Network/futures-rs-sgx.git?branch=phala-0.3.17)",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1710,7 +1720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f16c88aa13d2656ef20d1c042086b8767bbe2bdb62526894275a1b062161b2e"
 dependencies = [
  "futures-channel",
- "futures-core 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1887,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "httparse"
 version = "1.5.1"
-source = "git+https://github.com/Phala-Network/httparse-sgx.git?branch=phala#2feac740e644c8c747bfe51da76fb42cb3a1b951"
+source = "git+https://github.com/Phala-Network/httparse-sgx.git?branch=phala#26918afcb9dc7b865fce7c606901d3221c3d6a95"
 dependencies = [
  "sgx_trts 1.1.4",
 ]
@@ -1951,7 +1961,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -2046,7 +2056,7 @@ dependencies = [
  "ink_lang_ir",
  "itertools",
  "parity-scale-codec",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -2060,7 +2070,7 @@ dependencies = [
  "blake2",
  "either",
  "itertools",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -2075,7 +2085,7 @@ dependencies = [
  "ink_lang_ir",
  "ink_primitives",
  "parity-scale-codec",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "syn 1.0.82",
 ]
 
@@ -2139,7 +2149,7 @@ version = "3.0.0-rc7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cf027da2c5597dc1c2a551eab24f9df0817c62956b16bdbecbf4b89904685a2"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
  "synstructure",
@@ -2177,6 +2187,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
@@ -2241,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.110"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58a4469763e4e3a906c4ed786e1c70512d16aa88f84dded826da42640fc6a1c"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libm"
@@ -2471,7 +2487,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -2600,9 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 dependencies = [
  "parking_lot",
 ]
@@ -2825,7 +2841,7 @@ dependencies = [
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -3127,7 +3143,7 @@ name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -3267,7 +3283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -3293,7 +3309,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "syn 1.0.82",
  "synstructure",
 ]
@@ -3322,7 +3338,7 @@ checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 [[package]]
 name = "parking"
 version = "2.0.0"
-source = "git+https://github.com/Phala-Network/parking-sgx.git?branch=phala#d877f0a3a3a31ebf80b1ba81a0f765f968d8d9a5"
+source = "git+https://github.com/Phala-Network/parking-sgx.git?branch=phala#c2eb65053153b9439c371399242a22dc0d3f3335"
 dependencies = [
  "sgx_tstd",
 ]
@@ -3418,7 +3434,7 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -3731,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fc3db1018c4b59d7d582a739436478b6035138b6aecbce989fc91c3e98409f"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
  "phf_shared",
 ]
@@ -3783,7 +3799,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -3860,7 +3876,7 @@ dependencies = [
  "ink_lang_ir",
  "ink_lang_macro",
  "proc-macro-crate",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -3920,6 +3936,7 @@ dependencies = [
 [[package]]
 name = "ppv-lite86"
 version = "0.2.10"
+source = "git+https://github.com/Phala-Network/cryptocorrosion-sgx.git?branch=phala#9efe783c57ce7dd7a093b48d0fecf4f693dee468"
 dependencies = [
  "sgx_trts 1.1.4 (git+https://github.com/Phala-Network/incubator-teaclave-sgx-sdk.git?branch=phala)",
 ]
@@ -3966,7 +3983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
  "version_check",
@@ -3978,7 +3995,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "version_check",
 ]
@@ -3988,6 +4005,12 @@ name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -4000,9 +4023,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -4043,7 +4066,7 @@ checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -4079,7 +4102,7 @@ dependencies = [
  "itertools",
  "log",
  "multimap",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "prost",
  "prost-build",
  "prost-types",
@@ -4124,7 +4147,7 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
 ]
 
 [[package]]
@@ -4336,7 +4359,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c38e3aecd2b21cb3959637b883bb3714bc7e43f0268b9a29d3743ee3e55cdd2"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -4482,9 +4505,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "safe-mix"
@@ -4525,7 +4548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -4627,9 +4650,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.131"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
 dependencies = [
  "serde_derive",
 ]
@@ -4646,22 +4669,22 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.131"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -4684,7 +4707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -4955,7 +4978,7 @@ version = "4.0.0-dev"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -5145,7 +5168,7 @@ dependencies = [
 name = "sp-core-hashing-proc-macro"
 version = "4.0.0-dev"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "sp-core-hashing",
  "syn 1.0.82",
@@ -5155,7 +5178,7 @@ dependencies = [
 name = "sp-debug-derive"
 version = "4.0.0-dev"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -5274,7 +5297,7 @@ name = "sp-npos-elections-solution-type"
 version = "4.0.0-dev"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -5340,7 +5363,7 @@ version = "4.0.0-dev"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -5487,7 +5510,7 @@ name = "sp-version-proc-macro"
 version = "4.0.0-dev"
 dependencies = [
  "parity-scale-codec",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -5516,12 +5539,12 @@ checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "ss58-registry"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827441708a5dd8ca54e6b79690dc06d1bede78e61961e667f683c23c16ef964c"
+checksum = "c83f0afe7e571565ef9aae7b0e4fb30fcaec4ebb9aea2f00489b772782aa03a4"
 dependencies = [
  "Inflector",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "serde",
  "serde_json",
@@ -5576,7 +5599,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "serde",
  "serde_derive",
@@ -5590,7 +5613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "serde",
  "serde_derive",
@@ -5621,7 +5644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
 dependencies = [
  "heck",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -5668,7 +5691,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "cfg-if",
- "futures-util 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom 0.2.3",
  "http-client",
  "http-types",
@@ -5698,7 +5721,7 @@ version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "unicode-xid 0.2.2",
 ]
@@ -5709,7 +5732,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
  "unicode-xid 0.2.2",
@@ -5800,7 +5823,7 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -5857,7 +5880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "standback",
  "syn 1.0.82",
@@ -5918,11 +5941,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "pin-project-lite",
 ]
 
@@ -5953,7 +5975,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
 ]
@@ -6273,7 +6295,7 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
  "wasm-bindgen-shared",
@@ -6307,7 +6329,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
  "wasm-bindgen-backend",
@@ -6532,7 +6554,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
- "proc-macro2 1.0.33",
+ "proc-macro2 1.0.34",
  "quote 1.0.10",
  "syn 1.0.82",
  "synstructure",

--- a/standalone/pruntime/enclave/Cargo.toml
+++ b/standalone/pruntime/enclave/Cargo.toml
@@ -33,7 +33,6 @@ phala-allocator = { path = "../../../crates/phala-allocator" }
 
 http_req    = { version = "0.8.1", default-features = false, features = ["rust-tls"]}
 
-async-io = { version = "1.6" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 # to patch them to work in sgx
@@ -41,6 +40,12 @@ ppv-lite86 = { version = "0.2", default-features = false, features = ["phala-sgx
 aho-corasick = { version = "0.7.18", default-features = false, features = ["phala-sgx"] }
 parking_lot_core = { version = "0.8.5", default-features = false, features = ["phala-sgx"] }
 cpufeatures = { version = "0.2", default-features = false, features = ["phala-sgx"] }
+async-io = { version = "1.6", default-features = false, features = ["phala-sgx"] }
+parking = { version = "2.0", default-features = false, features = ["phala-sgx"] }
+httparse = { version = "1.5.1", default-features = false, features = ["phala-sgx"] }
+futures-executor = { version = "0.3.17", default-features = false, features = ["phala-sgx"] }
+event-listener = { version = "2.5.1", default-features = false, features = ["phala-sgx"] }
+
 once_cell = { version = "1.8.0", default-features = false, features = ["parking_lot"] }
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
@@ -55,13 +60,13 @@ sgx_unwind      = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sg
 sgx_tstd        = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", default-features = false, features = ["stdio"] }
 
 [patch.crates-io]
-ppv-lite86 = { path = "../../../cryptocorrosion-sgx/utils-simd/ppv-lite86/" }
+ppv-lite86 = { git = "https://github.com/Phala-Network/cryptocorrosion-sgx.git", branch = "phala" }
 ring = { git = "https://github.com/Phala-Network/ring-sgx.git", branch = "phala" }
 async-io = { git = "https://github.com/Phala-Network/async-io-sgx.git", branch = "phala" }
 parking = { git = "https://github.com/Phala-Network/parking-sgx.git", branch = "phala" }
 httparse = { git = "https://github.com/Phala-Network/httparse-sgx.git", branch = "phala" }
 aho-corasick = { git = "https://github.com/Phala-Network/aho-corasick-sgx.git", branch = "phala" }
-futures-executor = { git = "https://github.com/Phala-Network/futures-rs-sgx.git", branch = "phala" }
+futures-executor = { git = "https://github.com/Phala-Network/futures-rs-sgx.git", branch = "phala-0.3.17" }
 event-listener = { git = "https://github.com/Phala-Network/event-listener-sgx.git", branch = "phala" }
 parking_lot_core = { git = "https://github.com/Phala-Network/parking_lot-sgx.git", branch = "phala" }
 cpufeatures = { git = "https://github.com/Phala-Network/cpufeatures-sgx.git", branch = "phala" }


### PR DESCRIPTION
This PR rollback futures-rs-0.3.18 to 0.3.17 since the 18 has been [yanked](https://crates.io/crates/futures-core/versions) on crates.io.
Also add feature gates for all patched crates so that those patches do not take effects on proc-macro or build dependencies.
