### PR TITLE
Auto take checkpoints for gramine based pRuntime

### DIFF
--- a/crates/phactory/Cargo.toml
+++ b/crates/phactory/Cargo.toml
@@ -89,6 +89,8 @@ phala-async-executor = { path = '../phala-async-executor' }
 # for geo probing
 maxminddb = "0.17"
 
+glob = "0.3"
+
 [dev-dependencies]
 insta = "1.7.2"
 rmp-serde = "0.15.5"

--- a/crates/phactory/api/src/ecall_args.rs
+++ b/crates/phactory/api/src/ecall_args.rs
@@ -29,8 +29,8 @@ pub struct InitArgs {
     /// Checkpoint interval in seconds
     pub checkpoint_interval: u64,
 
-    /// Skip corrupted checkpoint, and start to sync blocks from the beginning.
-    pub skip_corrupted_checkpoint: bool,
+    /// Remove corrupted checkpoint so that pruntime can restart to continue to load others.
+    pub remove_corrupted_checkpoint: bool,
 }
 
 pub fn git_revision() -> String {

--- a/crates/phactory/api/src/ecall_args.rs
+++ b/crates/phactory/api/src/ecall_args.rs
@@ -31,6 +31,9 @@ pub struct InitArgs {
 
     /// Remove corrupted checkpoint so that pruntime can restart to continue to load others.
     pub remove_corrupted_checkpoint: bool,
+
+    /// Max number of checkpoint files kept
+    pub max_checkpoint_files: u32,
 }
 
 pub fn git_revision() -> String {

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -400,7 +400,8 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             Err(Error::PersistentRuntimeNotFound) => return Ok(None),
             other => other.context("Failed to load persistent data")?,
         };
-        let files = glob_checkpoint_files_sorted(sealing_path).context("Glob files")?;
+        let files =
+            glob_checkpoint_files_sorted(sealing_path).context("Glob checkpoint files failed")?;
         if files.is_empty() {
             return Ok(None);
         }

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -225,10 +225,10 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             self.handle_inbound_messages(block.block_header.number)?;
             self.poll_side_tasks(block.block_header.number)?;
             last_block = block.block_header.number;
-        }
 
-        if let Err(e) = self.maybe_take_checkpoint(last_block) {
-            error!("Failed to take checkpoint: {:?}", e);
+            if let Err(e) = self.maybe_take_checkpoint(last_block) {
+                error!("Failed to take checkpoint: {:?}", e);
+            }
         }
 
         Ok(pb::SyncedTo {

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -227,7 +227,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             last_block = block.block_header.number;
         }
 
-        if let Err(e) = self.maybe_take_checkpoint() {
+        if let Err(e) = self.maybe_take_checkpoint(last_block) {
             error!("Failed to take checkpoint: {:?}", e);
         }
 
@@ -236,14 +236,14 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         })
     }
 
-    fn maybe_take_checkpoint(&mut self) -> anyhow::Result<()> {
+    fn maybe_take_checkpoint(&mut self, current_block: chain::BlockNumber) -> anyhow::Result<()> {
         if !self.args.enable_checkpoint {
             return Ok(());
         }
         if self.last_checkpoint.elapsed().as_secs() < self.args.checkpoint_interval {
             return Ok(());
         }
-        self.take_checkpoint()
+        self.take_checkpoint(current_block)
     }
 
     fn init_runtime(
@@ -594,7 +594,10 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         // When delta time reaches 3600s, there are about 3600 / 12 = 300 blocks rest.
         // It need about 30 more seconds to sync up to date.
         let ready = block_time + 3600 > sys_time;
-        debug!("block_time={}, sys_time={}, ready={}", block_time, sys_time, ready);
+        debug!(
+            "block_time={}, sys_time={}, ready={}",
+            block_time, sys_time, ready
+        );
         benchmark::set_ready(ready);
 
         let storage = &state.chain_storage;

--- a/standalone/pruntime/pruntime/gramine-build/pruntime.manifest.template
+++ b/standalone/pruntime/pruntime/gramine-build/pruntime.manifest.template
@@ -12,22 +12,22 @@ insecure__use_cmdline_argv = true
 LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
 M_ARENA_MAX = "1"
 
-[fs.mount.lib]
+[[fs.mounts]]
 type = "chroot"
 path = "/lib"
 uri = "file:{{ gramine.runtimedir() }}"
 
-[fs.mount.lib2]
+[[fs.mounts]]
 type = "chroot"
 path = "/lib/x86_64-linux-gnu"
 uri = "file:/lib/x86_64-linux-gnu"
 
-[fs.mount.data]
+[[fs.mounts]]
 type = "chroot"
 path = "/protected_files"
 uri = "file:{{ seal_dir }}"
 
-[fs.mount.etc]
+[[fs.mounts]]
 type = "chroot"
 path = "/etc"
 uri = "file:/etc"

--- a/standalone/pruntime/pruntime/src/api_server.rs
+++ b/standalone/pruntime/pruntime/src/api_server.rs
@@ -1,11 +1,9 @@
 use std::str;
-use std::io::BufWriter;
 
 use rocket::data::Data;
 use rocket::http::Method;
 use rocket::http::Status;
 use rocket::response::status::Custom;
-use rocket::response::Stream;
 use rocket::{get, post, routes};
 use rocket_contrib::json;
 use rocket_contrib::json::{Json, JsonValue};
@@ -15,8 +13,6 @@ use colored::Colorize as _;
 use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-
-use os_pipe::PipeReader;
 
 use phactory_api::{actions, prpc};
 
@@ -144,29 +140,6 @@ fn prpc_proxy(method: String, data: Data) -> Custom<Vec<u8>> {
     }
 }
 
-#[get("/dump")]
-fn dump_state() -> anyhow::Result<Stream<PipeReader>> {
-    let (r, writer) = os_pipe::pipe()?;
-    std::thread::spawn(move || {
-        let writer = BufWriter::new(writer);
-        if let Err(err) = crate::runtime::ecall_dump_state(writer) {
-            error!("Failed to dump state: {:?}", err);
-        }
-    });
-    Ok(r.into())
-}
-
-#[post("/load", data = "<data>")]
-fn load_state(data: Data) -> Custom<()> {
-    match crate::runtime::ecall_load_state(data.open()) {
-        Ok(_) => Custom(Status::Ok, ()),
-        Err(err) => {
-            error!("Failed to load state: {:?}", err);
-            Custom(Status::BadRequest, ())
-        }
-    }
-}
-
 fn cors_options() -> CorsOptions {
     let allowed_origins = AllowedOrigins::all();
     let allowed_methods: AllowedMethods = vec![Method::Get, Method::Post]
@@ -227,8 +200,6 @@ pub fn rocket(allow_cors: bool, enable_kick_api: bool) -> rocket::Rocket {
 
         server = server.mount("/", routes![kick]);
     }
-
-    server = server.mount("/state", routes![dump_state, load_state]);
 
     server = server.mount("/prpc", routes![prpc_proxy]);
     print_rpc_methods("/prpc", prpc::phactory_api_server::supported_methods());

--- a/standalone/pruntime/pruntime/src/main.rs
+++ b/standalone/pruntime/pruntime/src/main.rs
@@ -45,6 +45,19 @@ struct Args {
     /// Listening port of HTTP
     #[structopt(long)]
     port: Option<String>,
+
+    /// Disable checkpoint
+    #[structopt(long)]
+    disable_checkpoint: bool,
+
+    /// Checkpoint interval in seconds, default to 5 minutes
+    #[structopt(long)]
+    #[structopt(default_value = "300")]
+    checkpoint_interval: u64,
+
+    /// Skip corrupted checkpoint, and start to sync blocks from the beginning.
+    #[structopt(long)]
+    skip_corrupted_checkpoint: bool,
 }
 
 fn main() {
@@ -89,9 +102,9 @@ fn main() {
         version: env!("CARGO_PKG_VERSION").into(),
         git_revision: git_revision(),
         geoip_city_db: args.geoip_city_db,
-        enable_checkpoint: false,
-        checkpoint_interval: 0,
-        skip_corrupted_checkpoint: false,
+        enable_checkpoint: !args.disable_checkpoint,
+        checkpoint_interval: args.checkpoint_interval,
+        skip_corrupted_checkpoint: args.skip_corrupted_checkpoint,
     };
     info!("init_args: {:#?}", init_args);
     if let Err(err) = runtime::ecall_init(init_args) {

--- a/standalone/pruntime/pruntime/src/main.rs
+++ b/standalone/pruntime/pruntime/src/main.rs
@@ -58,6 +58,11 @@ struct Args {
     /// Remove corrupted checkpoint so that pruntime can restart to continue to load others.
     #[structopt(long)]
     remove_corrupted_checkpoint: bool,
+
+    /// Max number of checkpoint files kept
+    #[structopt(long)]
+    #[structopt(default_value = "5")]
+    max_checkpoint_files: u32,
 }
 
 fn main() {
@@ -105,6 +110,7 @@ fn main() {
         enable_checkpoint: !args.disable_checkpoint,
         checkpoint_interval: args.checkpoint_interval,
         remove_corrupted_checkpoint: args.remove_corrupted_checkpoint,
+        max_checkpoint_files: args.max_checkpoint_files,
     };
     info!("init_args: {:#?}", init_args);
     if let Err(err) = runtime::ecall_init(init_args) {

--- a/standalone/pruntime/pruntime/src/main.rs
+++ b/standalone/pruntime/pruntime/src/main.rs
@@ -55,9 +55,9 @@ struct Args {
     #[structopt(default_value = "300")]
     checkpoint_interval: u64,
 
-    /// Skip corrupted checkpoint, and start to sync blocks from the beginning.
+    /// Remove corrupted checkpoint so that pruntime can restart to continue to load others.
     #[structopt(long)]
-    skip_corrupted_checkpoint: bool,
+    remove_corrupted_checkpoint: bool,
 }
 
 fn main() {
@@ -104,7 +104,7 @@ fn main() {
         geoip_city_db: args.geoip_city_db,
         enable_checkpoint: !args.disable_checkpoint,
         checkpoint_interval: args.checkpoint_interval,
-        skip_corrupted_checkpoint: args.skip_corrupted_checkpoint,
+        remove_corrupted_checkpoint: args.remove_corrupted_checkpoint,
     };
     info!("init_args: {:#?}", init_args);
     if let Err(err) = runtime::ecall_init(init_args) {

--- a/standalone/pruntime/pruntime/src/pal_gramine.rs
+++ b/standalone/pruntime/pruntime/src/pal_gramine.rs
@@ -37,45 +37,41 @@ impl Sealing for GraminePlatform {
     }
 }
 
-pub struct ProtectedFile(File);
-
-impl std::io::Read for ProtectedFile {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.0.read(buf)
-    }
-}
-
-impl std::io::Write for ProtectedFile {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.write(buf)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.0.flush()
-    }
-}
-
 impl ProtectedFileSystem for GraminePlatform {
     type IoError = std::io::Error;
 
-    type ReadFile = ProtectedFile;
+    type ReadFile = File;
 
-    type WriteFile = ProtectedFile;
+    type WriteFile = File;
 
     fn open_protected_file(
         &self,
-        _path: impl AsRef<std::path::Path>,
+        path: impl AsRef<std::path::Path>,
         _key: &[u8],
     ) -> Result<Option<Self::ReadFile>, Self::IoError> {
-        unimplemented!()
+        let todo = "Kevin: Use the key to encrypt the file";
+        // We currently use the mrenclave protected fs to store the data, so no need to encrypt twice.
+        // Gramine has a plan to support set key for individual files. We can turn back to use the key
+        // once gramine finish the feature.
+
+        match std::fs::File::open(path) {
+            Ok(file) => Ok(Some(file)),
+            Err(err) => {
+                if matches!(err.kind(), std::io::ErrorKind::NotFound) {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            }
+        }
     }
 
     fn create_protected_file(
         &self,
-        _path: impl AsRef<std::path::Path>,
+        path: impl AsRef<std::path::Path>,
         _key: &[u8],
     ) -> Result<Self::WriteFile, Self::IoError> {
-        unimplemented!()
+        std::fs::File::create(path)
     }
 }
 

--- a/standalone/pruntime/pruntime/src/runtime.rs
+++ b/standalone/pruntime/pruntime/src/runtime.rs
@@ -62,22 +62,3 @@ pub fn ecall_prpc_request(path: &[u8], data: &[u8]) -> (u16, Vec<u8>) {
     info!("pRPC status code: {}, data len: {}", code, data.len());
     (code, data)
 }
-
-pub fn ecall_dump_state<W: std::io::Write>(writer: W) -> Result<()> {
-    APPLICATION
-        .lock()
-        .unwrap()
-        .take_checkpoint_to_writer(writer)?;
-    Ok(())
-}
-
-pub fn ecall_load_state<R: std::io::Read>(reader: R) -> Result<()> {
-    let sealing_path = {
-        let app = APPLICATION.lock().unwrap();
-        app.args.sealing_path.clone()
-    };
-    let phactory =
-        Phactory::restore_from_checkpoint_reader(&GraminePlatform, &sealing_path, reader)?;
-    *APPLICATION.lock().unwrap() = phactory;
-    Ok(())
-}

--- a/standalone/pruntime/pruntime/src/runtime.rs
+++ b/standalone/pruntime/pruntime/src/runtime.rs
@@ -22,7 +22,11 @@ pub fn ecall_init(args: phactory_api::ecall_args::InitArgs) -> Result<()> {
     }
 
     if args.enable_checkpoint {
-        match Phactory::restore_from_checkpoint(&GraminePlatform, &args.sealing_path) {
+        match Phactory::restore_from_checkpoint(
+            &GraminePlatform,
+            &args.sealing_path,
+            args.skip_corrupted_checkpoint,
+        ) {
             Ok(Some(mut factory)) => {
                 info!("Loaded checkpoint");
                 factory.set_args(args.clone());

--- a/standalone/pruntime/pruntime/src/runtime.rs
+++ b/standalone/pruntime/pruntime/src/runtime.rs
@@ -41,7 +41,7 @@ pub fn ecall_init(args: phactory_api::ecall_args::InitArgs) -> Result<()> {
             }
         }
     } else {
-        info!("No checkpoint file specified.");
+        info!("Checkpoint disabled.");
     }
 
     APPLICATION.lock().unwrap().init(args);

--- a/standalone/pruntime/pruntime/src/runtime.rs
+++ b/standalone/pruntime/pruntime/src/runtime.rs
@@ -25,7 +25,7 @@ pub fn ecall_init(args: phactory_api::ecall_args::InitArgs) -> Result<()> {
         match Phactory::restore_from_checkpoint(
             &GraminePlatform,
             &args.sealing_path,
-            args.skip_corrupted_checkpoint,
+            args.remove_corrupted_checkpoint,
         ) {
             Ok(Some(mut factory)) => {
                 info!("Loaded checkpoint");


### PR DESCRIPTION
This PR implement auto taking checkpoints for gramine based pruntime.
Instead of write to tempfile then rename, we append block number to the filename to get rid of power cut off on writing file.
By default, keep latest 5 checkpoints:
```
ll data/
total 9712
drwxrwxr-x 2 kvin kvin    4096 4月  19 16:27 ./
drwxrwxr-x 6 kvin kvin    4096 4月  19 10:51 ../
-rw-rw-r-- 1 kvin kvin 1983963 4月  19 16:27 checkpoint.seal-000000570
-rw-rw-r-- 1 kvin kvin 1984253 4月  19 16:27 checkpoint.seal-000000572
-rw-rw-r-- 1 kvin kvin 1985183 4月  19 16:27 checkpoint.seal-000000574
-rw-rw-r-- 1 kvin kvin 1985268 4月  19 16:27 checkpoint.seal-000000577
-rw-rw-r-- 1 kvin kvin 1985686 4月  19 16:27 checkpoint.seal-000000579
-rw-rw-r-- 1 kvin kvin      98 4月  19 16:24 runtime-data.seal
```

@jasl  A new option `--remove-corrupted-checkpoint` added instead of the old `--skip-corrupted-checkpoint`.
This is because that loading checkpoint is not only deserializing the state but also start some background service. So skiping on error it not safe. pRuntime will try to load the latest checkpoint and panic on failure.
If `--remove-corrupted-checkpoint` is given and failed to load the latest one, the file would be removed. Just restart the pRuntime would try to load the next checkpoint.