### PR TITLE
Use clap instead of structopt

### DIFF
--- a/scripts/debug-cli/Cargo.toml
+++ b/scripts/debug-cli/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 base64 = "0.11"
 codec = { package = "parity-scale-codec", version = "3.0" }
 hex = "0.4"
-structopt = "0.3"
+clap = { version = "3", features = ["derive"] }
 anyhow = "1.0.43"
 
 sp-runtime = { path = "../../substrate/primitives/runtime" }

--- a/scripts/debug-cli/src/main.rs
+++ b/scripts/debug-cli/src/main.rs
@@ -4,40 +4,41 @@ use codec::{Encode, Decode};
 use phala_types::contract::ContractId;
 use std::convert::TryInto;
 use std::fmt::Debug;
-use structopt::StructOpt;
+use clap::{AppSettings, Parser, Subcommand};
 
 // use phala_types;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "Phala Debug Utility CLI")]
+#[derive(Debug, Parser)]
+#[clap(name = "Phala Debug Utility CLI")]
+#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 enum Cli {
     DecodeWorkerRegistrationInfo {
-        #[structopt(short)]
+        #[clap(short)]
         hex_data: String,
-        #[structopt(long)]
+        #[clap(long)]
         print_field: Option<String>,
     },
     DecodeRaQuote {
-        #[structopt(short)]
+        #[clap(short)]
         b64_data: String,
     },
     DecodeHeader {
-        #[structopt(short)]
+        #[clap(short)]
         hex_data: String,
     },
     DecodeBhwe {
-        #[structopt(short)]
+        #[clap(short)]
         b64_data: String,
     },
     DecodeEgressMessages {
         b64_data: String,
     },
     DecodeSignedMessage {
-        #[structopt(short)]
+        #[clap(short)]
         hex_data: String,
     },
     DecodeBridgeLotteryMessage {
-        #[structopt(short)]
+        #[clap(short)]
         hex_data: String,
     },
     DecodeMqPayload {
@@ -57,28 +58,28 @@ enum Cli {
         pallet_id: String,
     },
     Rpc {
-        #[structopt(long, default_value = "http://localhost:8000")]
+        #[clap(long, default_value = "http://localhost:8000")]
         url: String,
 
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         command: RpcCommand,
     },
     Pink {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         command: PinkCommand,
     },
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 enum RpcCommand {
     GetWorkerState { pubkey: String },
     GetInfo,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 enum PinkCommand {
     Query {
-        #[structopt(long, default_value = "http://localhost:8000")]
+        #[clap(long, default_value = "http://localhost:8000")]
         url: String,
         id: String,
         message: String,
@@ -91,7 +92,7 @@ enum PinkCommand {
 
 #[tokio::main]
 async fn main() {
-    let cli = Cli::from_args();
+    let cli = Cli::parse();
     match cli {
         Cli::DecodeWorkerRegistrationInfo {
             hex_data,

--- a/standalone/pherry/Cargo.toml
+++ b/standalone/pherry/Cargo.toml
@@ -18,8 +18,7 @@ base64 = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.8.4"
-structopt = { version = "0.3" }
-jsonrpsee-core = "0.7"
+clap = { version = "3", features = ["derive"] }
 
 async-trait = "0.1.49"
 system = { path = "../../substrate/frame/system", package = "frame-system" }

--- a/standalone/pruntime/pruntime/Cargo.toml
+++ b/standalone/pruntime/pruntime/Cargo.toml
@@ -8,6 +8,7 @@ panic = "abort"
 
 [dependencies]
 anyhow = "1.0"
+clap = {version = "3", features = ["derive"]}
 colored = "2"
 http_req = {version = "0.8.1", default-features = false, features = ["rust-tls"]}
 libc = "0.2"
@@ -18,7 +19,6 @@ rocket = "0.4.7"
 rocket_codegen = "0.4.5"
 rocket_cors = "0.5.2"
 serde_json = "1.0"
-structopt = "0.3.21"
 
 base64 = "0.13.0"
 

--- a/standalone/pruntime/pruntime/src/main.rs
+++ b/standalone/pruntime/pruntime/src/main.rs
@@ -7,61 +7,62 @@ mod runtime;
 
 use std::{env, thread};
 
+use clap::{AppSettings, Parser};
 use log::{error, info};
-use structopt::StructOpt;
 
 use phactory_api::ecall_args::{git_revision, InitArgs};
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "pruntime", about = "The Phala TEE worker app.")]
+#[derive(Parser, Debug)]
+#[clap(about = "The Phala TEE worker app.", version, author)]
+#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 struct Args {
     /// Number of CPU cores to be used for mining.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     cores: Option<u32>,
 
     /// Run benchmark at startup.
-    #[structopt(long)]
+    #[clap(long)]
     init_bench: bool,
 
-    #[structopt(long, default_value = "./GeoLite2-City.mmdb")]
+    #[clap(long, default_value = "./GeoLite2-City.mmdb")]
     geoip_city_db: String,
 
     /// Allow CORS for HTTP
-    #[structopt(long)]
+    #[clap(long)]
     allow_cors: bool,
 
     /// Turn on /kick API
-    #[structopt(long)]
+    #[clap(long)]
     enable_kick_api: bool,
 
     /// Log filter passed to env_logger
-    #[structopt(long, default_value = "INFO")]
+    #[clap(long, default_value = "INFO")]
     log_filter: String,
 
     /// Listening IP address of HTTP
-    #[structopt(long)]
+    #[clap(long)]
     address: Option<String>,
 
     /// Listening port of HTTP
-    #[structopt(long)]
+    #[clap(long)]
     port: Option<String>,
 
     /// Disable checkpoint
-    #[structopt(long)]
+    #[clap(long)]
     disable_checkpoint: bool,
 
     /// Checkpoint interval in seconds, default to 5 minutes
-    #[structopt(long)]
-    #[structopt(default_value = "300")]
+    #[clap(long)]
+    #[clap(default_value_t = 300)]
     checkpoint_interval: u64,
 
     /// Remove corrupted checkpoint so that pruntime can restart to continue to load others.
-    #[structopt(long)]
+    #[clap(long)]
     remove_corrupted_checkpoint: bool,
 
     /// Max number of checkpoint files kept
-    #[structopt(long)]
-    #[structopt(default_value = "5")]
+    #[clap(long)]
+    #[clap(default_value_t = 5)]
     max_checkpoint_files: u32,
 }
 
@@ -84,7 +85,7 @@ fn main() {
     }
     .into();
 
-    let args = Args::from_args();
+    let args = Args::parse();
 
     env::set_var("RUST_BACKTRACE", "1");
     env::set_var("ROCKET_ENV", "dev");

--- a/standalone/replay/Cargo.toml
+++ b/standalone/replay/Cargo.toml
@@ -14,7 +14,7 @@ sp-core = { path = "../../substrate/primitives/core", default-features = false }
 
 log = "0.4.14"
 anyhow = "1.0.43"
-structopt = "0.3"
+clap = { version = "3", features = ["derive"] }
 tokio = { version = "1.9.0", features = ["full"] }
 sqlx = { version = "0.5.7", features = ["postgres", "decimal", "chrono", "runtime-tokio-rustls"] }
 chrono = { version = "0.4.19" }

--- a/standalone/replay/src/main.rs
+++ b/standalone/replay/src/main.rs
@@ -1,53 +1,54 @@
 mod replay_gk;
 
-use structopt::StructOpt;
+use clap::{AppSettings, Parser};
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "replay")]
+#[derive(Parser, Debug)]
+#[clap(about = "The Phala TEE worker app.", version, author)]
+#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 pub struct Args {
-    #[structopt(
+    #[clap(
         default_value = "ws://localhost:9944",
         long,
         help = "Substrate rpc websocket endpoint."
     )]
     node_uri: String,
 
-    #[structopt(
+    #[clap(
         default_value = "413895",
         long,
         help = "The block number to start to replay at."
     )]
     start_at: u32,
 
-    #[structopt(
+    #[clap(
         default_value = "127.0.0.1:8080",
         long,
         help = "Bind address for local HTTP server."
     )]
     bind_addr: String,
 
-    #[structopt(
+    #[clap(
         default_value = "",
         long,
         help = "The PostgresQL database to store the events."
     )]
     persist_events_to: String,
 
-    #[structopt(
+    #[clap(
         default_value = "0",
         long,
         help = "Assume the give number of block finalized."
     )]
     assume_finalized: u32,
 
-    #[structopt(
+    #[clap(
         default_value = "100000",
         long,
         help = "The number of blocks between two checkpoints. 0 for disabled"
     )]
     checkpoint_interval: u32,
 
-    #[structopt(
+    #[clap(
         long,
         help = "The checkpoint file to restore from. Default is to use the latest checkpoint."
     )]
@@ -58,6 +59,6 @@ pub struct Args {
 async fn main() {
     env_logger::init();
 
-    let args = Args::from_args();
+    let args = Args::parse();
     replay_gk::replay(args).await.expect("Failed to run replay");
 }


### PR DESCRIPTION
Since structopt was merged into latest clap.

Bonus: The help messages now keep in it's declared order.
Before:
```
pruntime 0.1.0
The Phala TEE worker app.

USAGE:
    pruntime [FLAGS] [OPTIONS]

FLAGS:
        --allow-cors                     Allow CORS for HTTP
        --disable-checkpoint             Disable checkpoint
        --enable-kick-api                Turn on /kick API
    -h, --help                           Prints help information
        --init-bench                     Run benchmark at startup
        --remove-corrupted-checkpoint    Remove corrupted checkpoint so that pruntime can restart to continue to load
                                         others
    -V, --version                        Prints version information

OPTIONS:
        --address <address>                              Listening IP address of HTTP
        --checkpoint-interval <checkpoint-interval>
            Checkpoint interval in seconds, default to 5 minutes [default: 300]

    -c, --cores <cores>                                  Number of CPU cores to be used for mining
        --geoip-city-db <geoip-city-db>                   [default: ./GeoLite2-City.mmdb]
        --log-filter <log-filter>                        Log filter passed to env_logger [default: INFO]
        --max-checkpoint-files <max-checkpoint-files>    Max number of checkpoint files kept [default: 5]
        --port <port>                                    Listening port of HTTP
```
Now:
```
pruntime 0.1.0
The Phala TEE worker app.

USAGE:
    pruntime [OPTIONS]

OPTIONS:
    -c, --cores <CORES>
            Number of CPU cores to be used for mining

        --init-bench
            Run benchmark at startup

        --geoip-city-db <GEOIP_CITY_DB>
            [default: ./GeoLite2-City.mmdb]

        --allow-cors
            Allow CORS for HTTP

        --enable-kick-api
            Turn on /kick API

        --log-filter <LOG_FILTER>
            Log filter passed to env_logger [default: INFO]

        --address <ADDRESS>
            Listening IP address of HTTP

        --port <PORT>
            Listening port of HTTP

        --disable-checkpoint
            Disable checkpoint

        --checkpoint-interval <CHECKPOINT_INTERVAL>
            Checkpoint interval in seconds, default to 5 minutes [default: 300]

        --remove-corrupted-checkpoint
            Remove corrupted checkpoint so that pruntime can restart to continue to load others

        --max-checkpoint-files <MAX_CHECKPOINT_FILES>
            Max number of checkpoint files kept [default: 5]

    -h, --help
            Print help information

    -V, --version
            Print version information
```