### PR TITLE
Refactor the fat contract.

### DIFF
--- a/crates/phactory/src/contracts/mod.rs
+++ b/crates/phactory/src/contracts/mod.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom as _;
 use std::fmt::Debug;
 
 use crate::system::{TransactionError, TransactionResult};
-use crate::types::{deopaque_query, OpaqueError, OpaqueQuery, OpaqueReply};
+use crate::types::{OpaqueError, OpaqueQuery, OpaqueReply};
 use anyhow::{Context, Error, Result};
 use chain::AccountId;
 use parity_scale_codec::{Decode, Encode};

--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -2,11 +2,11 @@ use crate::contracts;
 use crate::system::{TransactionError, TransactionResult};
 use anyhow::{anyhow, Result};
 use parity_scale_codec::{Decode, Encode};
-use phala_mq::{ContractClusterId, MessageOrigin};
+use phala_mq::{ContractClusterId, MessageOrigin, ContractId};
 use pink::runtime::ExecSideEffects;
 use runtime::{AccountId, BlockNumber, Hash};
 
-use super::{contract_address_to_id, NativeContractMore};
+use super::contract_address_to_id;
 
 #[derive(Debug, Encode, Decode)]
 pub enum Command {
@@ -72,6 +72,14 @@ impl Pink {
             instance,
             cluster_id,
         }
+    }
+
+    pub fn id(&self) -> ContractId {
+        contract_address_to_id(&self.instance.address)
+    }
+
+    pub fn set_on_block_end_selector(&mut self, selector: u32) {
+        self.instance.set_on_block_end_selector(selector)
     }
 }
 
@@ -161,16 +169,6 @@ impl contracts::NativeContract for Pink {
 
     fn snapshot(&self) -> Self {
         self.clone()
-    }
-}
-
-impl NativeContractMore for Pink {
-    fn id(&self) -> phala_mq::ContractId {
-        contract_address_to_id(&self.instance.address)
-    }
-
-    fn set_on_block_end_selector(&mut self, selector: u32) {
-        self.instance.set_on_block_end_selector(selector)
     }
 }
 

--- a/crates/phactory/src/contracts/support.rs
+++ b/crates/phactory/src/contracts/support.rs
@@ -2,7 +2,6 @@ use phala_crypto::ecdh::EcdhPublicKey;
 use phala_mq::traits::MessageChannel;
 use runtime::BlockNumber;
 use serde::{Deserialize, Serialize};
-use sp_core::hashing::blake2_256;
 
 use super::pink::cluster::ClusterKeeper;
 use super::*;
@@ -35,36 +34,6 @@ impl NativeContext<'_, '_> {
     }
 }
 
-pub trait Queryable {
-    fn handle_query(
-        &self,
-        origin: Option<&chain::AccountId>,
-        req: OpaqueQuery,
-        context: &mut QueryContext,
-    ) -> Result<OpaqueReply, OpaqueError>;
-}
-
-pub trait Contract {
-    fn id(&self) -> ContractId;
-    fn snapshot_for_query(&self) -> Box<dyn Queryable>;
-    fn cluster_id(&self) -> phala_mq::ContractClusterId;
-    fn process_next_message(&mut self, env: &mut ExecuteEnv) -> Option<TransactionResult>;
-    fn on_block_end(&mut self, env: &mut ExecuteEnv) -> TransactionResult;
-    fn push_message(&self, payload: Vec<u8>, topic: Vec<u8>);
-    fn push_osp_message(
-        &self,
-        payload: Vec<u8>,
-        topic: Vec<u8>,
-        remote_pubkey: Option<&EcdhPublicKey>,
-    );
-    fn set_on_block_end_selector(&mut self, selector: u32);
-}
-
-pub trait NativeContractMore {
-    fn id(&self) -> phala_mq::ContractId;
-    fn set_on_block_end_selector(&mut self, _selector: u32) {}
-}
-
 pub trait NativeContract {
     type Cmd: Decode + Debug;
     type QReq: Decode + Debug;
@@ -93,105 +62,62 @@ pub trait NativeContract {
         Self: Sized;
 }
 
-#[derive(Serialize, Deserialize, Encode, Decode)]
-pub struct NativeContractWrapper<Con> {
-    inner: Con,
-    id: sp_core::H256,
+pub(crate) struct Query {
+    contract: AnyContract,
 }
 
-impl<Con> NativeContractWrapper<Con> {
-    pub fn new(inner: Con, contract_info: &ContractInfo<chain::Hash, chain::AccountId>) -> Self {
-        let id = contract_info.contract_id(blake2_256);
-        NativeContractWrapper { inner, id }
-    }
-}
-
-impl<Con: NativeContract> NativeContract for NativeContractWrapper<Con> {
-    type Cmd = Con::Cmd;
-    type QReq = Con::QReq;
-    type QResp = Con::QResp;
-
-    fn handle_command(
-        &mut self,
-        origin: MessageOrigin,
-        cmd: Self::Cmd,
-        context: &mut NativeContext,
-    ) -> TransactionResult {
-        self.inner.handle_command(origin, cmd, context)
-    }
-
-    fn handle_query(
-        &self,
-        origin: Option<&runtime::AccountId>,
-        req: Self::QReq,
-        context: &mut QueryContext,
-    ) -> Self::QResp {
-        self.inner.handle_query(origin, req, context)
-    }
-
-    fn on_block_end(&mut self, context: &mut NativeContext) -> TransactionResult {
-        self.inner.on_block_end(context)
-    }
-
-    fn snapshot(&self) -> Self {
-        Self {
-            inner: self.inner.snapshot(),
-            id: self.id,
-        }
-    }
-}
-
-impl<Con: NativeContract> NativeContractMore for NativeContractWrapper<Con> {
-    fn id(&self) -> phala_mq::ContractId {
-        self.id
-    }
-}
-
-struct Query<Con> {
-    contract: Con,
-}
-
-impl<Con> Queryable for Query<Con>
-where
-    Con: NativeContract,
-{
-    fn handle_query(
+impl Query {
+    pub fn handle_query(
         &self,
         origin: Option<&runtime::AccountId>,
         req: OpaqueQuery,
         context: &mut QueryContext,
     ) -> Result<OpaqueReply, OpaqueError> {
-        let response = self
-            .contract
-            .handle_query(origin, deopaque_query(req)?, context);
-        Ok(response.encode())
+        self.contract.handle_query(origin, req, context)
+    }
+}
+
+pub(crate) struct RawData(Vec<u8>);
+
+impl Decode for RawData {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        let capacity = input.remaining_len()?.unwrap_or_default();
+        let mut buf = Vec::with_capacity(capacity);
+        loop {
+            match input.read_byte() {
+                Ok(byte) => buf.push(byte),
+                Err(_) => break,
+            }
+        }
+        Ok(RawData(buf))
     }
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct NativeCompatContract<Con: NativeContract> {
-    #[serde(bound(serialize = "Con: Encode", deserialize = "Con: Decode"))]
+pub struct FatContract {
     #[serde(with = "more::scale_bytes")]
-    contract: Con,
+    contract: AnyContract,
     send_mq: SignedMessageChannel,
-    cmd_rcv_mq: SecretReceiver<Con::Cmd>,
+    cmd_rcv_mq: SecretReceiver<RawData>,
     #[serde(with = "crate::secret_channel::ecdh_serde")]
     ecdh_key: KeyPair,
     cluster_id: phala_mq::ContractClusterId,
     contract_id: phala_mq::ContractId,
 }
 
-impl<Con: NativeContract> NativeCompatContract<Con> {
-    pub fn new(
-        contract: Con,
+impl FatContract {
+    pub(crate) fn new(
+        contract: impl Into<AnyContract>,
         send_mq: SignedMessageChannel,
-        cmd_rcv_mq: SecretReceiver<Con::Cmd>,
+        cmd_rcv_mq: SecretReceiver<RawData>,
         ecdh_key: KeyPair,
         cluster_id: phala_mq::ContractClusterId,
         contract_id: phala_mq::ContractId,
     ) -> Self {
-        NativeCompatContract {
-            contract,
+        FatContract {
+            contract: contract.into(),
             send_mq,
             cmd_rcv_mq,
             ecdh_key,
@@ -201,22 +127,25 @@ impl<Con: NativeContract> NativeCompatContract<Con> {
     }
 }
 
-impl<Con: NativeContract + NativeContractMore + 'static> Contract for NativeCompatContract<Con> {
-    fn id(&self) -> ContractId {
+impl FatContract {
+    pub(crate) fn id(&self) -> ContractId {
         self.contract_id
     }
 
-    fn cluster_id(&self) -> phala_mq::ContractClusterId {
+    pub(crate) fn cluster_id(&self) -> phala_mq::ContractClusterId {
         self.cluster_id
     }
 
-    fn snapshot_for_query(&self) -> Box<dyn Queryable> {
-        Box::new(Query {
+    pub(crate) fn snapshot_for_query(&self) -> Query {
+        Query {
             contract: self.contract.snapshot(),
-        })
+        }
     }
 
-    fn process_next_message(&mut self, env: &mut ExecuteEnv) -> Option<TransactionResult> {
+    pub(crate) fn process_next_message(
+        &mut self,
+        env: &mut ExecuteEnv,
+    ) -> Option<TransactionResult> {
         let secret_mq = SecretMessageChannel::new(&self.ecdh_key, &self.send_mq);
         let mut context = NativeContext {
             block: env.block,
@@ -230,7 +159,7 @@ impl<Con: NativeContract + NativeContractMore + 'static> Contract for NativeComp
             next_cmd = self.cmd_rcv_mq => match next_cmd {
                 Ok((_, cmd, origin)) => {
                     info!(target: "contract", "Contract {:?} handling command", self.id());
-                    self.contract.handle_command(origin, cmd, &mut context)
+                    self.contract.handle_command(origin, cmd.0, &mut context)
                 }
                 Err(_e) => {
                     Err(TransactionError::ChannelError)
@@ -239,7 +168,7 @@ impl<Con: NativeContract + NativeContractMore + 'static> Contract for NativeComp
         }
     }
 
-    fn on_block_end(&mut self, env: &mut ExecuteEnv) -> TransactionResult {
+    pub(crate) fn on_block_end(&mut self, env: &mut ExecuteEnv) -> TransactionResult {
         let secret_mq = SecretMessageChannel::new(&self.ecdh_key, &self.send_mq);
         let mut context = NativeContext {
             block: env.block,
@@ -251,15 +180,19 @@ impl<Con: NativeContract + NativeContractMore + 'static> Contract for NativeComp
         self.contract.on_block_end(&mut context)
     }
 
-    fn set_on_block_end_selector(&mut self, selector: u32) {
-        self.contract.set_on_block_end_selector(selector)
+    pub(crate) fn set_on_block_end_selector(&mut self, selector: u32) {
+        if let AnyContract::Pink(pink) = &mut self.contract {
+            pink.set_on_block_end_selector(selector)
+        } else {
+            log::error!("Can not set block_end_selector for native contract");
+        }
     }
 
-    fn push_message(&self, payload: Vec<u8>, topic: Vec<u8>) {
+    pub(crate) fn push_message(&self, payload: Vec<u8>, topic: Vec<u8>) {
         self.send_mq.push_data(payload, topic)
     }
 
-    fn push_osp_message(
+    pub(crate) fn push_osp_message(
         &self,
         payload: Vec<u8>,
         topic: Vec<u8>,

--- a/crates/phactory/src/contracts/support/keeper.rs
+++ b/crates/phactory/src/contracts/support/keeper.rs
@@ -1,107 +1,102 @@
-use phala_mq::ContractId;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::ops::{Deref, DerefMut};
 
-use super::{Contract, NativeCompatContract, NativeContractWrapper};
-use crate::contracts::{
-    assets::Assets, balances::Balances, btc_lottery::BtcLottery, btc_price_bot::BtcPriceBot,
-    geolocation::Geolocation, guess_number::GuessNumber, pink::Pink,
+use crate::{
+    contracts::{
+        assets::Assets, balances::Balances, btc_lottery::BtcLottery, btc_price_bot::BtcPriceBot,
+        geolocation::Geolocation, guess_number::GuessNumber, pink::Pink, FatContract,
+        NativeContext, NativeContract as _, TransactionError, TransactionResult,
+    },
+    types::{deopaque_query, OpaqueError, OpaqueQuery, OpaqueReply},
 };
+use parity_scale_codec::{Decode, Encode};
+use phala_mq::{ContractId, MessageOrigin};
 
+use super::QueryContext;
 
-type ContractMap = BTreeMap<ContractId, AnyContract>;
-type Compat<T> = NativeCompatContract<NativeContractWrapper<T>>;
+type ContractMap = BTreeMap<ContractId, FatContract>;
 
-#[derive(Serialize, Deserialize)]
-pub enum AnyContract {
-    Pink(NativeCompatContract<Pink>),
-    Balances(Compat<Balances>),
-    Assets(Compat<Assets>),
-    BtcLottery(Compat<BtcLottery>),
-    Geolocation(Compat<Geolocation>),
-    GuessNumber(Compat<GuessNumber>),
-    BtcPriceBot(Compat<BtcPriceBot>),
-}
-
-impl Deref for AnyContract {
-    type Target = dyn Contract;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            AnyContract::Pink(c) => c,
-            AnyContract::Balances(c) => c,
-            AnyContract::Assets(c) => c,
-            AnyContract::BtcLottery(c) => c,
-            AnyContract::Geolocation(c) => c,
-            AnyContract::GuessNumber(c) => c,
-            AnyContract::BtcPriceBot(c) => c,
+macro_rules! define_any_native_contract {
+    (pub enum $name:ident { $($contract:ident ($contract_type: tt),)* }) => {
+        #[derive(Encode, Decode)]
+        pub enum $name {
+            $($contract($contract_type),)*
         }
-    }
-}
 
-impl DerefMut for AnyContract {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        match self {
-            AnyContract::Pink(c) => c,
-            AnyContract::Balances(c) => c,
-            AnyContract::Assets(c) => c,
-            AnyContract::BtcLottery(c) => c,
-            AnyContract::Geolocation(c) => c,
-            AnyContract::GuessNumber(c) => c,
-            AnyContract::BtcPriceBot(c) => c,
+        impl $name {
+            pub(crate) fn handle_command(
+                &mut self,
+                origin: MessageOrigin,
+                cmd: Vec<u8>,
+                context: &mut NativeContext,
+            ) -> TransactionResult {
+                match self {
+                    $(Self::$contract(me) => {
+                        let cmd = Decode::decode(&mut &cmd[..]).or(Err(TransactionError::BadInput))?;
+                        me.handle_command(origin, cmd, context)
+                    })*
+                }
+            }
+
+            pub(crate) fn on_block_end(&mut self, context: &mut NativeContext) -> TransactionResult {
+                match self {
+                    $(Self::$contract(me) => {
+                        me.on_block_end(context)
+                    })*
+                }
+            }
+
+            pub(crate) fn snapshot(&self) -> Self {
+                match self {
+                    $($name::$contract(me) => {
+                        Self::$contract(me.snapshot())
+                    })*
+                }
+            }
+
+            pub(crate) fn handle_query(
+                &self,
+                origin: Option<&runtime::AccountId>,
+                req: OpaqueQuery,
+                context: &mut QueryContext,
+            ) -> Result<OpaqueReply, OpaqueError> {
+                match self {
+                    $($name::$contract(me) => {
+                        let response = me.handle_query(origin, deopaque_query(req)?, context);
+                        Ok(response.encode())
+                    })*
+                }
+            }
         }
-    }
+
+        $(
+            impl From<$contract_type> for $name {
+                fn from(c: $contract_type) -> Self {
+                    $name::$contract(c)
+                }
+            }
+        )*
+    };
 }
 
-impl From<NativeCompatContract<Pink>> for AnyContract {
-    fn from(c: NativeCompatContract<Pink>) -> Self {
-        AnyContract::Pink(c)
+define_any_native_contract!(
+    pub enum AnyContract {
+        Pink(Pink),
+        Balances(Balances),
+        Assets(Assets),
+        BtcLottery(BtcLottery),
+        Geolocation(Geolocation),
+        GuessNumber(GuessNumber),
+        BtcPriceBot(BtcPriceBot),
     }
-}
+);
 
-impl From<Compat<Balances>> for AnyContract {
-    fn from(c: Compat<Balances>) -> Self {
-        AnyContract::Balances(c)
-    }
-}
-
-impl From<Compat<Assets>> for AnyContract {
-    fn from(c: Compat<Assets>) -> Self {
-        AnyContract::Assets(c)
-    }
-}
-
-impl From<Compat<BtcLottery>> for AnyContract {
-    fn from(c: Compat<BtcLottery>) -> Self {
-        AnyContract::BtcLottery(c)
-    }
-}
-
-impl From<Compat<Geolocation>> for AnyContract {
-    fn from(c: Compat<Geolocation>) -> Self {
-        AnyContract::Geolocation(c)
-    }
-}
-
-impl From<Compat<GuessNumber>> for AnyContract {
-    fn from(c: Compat<GuessNumber>) -> Self {
-        AnyContract::GuessNumber(c)
-    }
-}
-
-impl From<Compat<BtcPriceBot>> for AnyContract {
-    fn from(c: Compat<BtcPriceBot>) -> Self {
-        AnyContract::BtcPriceBot(c)
-    }
-}
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct ContractsKeeper(ContractMap);
 
 impl ContractsKeeper {
-    pub fn insert(&mut self, contract: impl Into<AnyContract>) {
-        let contract = contract.into();
+    pub fn insert(&mut self, contract: FatContract) {
         self.0.insert(contract.id(), contract);
     }
 
@@ -109,16 +104,16 @@ impl ContractsKeeper {
         self.0.keys()
     }
 
-    pub fn get_mut(&mut self, id: &ContractId) -> Option<&mut AnyContract> {
+    pub fn get_mut(&mut self, id: &ContractId) -> Option<&mut FatContract> {
         self.0.get_mut(id)
     }
 
-    pub fn get(&self, id: &ContractId) -> Option<&AnyContract> {
+    pub fn get(&self, id: &ContractId) -> Option<&FatContract> {
         self.0.get(id)
     }
 
     #[cfg(test)]
-    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut AnyContract> {
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut FatContract> {
         self.0.values_mut()
     }
 

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -4,9 +4,7 @@ mod side_tasks;
 
 use crate::{
     benchmark,
-    contracts::{
-        pink::cluster::Cluster, ContractsKeeper, ExecuteEnv, NativeContract, NativeContractMore,
-    },
+    contracts::{pink::cluster::Cluster, AnyContract, ContractsKeeper, ExecuteEnv},
     pink::{cluster::ClusterKeeper, Pink},
     secret_channel::{ecdh_serde, SecretReceiver},
     types::{BlockInfo, OpaqueError, OpaqueQuery, OpaqueReply},
@@ -877,7 +875,7 @@ impl<Platform: pal::Platform> System<Platform> {
                     block.send_mq.channel(sender, cluster.key().clone().into());
 
                 match contract_info.code_index {
-                    CodeIndex::NativeCode(contract_id) => {
+                    CodeIndex::NativeCode(code_id) => {
                         use contracts::*;
                         let deployer = phala_types::messaging::AccountId(
                             contract_info.clone().deployer.into(),
@@ -885,27 +883,26 @@ impl<Platform: pal::Platform> System<Platform> {
 
                         macro_rules! match_and_install_contract {
                             ($(($id: path => $contract: expr)),*) => {{
-                                match contract_id {
+                                match code_id {
                                     $(
                                         $id => {
-                                            let contract = NativeContractWrapper::new(
-                                                $contract,
-                                                &contract_info
-                                            );
+                                            let id = contract_info.contract_id(blake2_256);
                                             install_contract(
                                                 &mut self.contracts,
-                                                contract,
+                                                id,
+                                                $contract,
                                                 contract_key.clone(),
                                                 ecdh_key,
                                                 block,
                                                 cluster_id,
-                                            )?
+                                            )?;
+                                            id
                                         }
                                     )*
                                     _ => {
                                         anyhow::bail!(
-                                            "Invalid contract id: {:?}",
-                                            contract_id
+                                            "Invalid contract code id: {:?}",
+                                            code_id
                                         );
                                     }
                                 }
@@ -1129,8 +1126,10 @@ pub fn apply_pink_side_effects(
         let ecdh_key = contract_key
             .derive_ecdh_key()
             .expect("Derive ecdh_key should not fail");
-        let id = install_contract(
+        let id = pink.id();
+        let result = install_contract(
             contracts,
+            id,
             pink,
             contract_key.clone(),
             ecdh_key.clone(),
@@ -1138,15 +1137,12 @@ pub fn apply_pink_side_effects(
             cluster_id,
         );
 
-        let id = match id {
-            Ok(id) => id,
-            Err(err) => {
-                error!("BUG: Install contract failed: {:?}", err);
-                error!(" address: {:?}", address);
-                error!(" cluster_id: {:?}", cluster_id);
-                error!(" deployer: {:?}", deployer);
-                continue;
-            }
+        if let Err(err) = result {
+            error!("BUG: Install contract failed: {:?}", err);
+            error!(" address: {:?}", address);
+            error!(" cluster_id: {:?}", cluster_id);
+            error!(" deployer: {:?}", deployer);
+            continue;
         };
 
         cluster.add_contract(id);
@@ -1193,20 +1189,15 @@ pub fn apply_pink_side_effects(
 }
 
 #[must_use]
-pub fn install_contract<Contract>(
+pub fn install_contract(
     contracts: &mut ContractsKeeper,
-    contract: Contract,
+    contract_id: phala_mq::ContractId,
+    contract: impl Into<AnyContract>,
     contract_key: sr25519::Pair,
     ecdh_key: EcdhKey,
     block: &mut BlockInfo,
     cluster_id: phala_mq::ContractClusterId,
-) -> anyhow::Result<contracts::ContractId>
-where
-    Contract: NativeContract + NativeContractMore + Send + 'static,
-    <Contract as NativeContract>::Cmd: Send,
-    contracts::AnyContract: From<contracts::NativeCompatContract<Contract>>,
-{
-    let contract_id = contract.id();
+) -> anyhow::Result<()> {
     if contracts.get(&contract_id).is_some() {
         return Err(anyhow::anyhow!("Contract already exists"));
     }
@@ -1219,7 +1210,7 @@ where
             .into(),
         ecdh_key.clone(),
     );
-    let wrapped = contracts::NativeCompatContract::new(
+    let wrapped = contracts::FatContract::new(
         contract,
         mq,
         cmd_mq,
@@ -1228,7 +1219,7 @@ where
         contract_id,
     );
     contracts.insert(wrapped);
-    Ok(contract_id)
+    Ok(())
 }
 
 #[derive(Encode, Decode, Debug)]


### PR DESCRIPTION
This PR removed the abstraction over native/wasm. The top level `trait Contract` is removed. Instead, a new type `struct FatContract` is Introduced. Removed generic type parameters on those contract types. Reduced Contract type structural layers.
This make the code much easier to be understood.

#699 need to rebase onto this work.