### PR TITLE
replay: upsert to db

### DIFF
--- a/standalone/replay/src/replay_gk/data_persist.rs
+++ b/standalone/replay/src/replay_gk/data_persist.rs
@@ -116,11 +116,13 @@ async fn insert_records(pool: &sqlx::Pool<sqlx::Postgres>, records: &[EventRecor
         INSERT INTO worker_finance_events
             (sequence, pubkey, block, time, event, v, p, payout)
         SELECT *
-        FROM UNNEST($1, $2, $3, $4, $5, $6, $7, $8) u
+        FROM UNNEST($1, $2, $3, $4, $5, $6, $7, $8)
         ON CONFLICT (time, sequence)
         DO UPDATE
-        SET (pubkey, block, event, v, p, payout)
-            = (excluded.pubkey, excluded.block, excluded.event, excluded.v, excluded.p, excluded.payout)
+        SET (pubkey, block, event, v, p, payout) = (
+            EXCLUDED.pubkey, EXCLUDED.block, EXCLUDED.event, EXCLUDED.v, EXCLUDED.p,
+            EXCLUDED.payout
+        )
         "#,
     )
     .bind(&sequences)

--- a/standalone/replay/src/replay_gk/data_persist.rs
+++ b/standalone/replay/src/replay_gk/data_persist.rs
@@ -116,7 +116,11 @@ async fn insert_records(pool: &sqlx::Pool<sqlx::Postgres>, records: &[EventRecor
         INSERT INTO worker_finance_events
             (sequence, pubkey, block, time, event, v, p, payout)
         SELECT *
-        FROM UNNEST($1, $2, $3, $4, $5, $6, $7, $8)
+        FROM UNNEST($1, $2, $3, $4, $5, $6, $7, $8) u
+        ON CONFLICT (time, sequence)
+        DO UPDATE
+        SET (pubkey, block, event, v, p, payout)
+            = (excluded.pubkey, excluded.block, excluded.event, excluded.v, excluded.p, excluded.payout)
         "#,
     )
     .bind(&sequences)


### PR DESCRIPTION
This PR allows the replayer to override dirty data. Sometimes if we run an incorrect version of replayer, it may write bad data to the db. In such case, we can manually remove the bad data an rerun GK replay. However, without this PR, the write the db will be batched, and some rows at the edge may conflict with the data left in the db, and causing the full batch to fail to write. With this PR, the write will always override the rows in the database.