### PR TITLE
Add tests to detect block ABI changes

### DIFF
--- a/crates/phactory/api/Cargo.toml
+++ b/crates/phactory/api/Cargo.toml
@@ -9,6 +9,7 @@ resolver = "2"
 chain = { path = "../../../standalone/runtime", default-features = false, package = "phala-node-runtime" }
 sp-finality-grandpa = { package = "sp-finality-grandpa", path = "../../../substrate/primitives/finality-grandpa", default-features = false }
 parity-scale-codec   = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "1", default-features = false, features = ["derive", "serde"] }
 frame-system = { package = "frame-system", path = "../../../substrate/frame/system", default-features = false }
 sp-core = { package = "sp-core", path = "../../../substrate/primitives/core", default-features = false, features = ["full_crypto"] }
 sp-application-crypto = { package = "sp-application-crypto", path = "../../../substrate/primitives/application-crypto", default-features = false, features = ["full_crypto"] }
@@ -30,6 +31,10 @@ log = { version = "0.4.14", optional = true }
 reqwest = { version = "0.11.4", optional = true }
 
 primitive-types = { version = "0.10.1", optional = true, default-features = false }
+
+[dev-dependencies]
+insta = "1.13.0"
+serde_json = "1.0.79"
 
 [build-dependencies]
 prpc-build = { path = "../../../crates/prpc-build" }

--- a/crates/phactory/api/src/blocks.rs
+++ b/crates/phactory/api/src/blocks.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use parity_scale_codec::{Decode, Encode, FullCodec};
+use scale_info::TypeInfo;
 pub use sp_finality_grandpa::{AuthorityList, SetId};
 
 use sp_core::U256;
@@ -11,14 +12,13 @@ pub type StorageProof = Vec<Vec<u8>>;
 pub type StorageState = Vec<(Vec<u8>, Vec<u8>)>;
 
 /// The GRNADPA authority set with the id
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[derive(TypeInfo, Encode, Decode, Clone, PartialEq, Debug)]
 pub struct AuthoritySet {
     pub list: AuthorityList,
     pub id: SetId,
 }
-
 /// AuthoritySet change with the storage proof (including both the authority set and the id)
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[derive(TypeInfo, Encode, Decode, Clone, PartialEq, Debug)]
 pub struct AuthoritySetChange {
     pub authority_set: AuthoritySet,
     pub authority_proof: StorageProof,
@@ -29,7 +29,7 @@ pub struct AuthoritySetChange {
 /// The genesis block is the first block to start GRNADPA light validation tracking. It could
 /// be block 0 or a later block on the relay chain. The authority set represents the validator
 /// infomation at the selected block.
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[derive(TypeInfo, Encode, Decode, Clone, PartialEq, Debug)]
 pub struct GenesisBlockInfo {
     pub block_header: chain::Header,
     pub authority_set: AuthoritySet,
@@ -45,7 +45,7 @@ pub type HeadersToSync = Vec<HeaderToSync>;
 
 pub type RawStorageKey = Vec<u8>;
 
-#[derive(Debug, Encode, Decode, Clone)]
+#[derive(Debug, TypeInfo, Encode, Decode, Clone)]
 pub struct StorageKV<T: FullCodec + Clone>(pub RawStorageKey, pub T);
 
 impl<T: FullCodec + Clone> StorageKV<T> {
@@ -57,7 +57,7 @@ impl<T: FullCodec + Clone> StorageKV<T> {
     }
 }
 
-#[derive(Encode, Decode, Debug, Clone)]
+#[derive(TypeInfo, Encode, Decode, Debug, Clone)]
 pub struct GenericHeaderToSync<BlockNumber, Hash>
 where
     BlockNumber: Copy + Into<U256> + TryFrom<U256> + Clone,
@@ -67,7 +67,7 @@ where
     pub justification: Option<Vec<u8>>,
 }
 
-#[derive(Encode, Decode, Clone, Debug)]
+#[derive(TypeInfo, Encode, Decode, Clone, Debug)]
 pub struct GenericBlockHeaderWithChanges<BlockNumber, Hash>
 where
     BlockNumber: Copy + Into<U256> + TryFrom<U256> + FullCodec + Clone,
@@ -77,13 +77,13 @@ where
     pub storage_changes: StorageChanges,
 }
 
-#[derive(Encode, Decode, Clone, Debug)]
+#[derive(TypeInfo, Encode, Decode, Clone, Debug)]
 pub struct SyncHeaderReq {
     pub headers: Vec<HeaderToSync>,
     pub authority_set_change: Option<AuthoritySetChange>,
 }
 
-#[derive(Encode, Decode, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(TypeInfo, Encode, Decode, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ParaId(pub u32);
 
 impl ParaId {
@@ -92,13 +92,13 @@ impl ParaId {
     }
 }
 
-#[derive(Encode, Decode, Clone, Debug)]
+#[derive(TypeInfo, Encode, Decode, Clone, Debug)]
 pub struct SyncParachainHeaderReq {
     pub headers: Headers,
     pub proof: StorageProof,
 }
 
-#[derive(Encode, Decode, Clone, Debug)]
+#[derive(TypeInfo, Encode, Decode, Clone, Debug)]
 pub struct SyncCombinedHeadersReq {
     pub relaychain_headers: Vec<HeaderToSync>,
     pub authority_set_change: Option<AuthoritySetChange>,
@@ -106,7 +106,7 @@ pub struct SyncCombinedHeadersReq {
     pub proof: StorageProof,
 }
 
-#[derive(Encode, Decode, Clone, Debug)]
+#[derive(TypeInfo, Encode, Decode, Clone, Debug)]
 pub struct DispatchBlockReq {
     pub blocks: Vec<BlockHeaderWithChanges>,
 }

--- a/crates/phactory/api/tests/snapshots/test_block_abi__sync_blocks_abi_should_not_change-2.snap
+++ b/crates/phactory/api/tests/snapshots/test_block_abi__sync_blocks_abi_should_not_change-2.snap
@@ -1,0 +1,274 @@
+---
+source: crates/phactory/api/tests/test_block_abi.rs
+assertion_line: 13
+expression: "travel_types::<blocks::SyncParachainHeaderReq>()"
+---
+[
+  {
+    "id": 0,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 1
+        }
+      }
+    }
+  },
+  {
+    "id": 1,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "header",
+        "Header"
+      ],
+      "params": [
+        {
+          "name": "Number",
+          "type": 2
+        },
+        {
+          "name": "Hash",
+          "type": 3
+        }
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "parent_hash",
+              "type": 4,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "number",
+              "type": 7,
+              "typeName": "Number"
+            },
+            {
+              "name": "state_root",
+              "type": 4,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "extrinsics_root",
+              "type": 4,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "digest",
+              "type": 8,
+              "typeName": "Digest"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 2,
+    "type": {
+      "def": {
+        "primitive": "u32"
+      }
+    }
+  },
+  {
+    "id": 3,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "traits",
+        "BlakeTwo256"
+      ],
+      "def": {
+        "composite": {}
+      }
+    }
+  },
+  {
+    "id": 4,
+    "type": {
+      "path": [
+        "primitive_types",
+        "H256"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "type": 5,
+              "typeName": "[u8; 32]"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 5,
+    "type": {
+      "def": {
+        "array": {
+          "len": 32,
+          "type": 6
+        }
+      }
+    }
+  },
+  {
+    "id": 6,
+    "type": {
+      "def": {
+        "primitive": "u8"
+      }
+    }
+  },
+  {
+    "id": 7,
+    "type": {
+      "def": {
+        "compact": {
+          "type": 2
+        }
+      }
+    }
+  },
+  {
+    "id": 8,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "digest",
+        "Digest"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "logs",
+              "type": 9,
+              "typeName": "Vec<DigestItem>"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 9,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 10
+        }
+      }
+    }
+  },
+  {
+    "id": 10,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "digest",
+        "DigestItem"
+      ],
+      "def": {
+        "variant": {
+          "variants": [
+            {
+              "name": "PreRuntime",
+              "fields": [
+                {
+                  "type": 11,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 12,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 6
+            },
+            {
+              "name": "Consensus",
+              "fields": [
+                {
+                  "type": 11,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 12,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 4
+            },
+            {
+              "name": "Seal",
+              "fields": [
+                {
+                  "type": 11,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 12,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 5
+            },
+            {
+              "name": "Other",
+              "fields": [
+                {
+                  "type": 12,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 0
+            },
+            {
+              "name": "RuntimeEnvironmentUpdated",
+              "index": 8
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 11,
+    "type": {
+      "def": {
+        "array": {
+          "len": 4,
+          "type": 6
+        }
+      }
+    }
+  },
+  {
+    "id": 12,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 6
+        }
+      }
+    }
+  },
+  {
+    "id": 13,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 12
+        }
+      }
+    }
+  }
+]

--- a/crates/phactory/api/tests/snapshots/test_block_abi__sync_blocks_abi_should_not_change-3.snap
+++ b/crates/phactory/api/tests/snapshots/test_block_abi__sync_blocks_abi_should_not_change-3.snap
@@ -1,0 +1,507 @@
+---
+source: crates/phactory/api/tests/test_block_abi.rs
+assertion_line: 14
+expression: "travel_types::<blocks::SyncCombinedHeadersReq>()"
+---
+[
+  {
+    "id": 0,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 1
+        }
+      }
+    }
+  },
+  {
+    "id": 1,
+    "type": {
+      "path": [
+        "phactory_api",
+        "blocks",
+        "GenericHeaderToSync"
+      ],
+      "params": [
+        {
+          "name": "BlockNumber",
+          "type": 2
+        },
+        {
+          "name": "Hash",
+          "type": 3
+        }
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "header",
+              "type": 4,
+              "typeName": "Header<BlockNumber, Hash>"
+            },
+            {
+              "name": "justification",
+              "type": 14,
+              "typeName": "Option<Vec<u8>>"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 2,
+    "type": {
+      "def": {
+        "primitive": "u32"
+      }
+    }
+  },
+  {
+    "id": 3,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "traits",
+        "BlakeTwo256"
+      ],
+      "def": {
+        "composite": {}
+      }
+    }
+  },
+  {
+    "id": 4,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "header",
+        "Header"
+      ],
+      "params": [
+        {
+          "name": "Number",
+          "type": 2
+        },
+        {
+          "name": "Hash",
+          "type": 3
+        }
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "parent_hash",
+              "type": 5,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "number",
+              "type": 8,
+              "typeName": "Number"
+            },
+            {
+              "name": "state_root",
+              "type": 5,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "extrinsics_root",
+              "type": 5,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "digest",
+              "type": 9,
+              "typeName": "Digest"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 5,
+    "type": {
+      "path": [
+        "primitive_types",
+        "H256"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "type": 6,
+              "typeName": "[u8; 32]"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 6,
+    "type": {
+      "def": {
+        "array": {
+          "len": 32,
+          "type": 7
+        }
+      }
+    }
+  },
+  {
+    "id": 7,
+    "type": {
+      "def": {
+        "primitive": "u8"
+      }
+    }
+  },
+  {
+    "id": 8,
+    "type": {
+      "def": {
+        "compact": {
+          "type": 2
+        }
+      }
+    }
+  },
+  {
+    "id": 9,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "digest",
+        "Digest"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "logs",
+              "type": 10,
+              "typeName": "Vec<DigestItem>"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 10,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 11
+        }
+      }
+    }
+  },
+  {
+    "id": 11,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "digest",
+        "DigestItem"
+      ],
+      "def": {
+        "variant": {
+          "variants": [
+            {
+              "name": "PreRuntime",
+              "fields": [
+                {
+                  "type": 12,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 6
+            },
+            {
+              "name": "Consensus",
+              "fields": [
+                {
+                  "type": 12,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 4
+            },
+            {
+              "name": "Seal",
+              "fields": [
+                {
+                  "type": 12,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 5
+            },
+            {
+              "name": "Other",
+              "fields": [
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 0
+            },
+            {
+              "name": "RuntimeEnvironmentUpdated",
+              "index": 8
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 12,
+    "type": {
+      "def": {
+        "array": {
+          "len": 4,
+          "type": 7
+        }
+      }
+    }
+  },
+  {
+    "id": 13,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 7
+        }
+      }
+    }
+  },
+  {
+    "id": 14,
+    "type": {
+      "path": [
+        "Option"
+      ],
+      "params": [
+        {
+          "name": "T",
+          "type": 13
+        }
+      ],
+      "def": {
+        "variant": {
+          "variants": [
+            {
+              "name": "None",
+              "index": 0
+            },
+            {
+              "name": "Some",
+              "fields": [
+                {
+                  "type": 13
+                }
+              ],
+              "index": 1
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 15,
+    "type": {
+      "path": [
+        "Option"
+      ],
+      "params": [
+        {
+          "name": "T",
+          "type": 16
+        }
+      ],
+      "def": {
+        "variant": {
+          "variants": [
+            {
+              "name": "None",
+              "index": 0
+            },
+            {
+              "name": "Some",
+              "fields": [
+                {
+                  "type": 16
+                }
+              ],
+              "index": 1
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 16,
+    "type": {
+      "path": [
+        "phactory_api",
+        "blocks",
+        "AuthoritySetChange"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "authority_set",
+              "type": 17,
+              "typeName": "AuthoritySet"
+            },
+            {
+              "name": "authority_proof",
+              "type": 23,
+              "typeName": "StorageProof"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 17,
+    "type": {
+      "path": [
+        "phactory_api",
+        "blocks",
+        "AuthoritySet"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "list",
+              "type": 18,
+              "typeName": "AuthorityList"
+            },
+            {
+              "name": "id",
+              "type": 22,
+              "typeName": "SetId"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 18,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 19
+        }
+      }
+    }
+  },
+  {
+    "id": 19,
+    "type": {
+      "def": {
+        "tuple": [
+          20,
+          22
+        ]
+      }
+    }
+  },
+  {
+    "id": 20,
+    "type": {
+      "path": [
+        "sp_finality_grandpa",
+        "app",
+        "Public"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "type": 21,
+              "typeName": "ed25519::Public"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 21,
+    "type": {
+      "path": [
+        "sp_core",
+        "ed25519",
+        "Public"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "type": 6,
+              "typeName": "[u8; 32]"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 22,
+    "type": {
+      "def": {
+        "primitive": "u64"
+      }
+    }
+  },
+  {
+    "id": 23,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 13
+        }
+      }
+    }
+  },
+  {
+    "id": 24,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 4
+        }
+      }
+    }
+  }
+]

--- a/crates/phactory/api/tests/snapshots/test_block_abi__sync_blocks_abi_should_not_change-4.snap
+++ b/crates/phactory/api/tests/snapshots/test_block_abi__sync_blocks_abi_should_not_change-4.snap
@@ -1,0 +1,401 @@
+---
+source: crates/phactory/api/tests/test_block_abi.rs
+assertion_line: 15
+expression: "travel_types::<blocks::DispatchBlockReq>()"
+---
+[
+  {
+    "id": 0,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 1
+        }
+      }
+    }
+  },
+  {
+    "id": 1,
+    "type": {
+      "path": [
+        "phactory_api",
+        "blocks",
+        "GenericBlockHeaderWithChanges"
+      ],
+      "params": [
+        {
+          "name": "BlockNumber",
+          "type": 2
+        },
+        {
+          "name": "Hash",
+          "type": 3
+        }
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "block_header",
+              "type": 4,
+              "typeName": "Header<BlockNumber, Hash>"
+            },
+            {
+              "name": "storage_changes",
+              "type": 14,
+              "typeName": "StorageChanges"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 2,
+    "type": {
+      "def": {
+        "primitive": "u32"
+      }
+    }
+  },
+  {
+    "id": 3,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "traits",
+        "BlakeTwo256"
+      ],
+      "def": {
+        "composite": {}
+      }
+    }
+  },
+  {
+    "id": 4,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "header",
+        "Header"
+      ],
+      "params": [
+        {
+          "name": "Number",
+          "type": 2
+        },
+        {
+          "name": "Hash",
+          "type": 3
+        }
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "parent_hash",
+              "type": 5,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "number",
+              "type": 8,
+              "typeName": "Number"
+            },
+            {
+              "name": "state_root",
+              "type": 5,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "extrinsics_root",
+              "type": 5,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "digest",
+              "type": 9,
+              "typeName": "Digest"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 5,
+    "type": {
+      "path": [
+        "primitive_types",
+        "H256"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "type": 6,
+              "typeName": "[u8; 32]"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 6,
+    "type": {
+      "def": {
+        "array": {
+          "len": 32,
+          "type": 7
+        }
+      }
+    }
+  },
+  {
+    "id": 7,
+    "type": {
+      "def": {
+        "primitive": "u8"
+      }
+    }
+  },
+  {
+    "id": 8,
+    "type": {
+      "def": {
+        "compact": {
+          "type": 2
+        }
+      }
+    }
+  },
+  {
+    "id": 9,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "digest",
+        "Digest"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "logs",
+              "type": 10,
+              "typeName": "Vec<DigestItem>"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 10,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 11
+        }
+      }
+    }
+  },
+  {
+    "id": 11,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "digest",
+        "DigestItem"
+      ],
+      "def": {
+        "variant": {
+          "variants": [
+            {
+              "name": "PreRuntime",
+              "fields": [
+                {
+                  "type": 12,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 6
+            },
+            {
+              "name": "Consensus",
+              "fields": [
+                {
+                  "type": 12,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 4
+            },
+            {
+              "name": "Seal",
+              "fields": [
+                {
+                  "type": 12,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 5
+            },
+            {
+              "name": "Other",
+              "fields": [
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 0
+            },
+            {
+              "name": "RuntimeEnvironmentUpdated",
+              "index": 8
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 12,
+    "type": {
+      "def": {
+        "array": {
+          "len": 4,
+          "type": 7
+        }
+      }
+    }
+  },
+  {
+    "id": 13,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 7
+        }
+      }
+    }
+  },
+  {
+    "id": 14,
+    "type": {
+      "path": [
+        "phala_trie_storage",
+        "ser",
+        "StorageChanges"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "main_storage_changes",
+              "type": 15,
+              "typeName": "StorageCollection"
+            },
+            {
+              "name": "child_storage_changes",
+              "type": 18,
+              "typeName": "ChildStorageCollection"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 15,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 16
+        }
+      }
+    }
+  },
+  {
+    "id": 16,
+    "type": {
+      "def": {
+        "tuple": [
+          13,
+          17
+        ]
+      }
+    }
+  },
+  {
+    "id": 17,
+    "type": {
+      "path": [
+        "Option"
+      ],
+      "params": [
+        {
+          "name": "T",
+          "type": 13
+        }
+      ],
+      "def": {
+        "variant": {
+          "variants": [
+            {
+              "name": "None",
+              "index": 0
+            },
+            {
+              "name": "Some",
+              "fields": [
+                {
+                  "type": 13
+                }
+              ],
+              "index": 1
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 18,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 19
+        }
+      }
+    }
+  },
+  {
+    "id": 19,
+    "type": {
+      "def": {
+        "tuple": [
+          13,
+          15
+        ]
+      }
+    }
+  }
+]

--- a/crates/phactory/api/tests/snapshots/test_block_abi__sync_blocks_abi_should_not_change.snap
+++ b/crates/phactory/api/tests/snapshots/test_block_abi__sync_blocks_abi_should_not_change.snap
@@ -1,0 +1,497 @@
+---
+source: crates/phactory/api/tests/test_block_abi.rs
+assertion_line: 12
+expression: "travel_types::<blocks::SyncHeaderReq>()"
+---
+[
+  {
+    "id": 0,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 1
+        }
+      }
+    }
+  },
+  {
+    "id": 1,
+    "type": {
+      "path": [
+        "phactory_api",
+        "blocks",
+        "GenericHeaderToSync"
+      ],
+      "params": [
+        {
+          "name": "BlockNumber",
+          "type": 2
+        },
+        {
+          "name": "Hash",
+          "type": 3
+        }
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "header",
+              "type": 4,
+              "typeName": "Header<BlockNumber, Hash>"
+            },
+            {
+              "name": "justification",
+              "type": 14,
+              "typeName": "Option<Vec<u8>>"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 2,
+    "type": {
+      "def": {
+        "primitive": "u32"
+      }
+    }
+  },
+  {
+    "id": 3,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "traits",
+        "BlakeTwo256"
+      ],
+      "def": {
+        "composite": {}
+      }
+    }
+  },
+  {
+    "id": 4,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "header",
+        "Header"
+      ],
+      "params": [
+        {
+          "name": "Number",
+          "type": 2
+        },
+        {
+          "name": "Hash",
+          "type": 3
+        }
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "parent_hash",
+              "type": 5,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "number",
+              "type": 8,
+              "typeName": "Number"
+            },
+            {
+              "name": "state_root",
+              "type": 5,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "extrinsics_root",
+              "type": 5,
+              "typeName": "Hash::Output"
+            },
+            {
+              "name": "digest",
+              "type": 9,
+              "typeName": "Digest"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 5,
+    "type": {
+      "path": [
+        "primitive_types",
+        "H256"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "type": 6,
+              "typeName": "[u8; 32]"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 6,
+    "type": {
+      "def": {
+        "array": {
+          "len": 32,
+          "type": 7
+        }
+      }
+    }
+  },
+  {
+    "id": 7,
+    "type": {
+      "def": {
+        "primitive": "u8"
+      }
+    }
+  },
+  {
+    "id": 8,
+    "type": {
+      "def": {
+        "compact": {
+          "type": 2
+        }
+      }
+    }
+  },
+  {
+    "id": 9,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "digest",
+        "Digest"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "logs",
+              "type": 10,
+              "typeName": "Vec<DigestItem>"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 10,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 11
+        }
+      }
+    }
+  },
+  {
+    "id": 11,
+    "type": {
+      "path": [
+        "sp_runtime",
+        "generic",
+        "digest",
+        "DigestItem"
+      ],
+      "def": {
+        "variant": {
+          "variants": [
+            {
+              "name": "PreRuntime",
+              "fields": [
+                {
+                  "type": 12,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 6
+            },
+            {
+              "name": "Consensus",
+              "fields": [
+                {
+                  "type": 12,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 4
+            },
+            {
+              "name": "Seal",
+              "fields": [
+                {
+                  "type": 12,
+                  "typeName": "ConsensusEngineId"
+                },
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 5
+            },
+            {
+              "name": "Other",
+              "fields": [
+                {
+                  "type": 13,
+                  "typeName": "Vec<u8>"
+                }
+              ],
+              "index": 0
+            },
+            {
+              "name": "RuntimeEnvironmentUpdated",
+              "index": 8
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 12,
+    "type": {
+      "def": {
+        "array": {
+          "len": 4,
+          "type": 7
+        }
+      }
+    }
+  },
+  {
+    "id": 13,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 7
+        }
+      }
+    }
+  },
+  {
+    "id": 14,
+    "type": {
+      "path": [
+        "Option"
+      ],
+      "params": [
+        {
+          "name": "T",
+          "type": 13
+        }
+      ],
+      "def": {
+        "variant": {
+          "variants": [
+            {
+              "name": "None",
+              "index": 0
+            },
+            {
+              "name": "Some",
+              "fields": [
+                {
+                  "type": 13
+                }
+              ],
+              "index": 1
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 15,
+    "type": {
+      "path": [
+        "Option"
+      ],
+      "params": [
+        {
+          "name": "T",
+          "type": 16
+        }
+      ],
+      "def": {
+        "variant": {
+          "variants": [
+            {
+              "name": "None",
+              "index": 0
+            },
+            {
+              "name": "Some",
+              "fields": [
+                {
+                  "type": 16
+                }
+              ],
+              "index": 1
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 16,
+    "type": {
+      "path": [
+        "phactory_api",
+        "blocks",
+        "AuthoritySetChange"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "authority_set",
+              "type": 17,
+              "typeName": "AuthoritySet"
+            },
+            {
+              "name": "authority_proof",
+              "type": 23,
+              "typeName": "StorageProof"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 17,
+    "type": {
+      "path": [
+        "phactory_api",
+        "blocks",
+        "AuthoritySet"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "name": "list",
+              "type": 18,
+              "typeName": "AuthorityList"
+            },
+            {
+              "name": "id",
+              "type": 22,
+              "typeName": "SetId"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 18,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 19
+        }
+      }
+    }
+  },
+  {
+    "id": 19,
+    "type": {
+      "def": {
+        "tuple": [
+          20,
+          22
+        ]
+      }
+    }
+  },
+  {
+    "id": 20,
+    "type": {
+      "path": [
+        "sp_finality_grandpa",
+        "app",
+        "Public"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "type": 21,
+              "typeName": "ed25519::Public"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 21,
+    "type": {
+      "path": [
+        "sp_core",
+        "ed25519",
+        "Public"
+      ],
+      "def": {
+        "composite": {
+          "fields": [
+            {
+              "type": 6,
+              "typeName": "[u8; 32]"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": 22,
+    "type": {
+      "def": {
+        "primitive": "u64"
+      }
+    }
+  },
+  {
+    "id": 23,
+    "type": {
+      "def": {
+        "sequence": {
+          "type": 13
+        }
+      }
+    }
+  }
+]

--- a/crates/phactory/api/tests/test_block_abi.rs
+++ b/crates/phactory/api/tests/test_block_abi.rs
@@ -1,0 +1,16 @@
+use phactory_api::blocks;
+use scale_info::{IntoPortable, PortableRegistry, TypeInfo};
+
+fn travel_types<T: TypeInfo>() -> String {
+    let mut registry = Default::default();
+    let _ = T::type_info().into_portable(&mut registry);
+    serde_json::to_string_pretty(PortableRegistry::from(registry).types()).unwrap()
+}
+
+#[test]
+fn test_sync_blocks_abi_should_not_change() {
+    insta::assert_display_snapshot!(travel_types::<blocks::SyncHeaderReq>());
+    insta::assert_display_snapshot!(travel_types::<blocks::SyncParachainHeaderReq>());
+    insta::assert_display_snapshot!(travel_types::<blocks::SyncCombinedHeadersReq>());
+    insta::assert_display_snapshot!(travel_types::<blocks::DispatchBlockReq>());
+}

--- a/crates/phala-trie-storage/Cargo.toml
+++ b/crates/phala-trie-storage/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/Phala-Network/phala-blockchain"
 
 [dependencies]
 parity-scale-codec = { version = "2.3", default-features = false }
+scale-info = { version = "1", default-features = false, features = ["derive"] }
 sp-core = { path = "../../substrate/primitives/core", default-features = false, features = ["full_crypto"] }
 sp-trie = { path = "../../substrate/primitives/trie", default-features = false }
 sp-io   = { path = "../../substrate/primitives/io", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }

--- a/crates/phala-trie-storage/src/ser.rs
+++ b/crates/phala-trie-storage/src/ser.rs
@@ -1,17 +1,18 @@
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use parity_scale_codec::{Encode, Decode};
+use scale_info::TypeInfo;
 
 use super::{ChildStorageCollection, StorageCollection};
 
-#[derive(Serialize, Deserialize, Encode, Decode, Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, TypeInfo, Encode, Decode, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase", crate = "serde")]
 pub struct StorageChanges {
     pub main_storage_changes: StorageCollection,
     pub child_storage_changes: ChildStorageCollection,
 }
 
-#[derive(Serialize, Deserialize, Encode, Decode, Clone, Debug)]
+#[derive(Serialize, Deserialize, TypeInfo, Encode, Decode, Clone, Debug)]
 #[serde(crate = "serde")]
 pub struct StorageData {
     pub inner: Vec<(Vec<u8>, Vec<u8>)>,


### PR DESCRIPTION
This PR use TypeInfo to detect if there are any type definition changes in block header when we upgrade substrate. So that we can know if the old version of pruntime is compatible with new version of chain.