### PR TITLE
enclave: Dont link to sgx_tprotected_fs

### DIFF
--- a/standalone/pruntime/enclave/build.rs
+++ b/standalone/pruntime/enclave/build.rs
@@ -1,10 +1,6 @@
 use std::env;
 
 fn main() {
-    let sdk_dir = env::var("SGX_SDK").unwrap_or_else(|_| "/opt/intel/sgxsdk".to_string());
-    println!("cargo:rustc-link-search=native={}/lib64", sdk_dir);
-    println!("cargo:rustc-link-lib=static=sgx_tprotected_fs");
-
     let ias_env = env::var("IAS_ENV").unwrap_or_else(|_| "DEV".to_string());
     match ias_env.as_ref() {
         "PROD" => {


### PR DESCRIPTION
The top Makefile takes care of it well.