### PR TITLE
Better error messages

### DIFF
--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -270,10 +270,10 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             }
             let priv_key = sr25519::Pair::from_seed_slice(&raw_key).map_err(from_debug)?;
             self.init_runtime_data(genesis_block_hash, Some(priv_key))
-                .map_err(from_display)?
+                .map_err(from_debug)?
         } else {
             self.init_runtime_data(genesis_block_hash, None)
-                .map_err(from_display)?
+                .map_err(from_debug)?
         };
         self.dev_mode = rt_data.dev_mode;
         self.skip_ra = skip_ra;

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -801,7 +801,7 @@ pub async fn subxt_connect<T: subxt::Config>(uri: &str) -> Result<subxt::Client<
         .set_url(uri)
         .build()
         .await
-        .context("Connect to substrate")
+        .context("Failed to connect to substrate")
 }
 
 async fn bridge(

--- a/standalone/pruntime/pruntime/src/ra.rs
+++ b/standalone/pruntime/pruntime/src/ra.rs
@@ -59,21 +59,21 @@ fn get_report_from_intel(quote: &[u8], ias_key: &str) -> Result<(String, String,
         return Err(anyhow!("Empty HTTP response"));
     }
 
-    let attn_report = String::from_utf8(res_body_buffer).context("UTF8 decode response")?;
+    let attn_report = String::from_utf8(res_body_buffer).context("Failed to decode attestation report")?;
     let sig = res
         .headers()
         .get("X-IASReport-Signature")
-        .context("Get X-IASReport-Signature")?
+        .context("No header X-IASReport-Signature")?
         .to_string();
     let cert = res
         .headers()
         .get("X-IASReport-Signing-Certificate")
-        .context("Get X-IASReport-Signing-Certificate")?
+        .context("No header X-IASReport-Signing-Certificate")?
         .to_string();
 
     // Remove %0A from cert, and only obtain the signing cert
     let cert = cert.replace("%0A", "");
-    let cert = urlencoding::decode(&cert).context("percent_decode cert")?;
+    let cert = urlencoding::decode(&cert).context("Failed to urldecode cert")?;
     let v: Vec<&str> = cert.split("-----").collect();
     let sig_cert = v[2].to_string();
 


### PR DESCRIPTION
This PR improve the previous weird error messages like:
```
[2022-02-15T09:56:22Z INFO  pherry] bridge() exited with error: Seal runtime data
```

changes to
```
[2022-02-15T10:18:41Z INFO  pherry] bridge() exited with error: Failed to seal runtime data
    
    Caused by:
        No such file or directory (os error 2)
```