### PR TITLE
Add the contract code size limit 

### DIFF
--- a/crates/pink/src/runtime.rs
+++ b/crates/pink/src/runtime.rs
@@ -97,8 +97,12 @@ parameter_types! {
     pub const MaxValueSize: u32 = 16_384;
     pub const DeletionQueueDepth: u32 = 1024;
     pub const DeletionWeightLimit: Weight = 500_000_000_000;
-    pub const MaxCodeSize: u32 = 2 * 1024;
-    pub DefaultSchedule: Schedule<PinkRuntime> = <Schedule<PinkRuntime>>::default();
+    pub const MaxCodeSize: u32 = 2 * 1024 * 1024;
+    pub DefaultSchedule: Schedule<PinkRuntime> = {
+        let mut schedule = <Schedule<PinkRuntime>>::default();
+        schedule.limits.code_len = MaxCodeSize::get();
+        schedule
+    };
     pub const TransactionByteFee: u64 = 0;
 }
 


### PR DESCRIPTION
limit the wasm code size to 2MB max limit 