### PR TITLE
pruntime: Fix hanging on kick

### DIFF
--- a/standalone/pruntime/app/src/main.rs
+++ b/standalone/pruntime/app/src/main.rs
@@ -470,10 +470,6 @@ macro_rules! proxy_bin_routes {
 
 #[post("/kick")]
 fn kick() {
-    // TODO: we should improve this
-    info!("Kick API received, destroying enclave...");
-    destroy_enclave();
-
     std::process::exit(0);
 }
 


### PR DESCRIPTION
Fixes #724

The `/kick` API hangs because the `destroy_enclave` would block if there are any threads called into the enclave and we have benchmark threads always running if the worker is mining.

We simplely remove the destroying and let the OS clean it up.