### PR TITLE
pink-macro: generate mock helper

### DIFF
--- a/crates/pink/examples/http_client/lib.rs
+++ b/crates/pink/examples/http_client/lib.rs
@@ -38,15 +38,15 @@ mod http_client {
         use ink_lang as ink;
         #[ink::test]
         fn get_ip_works() {
-            use pink_extension::chain_extension::{HttpResponse, test::MockHttpRequest};
+            use pink_extension::chain_extension::{mock, HttpResponse};
 
-            ink_env::test::register_chain_extension(MockHttpRequest::new(|request| {
+            mock::mock_http_request(|request| {
                 if request.url == "https://ip.kvin.wang" {
                     HttpResponse::ok(b"1.1.1.1".to_vec())
                 } else {
                     HttpResponse::not_found()
                 }
-            }));
+            });
 
             let contract = HttpClient::default();
             assert_eq!(contract.get_ip().1, b"1.1.1.1");

--- a/crates/pink/pink-extension/src/chain_extension/test.rs
+++ b/crates/pink/pink-extension/src/chain_extension/test.rs
@@ -40,12 +40,16 @@ where
 
 use super::func_ids;
 
+/// Deprecated. Use pink_extension::chain_extension::mock::* instead.
 pub type MockHttpRequest<F> =
     MockExtension<F, HttpRequest, HttpResponse, { func_ids::HTTP_REQUEST }>;
-
+/// Deprecated. Use pink_extension::chain_extension::mock::* instead.
 pub type MockSign<'a, F> = MockExtension<F, SignArgs<'a>, Vec<u8>, { func_ids::SIGN }>;
+/// Deprecated. Use pink_extension::chain_extension::mock::* instead.
 pub type MockVerify<'a, F> = MockExtension<F, VerifyArgs<'a>, bool, { func_ids::VERIFY }>;
+/// Deprecated. Use pink_extension::chain_extension::mock::* instead.
 pub type MockDeriveSr25519Key<F> =
-    MockExtension<F, Vec<u8>, (Vec<u8>, Vec<u8>), { func_ids::DERIVE_SR25519_KEY }>;
+    MockExtension<F, Vec<u8>, Vec<u8>, { func_ids::DERIVE_SR25519_KEY }>;
+/// Deprecated. Use pink_extension::chain_extension::mock::* instead.
 pub type MockGetPublicKey<'a, F> =
     MockExtension<F, PublicKeyForArgs<'a>, Vec<u8>, { func_ids::GET_PUBLIC_KEY }>;


### PR DESCRIPTION
Let the attribute macro `chain_extension` also generate mock helper functions:
```rust
        pub fn mock_http_request(call: impl FnMut(HttpRequest) -> HttpResponse + 'static) {
            ink_env::test::register_chain_extension(MockExtension::<_, _, _, 4278190081>::new(
                call,
            ));
        }
        pub fn mock_sign(call: impl FnMut(SignArgs) -> Vec<u8> + 'static) {
            ink_env::test::register_chain_extension(MockExtension::<_, _, _, 4278190082>::new(
                call,
            ));
        }
        pub fn mock_verify(call: impl FnMut(VerifyArgs) -> bool + 'static) {
            ink_env::test::register_chain_extension(MockExtension::<_, _, _, 4278190083>::new(
                call,
            ));
        }
        pub fn mock_derive_sr25519_key(call: impl FnMut(Cow<[u8]>) -> Vec<u8> + 'static) {
            ink_env::test::register_chain_extension(MockExtension::<_, _, _, 4278190084>::new(
                call,
            ));
        }
        pub fn mock_get_public_key(call: impl FnMut(PublicKeyForArgs) -> Vec<u8> + 'static) {
            ink_env::test::register_chain_extension(MockExtension::<_, _, _, 4278190085>::new(
                call,
            ));
        }
```
To avoid to shoot myself in the foot.
The  type aliases `Mock*` are deprecated.