### PR TITLE
Check llvm version from the system #61

### DIFF
--- a/ring/mk/cargo.sh
+++ b/ring/mk/cargo.sh
@@ -14,7 +14,7 @@
 # OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-set -eux -o pipefail
+set -ex -o pipefail
 IFS=$'\n\t'
 
 rustflags_self_contained="-Clink-self-contained=yes -Clinker=rust-lld"
@@ -38,11 +38,18 @@ for arg in $*; do
   esac
 done
 
+source "llvm_check.sh"
+
 # See comments in install-build-tools.sh.
-llvm_version=10
+export llvm_version=10
 if [ -n "${RING_COVERAGE-}" ]; then
   llvm_version=11
 fi
+
+llvm_version_check # Change llvm_version if we can detect another one
+
+echo "My llvm_version is set to: $llvm_version"
+
 
 case $target in
    aarch64-linux-android)
@@ -110,6 +117,10 @@ case $target in
   *)
     ;;
 esac
+
+
+
+
 
 if [ -n "${RING_COVERAGE-}" ]; then
   # XXX: Collides between release and debug.

--- a/ring/mk/install-build-tools.sh
+++ b/ring/mk/install-build-tools.sh
@@ -81,12 +81,17 @@ case $target in
   ;;
 esac
 
+# Check if we can fingerprint the version of llvm, if so then we change the local variable
+source "llvm_check" # import llvm_check
 if [ -n "$use_clang" ]; then
   llvm_version=10
+  llvm_version_check
+
   if [ -n "${RING_COVERAGE-}" ]; then
     # https://github.com/rust-lang/rust/pull/79365 upgraded the coverage file
     # format to one that only LLVM 11+ can use
     llvm_version=11
+    llvm_version_check
     sudo apt-key add mk/llvm-snapshot.gpg.key
     sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-$llvm_version main"
     sudo apt-get update

--- a/ring/mk/llvm_check.sh
+++ b/ring/mk/llvm_check.sh
@@ -3,9 +3,7 @@
 
 function llvm_version_check() {
   tmpllvm="$(llvm-config --version)" # Check if we can get the llvm version from llvm-config
-  if [ $tmpllvm ]
-  then
+  if [ $tmpllvm > 10.0.0 ] || [ $tmpllvm > $llvm_version ]; then # Only change llvm_version if newer then version 10 or the local version is newer then the current llvm_version. 
         export llvm_version=$tmpllvm
   fi
 }
-

--- a/ring/mk/llvm_check.sh
+++ b/ring/mk/llvm_check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash  
+
+
+function llvm_version_check() {
+  tmpllvm="$(llvm-config --version)" # Check if we can get the llvm version from llvm-config
+  if [ $tmpllvm ]
+  then
+        export llvm_version=$tmpllvm
+  fi
+}
+


### PR DESCRIPTION
For issue #61 .


Installer scripts now checks if it can get the llvm version from the system, if it finds it, it will change it otherwise leave it as it is