### PR TITLE
Concurrent query

### DIFF
--- a/crates/phactory/Cargo.toml
+++ b/crates/phactory/Cargo.toml
@@ -48,7 +48,7 @@ parity-scale-codec   = { package = "parity-scale-codec", version = "2.0.0", defa
 scopeguard   = { version = "1.1", default-features = false }
 
 # Phala specific
-runtime = { path = "../../standalone/runtime", package = "phala-node-runtime" }
+runtime = { path = "../../standalone/runtime", package = "phala-node-runtime", default-features = false }
 phala-pallets = { path = "../../pallets/phala", default-features = false }
 phala-types = { path = "../phala-types", default-features = false, features = ["enable_serde", "pruntime", "sgx"] }
 phactory-api = { path = "./api", default-features = false, features = ["serde"] }

--- a/crates/phactory/src/contracts/assets.rs
+++ b/crates/phactory/src/contracts/assets.rs
@@ -292,6 +292,11 @@ impl contracts::NativeContract for Assets {
             Ok(resp) => resp,
         }
     }
+
+    fn snapshot(&self) -> Self {
+        // TODO: it's heavy
+        self.clone()
+    }
 }
 
 fn is_tracked(_id: &AccountId) -> bool {

--- a/crates/phactory/src/contracts/assets.rs
+++ b/crates/phactory/src/contracts/assets.rs
@@ -214,7 +214,7 @@ impl contracts::NativeContract for Assets {
     }
 
     fn handle_query(
-        &mut self,
+        &self,
         origin: Option<&chain::AccountId>,
         req: Self::QReq,
         _context: &mut contracts::QueryContext,

--- a/crates/phactory/src/contracts/balances.rs
+++ b/crates/phactory/src/contracts/balances.rs
@@ -155,7 +155,7 @@ impl contracts::NativeContract for Balances {
     }
 
     fn handle_query(
-        &mut self,
+        &self,
         origin: Option<&chain::AccountId>,
         req: Request,
         _context: &mut contracts::QueryContext,

--- a/crates/phactory/src/contracts/balances.rs
+++ b/crates/phactory/src/contracts/balances.rs
@@ -2,10 +2,10 @@ use std::collections::BTreeMap;
 use std::string::ToString;
 
 use anyhow::Result;
-use phala_mq::traits::MessageChannel;
 use core::fmt;
 use log::info;
 use parity_scale_codec::{Decode, Encode};
+use phala_mq::traits::MessageChannel;
 use phala_mq::MessageOrigin;
 
 use super::{TransactionError, TransactionResult};
@@ -17,7 +17,7 @@ use phala_types::messaging::{BalancesCommand, BalancesTransfer};
 
 pub type Command = BalancesCommand<chain::AccountId, chain::Balance>;
 
-#[derive(Debug, Encode, Decode)]
+#[derive(Debug, Encode, Decode, Clone)]
 pub struct Balances {
     total_issuance: chain::Balance,
     accounts: BTreeMap<AccountId, chain::Balance>,
@@ -181,5 +181,10 @@ impl contracts::NativeContract for Balances {
             Err(error) => Response::Error(error.to_string()),
             Ok(resp) => resp,
         }
+    }
+
+    fn snapshot(&self) -> Self {
+        // TODO: it's heavy
+        self.clone()
     }
 }

--- a/crates/phactory/src/contracts/btc_lottery.rs
+++ b/crates/phactory/src/contracts/btc_lottery.rs
@@ -45,6 +45,7 @@ lazy_static! {
     static ref TYPE_NF_BIT: U256 = U256::from(1) << 255;
 }
 
+#[derive(Clone)]
 struct PrivateKeyWrapper(PrivateKey);
 impl From<PrivateKey> for PrivateKeyWrapper {
     fn from(pk: PrivateKey) -> Self {
@@ -70,7 +71,7 @@ impl Decode for PrivateKeyWrapper {
     }
 }
 
-#[derive(Encode, Decode)]
+#[derive(Encode, Decode, Clone)]
 pub struct BtcLottery {
     round_id: u32,
     token_set: BTreeMap<u32, Vec<String>>,
@@ -429,6 +430,11 @@ impl contracts::NativeContract for BtcLottery {
                 tx_set: self.tx_set.clone(),
             },
         }
+    }
+
+    fn snapshot(&self) -> Self {
+        // TODO: it's heavy
+        self.clone()
     }
 }
 

--- a/crates/phactory/src/contracts/btc_lottery.rs
+++ b/crates/phactory/src/contracts/btc_lottery.rs
@@ -360,7 +360,7 @@ impl contracts::NativeContract for BtcLottery {
     }
 
     fn handle_query(
-        &mut self,
+        &self,
         _origin: Option<&chain::AccountId>,
         req: Request,
         _context: &mut contracts::QueryContext,

--- a/crates/phactory/src/contracts/btc_price_bot.rs
+++ b/crates/phactory/src/contracts/btc_price_bot.rs
@@ -275,4 +275,8 @@ impl contracts::NativeContract for BtcPriceBot {
             Request::QueryPrice => Ok(Response::Price(self.price.clone())),
         }
     }
+
+    fn snapshot(&self) -> Self {
+        self.clone()
+    }
 }

--- a/crates/phactory/src/contracts/btc_price_bot.rs
+++ b/crates/phactory/src/contracts/btc_price_bot.rs
@@ -246,7 +246,7 @@ impl contracts::NativeContract for BtcPriceBot {
 
     // Handle a direct Query and respond to it. It shouldn't modify the contract state.
     fn handle_query(
-        &mut self,
+        &self,
         origin: Option<&chain::AccountId>,
         req: Request,
         _context: &mut contracts::QueryContext,

--- a/crates/phactory/src/contracts/data_plaza.rs
+++ b/crates/phactory/src/contracts/data_plaza.rs
@@ -296,7 +296,7 @@ impl contracts::NativeContract for DataPlaza {
     }
 
     fn handle_query(
-        &mut self,
+        &self,
         _origin: Option<&chain::AccountId>,
         req: Request,
         _context: &mut contracts::QueryContext,

--- a/crates/phactory/src/contracts/geolocation.rs
+++ b/crates/phactory/src/contracts/geolocation.rs
@@ -126,7 +126,7 @@ impl contracts::NativeContract for Geolocation {
     }
 
     fn handle_query(
-        &mut self,
+        &self,
         origin: Option<&chain::AccountId>,
         req: Request,
         _: &mut contracts::QueryContext,

--- a/crates/phactory/src/contracts/geolocation.rs
+++ b/crates/phactory/src/contracts/geolocation.rs
@@ -169,4 +169,9 @@ impl contracts::NativeContract for Geolocation {
         self.guard(&context.block.block_number);
         Ok(Default::default())
     }
+
+    fn snapshot(&self) -> Self {
+        // TODO: this is really heavy, fix it or port me to wasm contract.
+        self.clone()
+    }
 }

--- a/crates/phactory/src/contracts/guess_number.rs
+++ b/crates/phactory/src/contracts/guess_number.rs
@@ -157,7 +157,7 @@ impl contracts::NativeContract for GuessNumber {
     /// * `req` — Off-chain Query to handle
     /// * `context` - The simplified current block info
     fn handle_query(
-        &mut self,
+        &self,
         origin: Option<&chain::AccountId>,
         req: Request,
         _context: &mut contracts::QueryContext,

--- a/crates/phactory/src/contracts/guess_number.rs
+++ b/crates/phactory/src/contracts/guess_number.rs
@@ -188,4 +188,8 @@ impl contracts::NativeContract for GuessNumber {
             }
         }
     }
+
+    fn snapshot(&self) -> Self {
+        self.clone()
+    }
 }

--- a/crates/phactory/src/contracts/mod.rs
+++ b/crates/phactory/src/contracts/mod.rs
@@ -12,12 +12,14 @@ use phala_mq::{MessageOrigin, SignedMessageChannel};
 pub mod assets;
 pub mod balances;
 pub mod btc_lottery;
-pub mod data_plaza;
 // pub mod diem;
 pub mod geolocation;
 pub mod pink;
 // pub mod substrate_kitties;
-pub mod web3analytics;
+
+// Disabled due to requiring &mut self in query
+// pub mod web3analytics;
+// pub mod data_plaza;
 
 pub mod btc_price_bot;
 pub mod guess_number;

--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -83,7 +83,7 @@ impl contracts::NativeContract for Pink {
     type QResp = Result<Response, QueryError>;
 
     fn handle_query(
-        &mut self,
+        &self,
         origin: Option<&AccountId>,
         req: Query,
         context: &mut contracts::QueryContext,
@@ -91,8 +91,7 @@ impl contracts::NativeContract for Pink {
         let origin = origin.ok_or(QueryError::BadOrigin)?;
         match req {
             Query::InkMessage(input_data) => {
-                let storage = cluster_storage(&mut context.contract_clusters, &self.cluster_id)
-                    .expect("Pink cluster should always exists!");
+                let storage = &mut context.cluster.storage;
 
                 let (ink_result, _effects) = self.instance.bare_call(
                     storage,
@@ -258,13 +257,6 @@ pub mod cluster {
                 cluster
             })
         }
-
-        pub fn commit_changes(&mut self) -> anyhow::Result<()> {
-            for cluster in self.clusters.values_mut() {
-                cluster.commit_changes()?;
-            }
-            Ok(())
-        }
     }
 
     #[derive(Serialize, Deserialize)]
@@ -285,11 +277,6 @@ pub mod cluster {
             &self.key
         }
 
-        pub fn commit_changes(&mut self) -> anyhow::Result<()> {
-            self.storage.commit_changes();
-            Ok(())
-        }
-
         pub fn set_id(&mut self, id: &ContractClusterId) {
             self.storage.set_cluster_id(id.as_bytes());
         }
@@ -304,6 +291,10 @@ pub mod cluster {
             code: Vec<u8>,
         ) -> Result<Hash, DispatchError> {
             self.storage.upload_code(origin, code)
+        }
+
+        pub fn snapshot(&self) -> Self {
+            todo!("TODO.kevin.must")
         }
     }
 }

--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -29,7 +29,7 @@ pub enum QueryError {
     RuntimeError(String),
 }
 
-#[derive(Encode, Decode)]
+#[derive(Encode, Decode, Clone)]
 pub struct Pink {
     instance: pink::Contract,
     cluster_id: ContractClusterId,
@@ -157,6 +157,10 @@ impl contracts::NativeContract for Pink {
                 TransactionError::Other(format!("Call contract on_block_end failed: {:?}", err))
             })?;
         Ok(effects)
+    }
+
+    fn snapshot(&self) -> Self {
+        self.clone()
     }
 }
 

--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -91,7 +91,7 @@ impl contracts::NativeContract for Pink {
         let origin = origin.ok_or(QueryError::BadOrigin)?;
         match req {
             Query::InkMessage(input_data) => {
-                let storage = &mut context.cluster.storage;
+                let storage = &mut context.storage;
 
                 let (ink_result, _effects) = self.instance.bare_call(
                     storage,
@@ -293,8 +293,5 @@ pub mod cluster {
             self.storage.upload_code(origin, code)
         }
 
-        pub fn snapshot(&self) -> Self {
-            todo!("TODO.kevin.must")
-        }
     }
 }

--- a/crates/phactory/src/contracts/support.rs
+++ b/crates/phactory/src/contracts/support.rs
@@ -90,10 +90,7 @@ pub trait NativeContract {
 
     fn snapshot(&self) -> Self
     where
-        Self: Sized,
-    {
-        todo!("TODO.kevin.must")
-    }
+        Self: Sized;
 }
 
 #[derive(Serialize, Deserialize, Encode, Decode)]
@@ -134,6 +131,13 @@ impl<Con: NativeContract> NativeContract for NativeContractWrapper<Con> {
 
     fn on_block_end(&mut self, context: &mut NativeContext) -> TransactionResult {
         self.inner.on_block_end(context)
+    }
+
+    fn snapshot(&self) -> Self {
+        Self {
+            inner: self.inner.snapshot(),
+            id: self.id,
+        }
     }
 }
 

--- a/crates/phactory/src/contracts/support.rs
+++ b/crates/phactory/src/contracts/support.rs
@@ -4,7 +4,7 @@ use runtime::BlockNumber;
 use serde::{Deserialize, Serialize};
 use sp_core::hashing::blake2_256;
 
-use super::pink::cluster::{Cluster, ClusterKeeper};
+use super::pink::cluster::ClusterKeeper;
 use super::*;
 use crate::secret_channel::SecretReceiver;
 use crate::types::BlockInfo;
@@ -26,7 +26,7 @@ pub struct NativeContext<'a, 'b> {
 pub struct QueryContext {
     pub block_number: BlockNumber,
     pub now_ms: u64,
-    pub cluster: Cluster,
+    pub storage: ::pink::Storage,
 }
 
 impl NativeContext<'_, '_> {

--- a/crates/phactory/src/contracts/support.rs
+++ b/crates/phactory/src/contracts/support.rs
@@ -4,7 +4,7 @@ use runtime::BlockNumber;
 use serde::{Deserialize, Serialize};
 use sp_core::hashing::blake2_256;
 
-use super::pink::cluster::ClusterKeeper;
+use super::pink::cluster::{Cluster, ClusterKeeper};
 use super::*;
 use crate::secret_channel::SecretReceiver;
 use crate::types::BlockInfo;
@@ -23,10 +23,10 @@ pub struct NativeContext<'a, 'b> {
     pub self_id: ContractId,
 }
 
-pub struct QueryContext<'a> {
+pub struct QueryContext {
     pub block_number: BlockNumber,
     pub now_ms: u64,
-    pub contract_clusters: &'a mut ClusterKeeper,
+    pub cluster: Cluster,
 }
 
 impl NativeContext<'_, '_> {
@@ -35,14 +35,18 @@ impl NativeContext<'_, '_> {
     }
 }
 
-pub trait Contract {
-    fn id(&self) -> ContractId;
+pub trait Queryable {
     fn handle_query(
-        &mut self,
+        &self,
         origin: Option<&chain::AccountId>,
         req: OpaqueQuery,
         context: &mut QueryContext,
     ) -> Result<OpaqueReply, OpaqueError>;
+}
+
+pub trait Contract {
+    fn id(&self) -> ContractId;
+    fn snapshot_for_query(&self) -> Box<dyn Queryable>;
     fn cluster_id(&self) -> phala_mq::ContractClusterId;
     fn process_next_message(&mut self, env: &mut ExecuteEnv) -> Option<TransactionResult>;
     fn on_block_end(&mut self, env: &mut ExecuteEnv) -> TransactionResult;
@@ -75,13 +79,20 @@ pub trait NativeContract {
         Ok(Default::default())
     }
     fn handle_query(
-        &mut self,
+        &self,
         origin: Option<&chain::AccountId>,
         req: Self::QReq,
         context: &mut QueryContext,
     ) -> Self::QResp;
     fn on_block_end(&mut self, _context: &mut NativeContext) -> TransactionResult {
         Ok(Default::default())
+    }
+
+    fn snapshot(&self) -> Self
+    where
+        Self: Sized,
+    {
+        todo!("TODO.kevin.must")
     }
 }
 
@@ -113,7 +124,7 @@ impl<Con: NativeContract> NativeContract for NativeContractWrapper<Con> {
     }
 
     fn handle_query(
-        &mut self,
+        &self,
         origin: Option<&runtime::AccountId>,
         req: Self::QReq,
         context: &mut QueryContext,
@@ -129,6 +140,27 @@ impl<Con: NativeContract> NativeContract for NativeContractWrapper<Con> {
 impl<Con: NativeContract> NativeContractMore for NativeContractWrapper<Con> {
     fn id(&self) -> phala_mq::ContractId {
         self.id
+    }
+}
+
+struct Query<Con> {
+    contract: Con,
+}
+
+impl<Con> Queryable for Query<Con>
+where
+    Con: NativeContract,
+{
+    fn handle_query(
+        &self,
+        origin: Option<&runtime::AccountId>,
+        req: OpaqueQuery,
+        context: &mut QueryContext,
+    ) -> Result<OpaqueReply, OpaqueError> {
+        let response = self
+            .contract
+            .handle_query(origin, deopaque_query(req)?, context);
+        Ok(response.encode())
     }
 }
 
@@ -165,7 +197,7 @@ impl<Con: NativeContract> NativeCompatContract<Con> {
     }
 }
 
-impl<Con: NativeContract + NativeContractMore> Contract for NativeCompatContract<Con> {
+impl<Con: NativeContract + NativeContractMore + 'static> Contract for NativeCompatContract<Con> {
     fn id(&self) -> ContractId {
         self.contract_id
     }
@@ -174,17 +206,10 @@ impl<Con: NativeContract + NativeContractMore> Contract for NativeCompatContract
         self.cluster_id
     }
 
-    fn handle_query(
-        &mut self,
-        origin: Option<&runtime::AccountId>,
-        req: OpaqueQuery,
-        context: &mut QueryContext,
-    ) -> Result<OpaqueReply, OpaqueError> {
-        debug!(target: "contract", "Contract {:?} handling query", self.id());
-        let response = self
-            .contract
-            .handle_query(origin, deopaque_query(req)?, context);
-        Ok(response.encode())
+    fn snapshot_for_query(&self) -> Box<dyn Queryable> {
+        Box::new(Query {
+            contract: self.contract.snapshot(),
+        })
     }
 
     fn process_next_message(&mut self, env: &mut ExecuteEnv) -> Option<TransactionResult> {

--- a/crates/phactory/src/contracts/support/keeper.rs
+++ b/crates/phactory/src/contracts/support/keeper.rs
@@ -6,9 +6,9 @@ use std::ops::{Deref, DerefMut};
 use super::{Contract, NativeCompatContract, NativeContractWrapper};
 use crate::contracts::{
     assets::Assets, balances::Balances, btc_lottery::BtcLottery, btc_price_bot::BtcPriceBot,
-    data_plaza::DataPlaza, geolocation::Geolocation, guess_number::GuessNumber, pink::Pink,
-    web3analytics::Web3Analytics,
+    geolocation::Geolocation, guess_number::GuessNumber, pink::Pink,
 };
+
 
 type ContractMap = BTreeMap<ContractId, AnyContract>;
 type Compat<T> = NativeCompatContract<NativeContractWrapper<T>>;
@@ -16,10 +16,8 @@ type Compat<T> = NativeCompatContract<NativeContractWrapper<T>>;
 #[derive(Serialize, Deserialize)]
 pub enum AnyContract {
     Pink(NativeCompatContract<Pink>),
-    DataPlaza(Compat<DataPlaza>),
     Balances(Compat<Balances>),
     Assets(Compat<Assets>),
-    Web3Analytics(Compat<Web3Analytics>),
     BtcLottery(Compat<BtcLottery>),
     Geolocation(Compat<Geolocation>),
     GuessNumber(Compat<GuessNumber>),
@@ -32,10 +30,8 @@ impl Deref for AnyContract {
     fn deref(&self) -> &Self::Target {
         match self {
             AnyContract::Pink(c) => c,
-            AnyContract::DataPlaza(c) => c,
             AnyContract::Balances(c) => c,
             AnyContract::Assets(c) => c,
-            AnyContract::Web3Analytics(c) => c,
             AnyContract::BtcLottery(c) => c,
             AnyContract::Geolocation(c) => c,
             AnyContract::GuessNumber(c) => c,
@@ -48,10 +44,8 @@ impl DerefMut for AnyContract {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             AnyContract::Pink(c) => c,
-            AnyContract::DataPlaza(c) => c,
             AnyContract::Balances(c) => c,
             AnyContract::Assets(c) => c,
-            AnyContract::Web3Analytics(c) => c,
             AnyContract::BtcLottery(c) => c,
             AnyContract::Geolocation(c) => c,
             AnyContract::GuessNumber(c) => c,
@@ -66,12 +60,6 @@ impl From<NativeCompatContract<Pink>> for AnyContract {
     }
 }
 
-impl From<Compat<DataPlaza>> for AnyContract {
-    fn from(c: Compat<DataPlaza>) -> Self {
-        AnyContract::DataPlaza(c)
-    }
-}
-
 impl From<Compat<Balances>> for AnyContract {
     fn from(c: Compat<Balances>) -> Self {
         AnyContract::Balances(c)
@@ -81,12 +69,6 @@ impl From<Compat<Balances>> for AnyContract {
 impl From<Compat<Assets>> for AnyContract {
     fn from(c: Compat<Assets>) -> Self {
         AnyContract::Assets(c)
-    }
-}
-
-impl From<Compat<Web3Analytics>> for AnyContract {
-    fn from(c: Compat<Web3Analytics>) -> Self {
-        AnyContract::Web3Analytics(c)
     }
 }
 

--- a/crates/phactory/src/contracts/web3analytics.rs
+++ b/crates/phactory/src/contracts/web3analytics.rs
@@ -913,7 +913,7 @@ impl contracts::NativeContract for Web3Analytics {
     }
 
     fn handle_query(
-        &mut self,
+        &self,
         origin: Option<&chain::AccountId>,
         req: Request,
         _: &mut contracts::QueryContext,

--- a/crates/phactory/src/cryptography/aead.rs
+++ b/crates/phactory/src/cryptography/aead.rs
@@ -9,6 +9,7 @@ fn load_key(raw: &[u8]) -> ring::aead::LessSafeKey {
 }
 
 // Encrypts the data in-place and appends a 128bit auth tag
+#[allow(dead_code)]
 pub fn encrypt(iv: &IV, secret: &[u8], in_out: &mut Vec<u8>) {
     let nonce = ring::aead::Nonce::assume_unique_for_key(*iv);
     let key = load_key(secret);
@@ -18,6 +19,7 @@ pub fn encrypt(iv: &IV, secret: &[u8], in_out: &mut Vec<u8>) {
 }
 
 // Decrypts the cipher (with 128 auth tag appended) in-place and returns the message as a slice.
+#[allow(dead_code)]
 pub fn decrypt<'in_out>(iv: &[u8], secret: &[u8], in_out: &'in_out mut [u8]) -> &'in_out mut [u8] {
     let mut iv_arr = [0u8; IV_BYTES];
     iv_arr.copy_from_slice(&iv[..IV_BYTES]);

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -396,13 +396,6 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             serde_cbor::de::from_reader(dec_reader).context("Failed to decode state")?;
         Ok(loader.0)
     }
-
-    pub(crate) fn commit_storage_changes(&mut self) -> anyhow::Result<()> {
-        if let Some(system) = self.system.as_mut() {
-            system.commit_changes()?;
-        }
-        Ok(())
-    }
 }
 
 impl<Platform: Serialize + DeserializeOwned> Phactory<Platform> {

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -55,6 +55,7 @@ pub use side_task::SideTaskManager;
 pub use storage::{Storage, StorageExt};
 pub use system::gk;
 pub use types::BlockInfo;
+pub use prpc_service::dispatch_prpc_request;
 
 pub mod benchmark;
 

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -472,7 +472,9 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         let data = encrypted_req.decrypt(&ecdh_key).map_err(from_debug)?;
 
         // Decode head
-        let head = contract::ContractQueryHead::decode(&mut &data[..])?;
+        let mut data_cursor = &data[..];
+        let head = contract::ContractQueryHead::decode(&mut data_cursor)?;
+        let rest = data_cursor.len();
 
         // Origin
         let accid_origin = match origin {
@@ -492,7 +494,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             // Encode response
             let response = contract::ContractQueryResponse {
                 nonce: head.nonce,
-                result: contract::Data(call(accid_origin.as_ref(), &data)?),
+                result: contract::Data(call(accid_origin.as_ref(), &data[data.len()-rest..])?),
             };
             let response_data = response.encode();
 

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -1,3 +1,5 @@
+use std::sync::{Mutex, MutexGuard};
+
 use crate::system::System;
 
 use super::*;
@@ -484,9 +486,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         };
 
         // Dispatch
-        let call = self
-            .system()?
-            .make_query(&head.id)?;
+        let call = self.system()?.make_query(&head.id)?;
 
         Ok(move || {
             // Encode response
@@ -507,46 +507,6 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
 
             Ok(pb::ContractQueryResponse::new(encrypted_resp))
         })
-    }
-
-    pub fn dispatch_prpc_request(
-        &mut self,
-        path: &[u8],
-        data: &[u8],
-        output_buf_len: usize,
-    ) -> (u16, Vec<u8>) {
-        use prpc::server::{Error, ProtoError};
-
-        let path = match std::str::from_utf8(path) {
-            Ok(path) => path,
-            Err(e) => {
-                error!("prpc_request: invalid path: {}", e);
-                return (400, b"Invalid path".to_vec());
-            }
-        };
-        info!("Dispatching request: {}", path);
-
-        let mut server = PhactoryApiServer::new(RpcService {
-            output_buf_len,
-            phactory: self,
-        });
-        let (code, data) = match server.dispatch_request(path, data.to_vec()) {
-            Ok(data) => (200, data),
-            Err(err) => {
-                error!("Rpc error: {:?}", err);
-                let (code, err) = match err {
-                    Error::NotFound => (404, ProtoError::new("Method Not Found")),
-                    Error::DecodeError(err) => {
-                        (400, ProtoError::new(format!("DecodeError({:?})", err)))
-                    }
-                    Error::AppError(msg) => (500, ProtoError::new(msg)),
-                    Error::ContractQueryError(msg) => (500, ProtoError::new(msg)),
-                };
-                (code, prpc::codec::encode_message_to_vec(&err))
-            }
-        };
-
-        (code, data)
     }
 
     fn handle_inbound_messages(&mut self, block_number: chain::BlockNumber) -> RpcResult<()> {
@@ -641,9 +601,57 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
     }
 }
 
+pub fn dispatch_prpc_request<Platform>(
+    path: &[u8],
+    data: &[u8],
+    output_buf_len: usize,
+    phactory: &Mutex<Phactory<Platform>>,
+) -> (u16, Vec<u8>)
+where
+    Platform: pal::Platform + Serialize + DeserializeOwned,
+{
+    use prpc::server::{Error, ProtoError};
+
+    let path = match std::str::from_utf8(path) {
+        Ok(path) => path,
+        Err(e) => {
+            error!("prpc_request: invalid path: {}", e);
+            return (400, b"Invalid path".to_vec());
+        }
+    };
+    info!("Dispatching request: {}", path);
+
+    let mut server = PhactoryApiServer::new(RpcService {
+        output_buf_len,
+        phactory,
+    });
+    let (code, data) = match server.dispatch_request(path, data.to_vec()) {
+        Ok(data) => (200, data),
+        Err(err) => {
+            error!("Rpc error: {:?}", err);
+            let (code, err) = match err {
+                Error::NotFound => (404, ProtoError::new("Method Not Found")),
+                Error::DecodeError(err) => {
+                    (400, ProtoError::new(format!("DecodeError({:?})", err)))
+                }
+                Error::AppError(msg) => (500, ProtoError::new(msg)),
+                Error::ContractQueryError(msg) => (500, ProtoError::new(msg)),
+            };
+            (code, prpc::codec::encode_message_to_vec(&err))
+        }
+    };
+
+    (code, data)
+}
 pub struct RpcService<'a, Platform> {
     output_buf_len: usize,
-    phactory: &'a mut Phactory<Platform>,
+    phactory: &'a Mutex<Phactory<Platform>>,
+}
+
+impl<Platform> RpcService<'_, Platform> {
+    fn lock_phactory(&self) -> MutexGuard<'_, Phactory<Platform>> {
+        self.phactory.lock().unwrap()
+    }
 }
 
 /// A server that process all RPCs.
@@ -652,27 +660,29 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> PhactoryApi
 {
     /// Get basic information about Phactory state.
     fn get_info(&mut self, _request: ()) -> RpcResult<pb::PhactoryInfo> {
-        Ok(self.phactory.get_info())
+        Ok(self.lock_phactory().get_info())
     }
 
     /// Sync the parent chain header
     fn sync_header(&mut self, request: pb::HeadersToSync) -> RpcResult<pb::SyncedTo> {
         let headers = request.decode_headers()?;
         let authority_set_change = request.decode_authority_set_change()?;
-        self.phactory.sync_header(headers, authority_set_change)
+        self.lock_phactory()
+            .sync_header(headers, authority_set_change)
     }
 
     /// Sync the parachain header
     fn sync_para_header(&mut self, request: pb::ParaHeadersToSync) -> RpcResult<pb::SyncedTo> {
         let headers = request.decode_headers()?;
-        self.phactory.sync_para_header(headers, request.proof)
+        self.lock_phactory()
+            .sync_para_header(headers, request.proof)
     }
 
     fn sync_combined_headers(
         &mut self,
         request: pb::CombinedHeadersToSync,
     ) -> Result<pb::HeadersSyncedTo, prpc::server::Error> {
-        self.phactory.sync_combined_headers(
+        self.lock_phactory().sync_combined_headers(
             request.decode_relaychain_headers()?,
             request.decode_authority_set_change()?,
             request.decode_parachain_headers()?,
@@ -683,14 +693,14 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> PhactoryApi
     /// Dispatch blocks (Sync storage changes)"
     fn dispatch_blocks(&mut self, request: pb::Blocks) -> RpcResult<pb::SyncedTo> {
         let blocks = request.decode_blocks()?;
-        self.phactory.dispatch_block(blocks)
+        self.lock_phactory().dispatch_block(blocks)
     }
 
     fn init_runtime(
         &mut self,
         request: pb::InitRuntimeRequest,
     ) -> RpcResult<pb::InitRuntimeResponse> {
-        self.phactory.init_runtime(
+        self.lock_phactory().init_runtime(
             request.skip_ra,
             request.is_parachain,
             request.decode_genesis_info()?,
@@ -701,13 +711,13 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> PhactoryApi
     }
 
     fn get_runtime_info(&mut self, _: ()) -> RpcResult<pb::InitRuntimeResponse> {
-        self.phactory.get_runtime_info()
+        self.lock_phactory().get_runtime_info()
     }
 
     fn get_egress_messages(&mut self, _: ()) -> RpcResult<pb::GetEgressMessagesResponse> {
         // The ENCLAVE OUTPUT BUFFER is a fixed size big buffer.
         assert!(self.output_buf_len >= 1024);
-        self.phactory
+        self.lock_phactory()
             .get_egress_messages(self.output_buf_len - 1024)
             .map(pb::GetEgressMessagesResponse::new)
     }
@@ -716,15 +726,16 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> PhactoryApi
         &mut self,
         request: pb::ContractQueryRequest,
     ) -> RpcResult<pb::ContractQueryResponse> {
-        let query = self.phactory.contract_query(request)?;
-        query()
+        let do_query = self.lock_phactory().contract_query(request)?;
+        do_query()
     }
 
     fn get_worker_state(
         &mut self,
         request: pb::GetWorkerStateRequest,
     ) -> RpcResult<pb::WorkerState> {
-        let system = self.phactory.system()?;
+        let mut phactory = self.lock_phactory();
+        let system = phactory.system()?;
         let gk = system
             .gatekeeper
             .as_ref()

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -494,7 +494,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             // Encode response
             let response = contract::ContractQueryResponse {
                 nonce: head.nonce,
-                result: contract::Data(call(accid_origin.as_ref(), &data[data.len()-rest..])?),
+                result: contract::Data(call(accid_origin.as_ref(), &data[data.len() - rest..])?),
             };
             let response_data = response.encode();
 
@@ -645,6 +645,7 @@ where
 
     (code, data)
 }
+
 pub struct RpcService<'a, Platform> {
     output_buf_len: usize,
     phactory: &'a Mutex<Phactory<Platform>>,

--- a/crates/pink/src/contract.rs
+++ b/crates/pink/src/contract.rs
@@ -71,35 +71,34 @@ impl Contract {
 
         let code_hash = Hashing::hash(&code);
 
-        let (address, effects) =
-            storage.execute_with(false, move || -> Result<_, ExecError> {
-                System::set_block_number(block_number);
-                Timestamp::set_timestamp(now);
+        let (address, effects) = storage.execute_with(false, move || -> Result<_, ExecError> {
+            System::set_block_number(block_number);
+            Timestamp::set_timestamp(now);
 
-                let result = Contracts::bare_instantiate(
-                    origin.clone(),
-                    0,
-                    GAS_LIMIT,
-                    None,
-                    pallet_contracts_primitives::Code::Upload(code.into()),
-                    input_data,
-                    salt.clone(),
-                    true,
-                );
-                if let Err(err) = result.result {
-                    return Err(ExecError {
-                        source: err,
-                        message: String::from_utf8_lossy(&result.debug_message).to_string(),
-                    });
-                }
-                let preimage = contract_id_preimage(
-                    origin.as_ref(),
-                    code_hash.as_ref(),
-                    cluster_id.as_ref(),
-                    salt.as_ref(),
-                );
-                Ok(AccountId::from(hashing::blake2_256(&preimage)))
-            });
+            let result = Contracts::bare_instantiate(
+                origin.clone(),
+                0,
+                GAS_LIMIT,
+                None,
+                pallet_contracts_primitives::Code::Upload(code.into()),
+                input_data,
+                salt.clone(),
+                true,
+            );
+            if let Err(err) = result.result {
+                return Err(ExecError {
+                    source: err,
+                    message: String::from_utf8_lossy(&result.debug_message).to_string(),
+                });
+            }
+            let preimage = contract_id_preimage(
+                origin.as_ref(),
+                code_hash.as_ref(),
+                cluster_id.as_ref(),
+                salt.as_ref(),
+            );
+            Ok(AccountId::from(hashing::blake2_256(&preimage)))
+        });
         Ok((Self::from_address(address?), effects))
     }
 

--- a/crates/pink/src/contract.rs
+++ b/crates/pink/src/contract.rs
@@ -21,12 +21,12 @@ pub struct ExecError {
     pub message: String,
 }
 
-#[derive(Debug, Default, Encode, Decode)]
+#[derive(Debug, Default, Encode, Decode, Clone)]
 struct HookSelectors {
     on_block_end: Option<u32>,
 }
 
-#[derive(Debug, Encode, Decode)]
+#[derive(Debug, Encode, Decode, Clone)]
 pub struct Contract {
     pub address: AccountId,
     hooks: HookSelectors,

--- a/crates/pink/src/contract.rs
+++ b/crates/pink/src/contract.rs
@@ -71,34 +71,35 @@ impl Contract {
 
         let code_hash = Hashing::hash(&code);
 
-        let (address, effects) = storage.execute_with(false, move || -> Result<_, ExecError> {
-            System::set_block_number(block_number);
-            Timestamp::set_timestamp(now);
+        let (address, effects) =
+            storage.execute_with(false, move || -> Result<_, ExecError> {
+                System::set_block_number(block_number);
+                Timestamp::set_timestamp(now);
 
-            let result = Contracts::bare_instantiate(
-                origin.clone(),
-                0,
-                GAS_LIMIT,
-                None,
-                pallet_contracts_primitives::Code::Upload(code.into()),
-                input_data,
-                salt.clone(),
-                true,
-            );
-            if let Err(err) = result.result {
-                return Err(ExecError {
-                    source: err,
-                    message: String::from_utf8_lossy(&result.debug_message).to_string(),
-                });
-            }
-            let preimage = contract_id_preimage(
-                origin.as_ref(),
-                code_hash.as_ref(),
-                cluster_id.as_ref(),
-                salt.as_ref(),
-            );
-            Ok(AccountId::from(hashing::blake2_256(&preimage)))
-        });
+                let result = Contracts::bare_instantiate(
+                    origin.clone(),
+                    0,
+                    GAS_LIMIT,
+                    None,
+                    pallet_contracts_primitives::Code::Upload(code.into()),
+                    input_data,
+                    salt.clone(),
+                    true,
+                );
+                if let Err(err) = result.result {
+                    return Err(ExecError {
+                        source: err,
+                        message: String::from_utf8_lossy(&result.debug_message).to_string(),
+                    });
+                }
+                let preimage = contract_id_preimage(
+                    origin.as_ref(),
+                    code_hash.as_ref(),
+                    cluster_id.as_ref(),
+                    salt.as_ref(),
+                );
+                Ok(AccountId::from(hashing::blake2_256(&preimage)))
+            });
         Ok((Self::from_address(address?), effects))
     }
 
@@ -136,7 +137,7 @@ impl Contract {
     /// # Return
     /// Returns the SCALE encoded method return value.
     pub fn bare_call(
-        &mut self,
+        &self,
         storage: &mut Storage,
         origin: AccountId,
         input_data: Vec<u8>,
@@ -160,7 +161,7 @@ impl Contract {
     }
 
     fn unchecked_bare_call(
-        &mut self,
+        &self,
         storage: &mut Storage,
         origin: AccountId,
         input_data: Vec<u8>,
@@ -179,7 +180,7 @@ impl Contract {
     /// Call a contract method given it's selector
     #[allow(clippy::too_many_arguments)]
     pub fn call_with_selector<RV: Decode>(
-        &mut self,
+        &self,
         storage: &mut Storage,
         origin: AccountId,
         selector: [u8; 4],
@@ -205,7 +206,7 @@ impl Contract {
 
     /// Called by on each block end by the runtime
     pub fn on_block_end(
-        &mut self,
+        &self,
         storage: &mut Storage,
         block_number: BlockNumber,
         now: u64,

--- a/crates/pink/src/lib.rs
+++ b/crates/pink/src/lib.rs
@@ -1,7 +1,8 @@
-mod storage;
 mod contract;
 mod export_fixtures;
+
 pub mod runtime;
+pub mod storage;
 
 pub mod types;
 

--- a/crates/pink/src/storage.rs
+++ b/crates/pink/src/storage.rs
@@ -23,20 +23,18 @@ impl CommitTransaction for InMemoryBackend {
 #[derive(Default)]
 pub struct Storage<Backend> {
     backend: Backend,
-    overlay: OverlayedChanges,
+}
+
+impl<Backend> Storage<Backend> {
+    pub fn new(backend: Backend) -> Self {
+        Self { backend }
+    }
 }
 
 impl<Backend> Storage<Backend>
 where
     Backend: StorageBackend<Hashing> + CommitTransaction,
 {
-    pub fn new(backend: Backend) -> Self {
-        Self {
-            backend,
-            overlay: Default::default(),
-        }
-    }
-
     pub fn execute_with<R>(
         &mut self,
         rollback: bool,
@@ -44,9 +42,10 @@ where
     ) -> (R, ExecSideEffects) {
         let backend = self.backend.as_trie_backend().expect("No trie backend?");
 
-        self.overlay.start_transaction();
+        let mut overlay = OverlayedChanges::default();
+        overlay.start_transaction();
         let mut cache = StorageTransactionCache::default();
-        let mut ext = Ext::new(&mut self.overlay, &mut cache, backend, None);
+        let mut ext = Ext::new(&mut overlay, &mut cache, backend, None);
         let r = sp_externalities::set_and_run_with_externalities(&mut ext, move || {
             crate::runtime::System::reset_events();
             let mode = if rollback {
@@ -57,21 +56,20 @@ where
             let r = crate::runtime::using_mode(mode, f);
             (r, crate::runtime::get_side_effects())
         });
-        if rollback {
-            self.overlay.rollback_transaction()
-        } else {
-            self.overlay.commit_transaction()
+        overlay
+            .commit_transaction()
+            .expect("BUG: mis-paired transaction");
+        if !rollback {
+            self.commit_changes(overlay);
         }
-        .expect("BUG: mis-paired transaction");
         r
     }
 
-    pub fn changes_transaction(&self) -> (Hash, Backend::Transaction) {
-        let delta = self
-            .overlay
+    pub fn changes_transaction(&self, changes: OverlayedChanges) -> (Hash, Backend::Transaction) {
+        let delta = changes
             .changes()
             .map(|(k, v)| (&k[..], v.value().map(|v| &v[..])));
-        let child_delta = self.overlay.children().map(|(changes, info)| {
+        let child_delta = changes.children().map(|(changes, info)| {
             (
                 info,
                 changes.map(|(k, v)| (&k[..], v.value().map(|v| &v[..]))),
@@ -82,18 +80,9 @@ where
             .full_storage_root(delta, child_delta, sp_core::storage::StateVersion::V0)
     }
 
-    pub fn commit_transaction(&mut self, root: Hash, transaction: Backend::Transaction) {
+    pub fn commit_changes(&mut self, changes: OverlayedChanges) {
+        let (root, transaction) = self.changes_transaction(changes);
         self.backend.commit_transaction(root, transaction)
-    }
-
-    pub fn clear_changes(&mut self) {
-        self.overlay = Default::default();
-    }
-
-    pub fn commit_changes(&mut self) {
-        let (root, transaction) = self.changes_transaction();
-        self.commit_transaction(root, transaction);
-        self.clear_changes();
     }
 
     pub fn set_cluster_id(&mut self, cluster_id: &[u8]) {

--- a/crates/pink/src/storage.rs
+++ b/crates/pink/src/storage.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use sp_runtime::DispatchError;
 use sp_state_machine::{Backend as StorageBackend, Ext, OverlayedChanges, StorageTransactionCache};
 
+mod backend;
+
 pub type InMemoryBackend = sp_state_machine::InMemoryBackend<Hashing>;
 
 pub trait CommitTransaction: StorageBackend<Hashing> {
@@ -20,6 +22,10 @@ impl CommitTransaction for InMemoryBackend {
     }
 }
 
+pub trait Snapshot {
+    fn snapshot(&self) -> Self;
+}
+
 #[derive(Default)]
 pub struct Storage<Backend> {
     backend: Backend,
@@ -28,6 +34,17 @@ pub struct Storage<Backend> {
 impl<Backend> Storage<Backend> {
     pub fn new(backend: Backend) -> Self {
         Self { backend }
+    }
+}
+
+impl<Backend> Storage<Backend>
+where
+    Backend: Snapshot,
+{
+    pub fn snapshot(&self) -> Self {
+        Self {
+            backend: self.backend.snapshot(),
+        }
     }
 }
 

--- a/crates/pink/src/storage/backend.rs
+++ b/crates/pink/src/storage/backend.rs
@@ -1,0 +1,14 @@
+use phala_trie_storage::clone_trie_backend;
+
+use crate::Storage;
+
+use super::Snapshot;
+
+impl Snapshot for Storage {
+    fn snapshot(&self) -> Self {
+        Storage {
+            // TODO.kevin: This is a heavy deep copy. Replace with an optimized snapshot implementation.
+            backend: clone_trie_backend(&self.backend),
+        }
+    }
+}

--- a/standalone/pruntime/enclave/src/lib.rs
+++ b/standalone/pruntime/enclave/src/lib.rs
@@ -132,8 +132,7 @@ pub extern "C" fn ecall_prpc_request(
 ) -> sgx_status_t {
     let path = unsafe { std::slice::from_raw_parts(path, path_len) };
     let data = unsafe { std::slice::from_raw_parts(data, data_len) };
-    let mut factory = APPLICATION.lock().unwrap();
-    let (code, data) = factory.dispatch_prpc_request(path, data, output_buf_len);
+    let (code, data) = phactory::dispatch_prpc_request(path, data, output_buf_len, &APPLICATION);
     let (code, data) = if data.len() > output_buf_len {
         error!("ecall_prpc_request: output buffer too short");
         (500, vec![])

--- a/standalone/pruntime/pruntime/Cargo.lock
+++ b/standalone/pruntime/pruntime/Cargo.lock
@@ -557,15 +557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-helper"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdce191bf3fa4995ce948c8c83b4640a1745457a149e73c6db75b4ffe36aad5f"
-dependencies = [
- "semver 0.6.0",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,37 +618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.4",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,9 +631,6 @@ name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -2355,15 +2312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,15 +3537,6 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ad52817c4d343339b3bc2e26861bd21478eda0b7509acf83505727000512ac"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
@@ -3968,14 +3907,12 @@ dependencies = [
  "sp-npos-elections",
  "sp-offchain",
  "sp-runtime",
- "sp-sandbox",
  "sp-session",
  "sp-staking",
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "static_assertions",
- "substrate-wasm-builder",
 ]
 
 [[package]]
@@ -5039,15 +4976,6 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -5060,9 +4988,6 @@ name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "semver-parser"
@@ -5596,13 +5521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-maybe-compressed-blob"
-version = "4.1.0-dev"
-dependencies = [
- "zstd",
-]
-
-[[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
 dependencies = [
@@ -6031,20 +5949,6 @@ dependencies = [
  "schnorrkel",
  "sha2 0.9.9",
  "zeroize",
-]
-
-[[package]]
-name = "substrate-wasm-builder"
-version = "5.0.0-dev"
-dependencies = [
- "ansi_term",
- "build-helper",
- "cargo_metadata",
- "sp-maybe-compressed-blob",
- "tempfile",
- "toml 0.5.8",
- "walkdir",
- "wasm-gc-api",
 ]
 
 [[package]]
@@ -6783,17 +6687,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
-name = "wasm-gc-api"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c32691b6c7e6c14e7f8fd55361a9088b507aa49620fcd06c09b3a1082186b9"
-dependencies = [
- "log 0.4.14",
- "parity-wasm 0.32.0",
- "rustc-demangle",
-]
-
-[[package]]
 name = "wasm-instrument"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7037,33 +6930,4 @@ dependencies = [
  "quote 1.0.15",
  "syn 1.0.86",
  "synstructure",
-]
-
-[[package]]
-name = "zstd"
-version = "0.9.2+zstd.1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2390ea1bf6c038c39674f22d95f0564725fc06034a47129179810b2fc58caa54"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "4.1.3+zstd.1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99d81b99fb3c2c2c794e3fe56c305c63d5173a16a46b5850b07c935ffc7db79"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "1.6.2+zstd.1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daf2f248d9ea44454bfcb2516534e8b8ad2fc91bf818a1885495fc42bc8ac9f"
-dependencies = [
- "cc",
- "libc",
 ]

--- a/standalone/pruntime/pruntime/src/runtime.rs
+++ b/standalone/pruntime/pruntime/src/runtime.rs
@@ -54,8 +54,7 @@ pub fn ecall_bench_run(index: u32) {
 }
 
 pub fn ecall_prpc_request(path: &[u8], data: &[u8]) -> (u16, Vec<u8>) {
-    let mut factory = APPLICATION.lock().unwrap();
-    let (code, data) = factory.dispatch_prpc_request(path, data, usize::MAX);
+    let (code, data) = phactory::dispatch_prpc_request(path, data, usize::MAX, &APPLICATION);
     info!("pRPC status code: {}, data len: {}", code, data.len());
     (code, data)
 }


### PR DESCRIPTION
This PR add support for concurrent query for pruntime.

The previous implementation required locking the global Phactory instance to handle any pRPC request. This PR tuned the architecture to let the inner pRPC implementation to deside to whether to lock the global instance.

And further more splited the query RPC into two parts, the bottom-half could be executed after the lock has been released.

This requires the contracts and storage to be able to take snapshot on their states. **The snapshots are currently implemented with simple clone and should be optimized to in some lightweight way in the future**.
