### PR TITLE
pruntime: Add option to measure time cost of each RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "bytes 1.1.0",
  "futures-core",
  "futures-sink",
- "log",
+ "log 0.4.16",
  "memchr",
  "pin-project-lite 0.2.8",
  "tokio",
@@ -54,10 +54,10 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa 1.0.1",
- "language-tags",
+ "language-tags 0.3.2",
  "local-channel",
- "log",
- "mime",
+ "log 0.4.16",
+ "mime 0.3.16",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.2.8",
  "rand 0.8.5",
@@ -85,7 +85,7 @@ dependencies = [
  "bytestring",
  "firestorm",
  "http",
- "log",
+ "log 0.4.16",
  "regex",
  "serde",
 ]
@@ -165,9 +165,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "itoa 1.0.1",
- "language-tags",
- "log",
- "mime",
+ "language-tags 0.3.2",
+ "log 0.4.16",
+ "mime 0.3.16",
  "once_cell",
  "pin-project-lite 0.2.8",
  "regex",
@@ -313,7 +313,7 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.6",
  "once_cell",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -502,7 +502,7 @@ dependencies = [
  "futures-core",
  "http-types",
  "httparse",
- "log",
+ "log 0.4.16",
  "pin-project 1.0.10",
 ]
 
@@ -515,7 +515,7 @@ dependencies = [
  "concurrent-queue",
  "futures-lite",
  "libc",
- "log",
+ "log 0.4.16",
  "once_cell",
  "parking",
  "polling",
@@ -561,7 +561,7 @@ dependencies = [
  "futures-lite",
  "gloo-timers",
  "kv-log-macro",
- "log",
+ "log 0.4.16",
  "memchr",
  "num_cpus",
  "once_cell",
@@ -720,6 +720,16 @@ name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
+
+[[package]]
+name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+dependencies = [
+ "byteorder",
+ "safemem",
+]
 
 [[package]]
 name = "base64"
@@ -1456,6 +1466,22 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f6044740a4a516b8aac14c140cdf35c1a640b1bd6b98b6224e49143b2f1566"
+dependencies = [
+ "aes-gcm 0.8.0",
+ "base64 0.13.0",
+ "hkdf 0.10.0",
+ "hmac 0.10.1",
+ "percent-encoding 2.1.0",
+ "rand 0.8.5",
+ "sha2 0.9.9",
+ "time 0.1.44",
+]
+
+[[package]]
+name = "cookie"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
@@ -1468,7 +1494,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.9.9",
  "time 0.2.27",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -1479,7 +1505,7 @@ checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
  "percent-encoding 2.1.0",
  "time 0.3.9",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -1551,7 +1577,7 @@ dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
  "gimli",
- "log",
+ "log 0.4.16",
  "regalloc",
  "smallvec",
  "target-lexicon",
@@ -1588,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
- "log",
+ "log 0.4.16",
  "smallvec",
  "target-lexicon",
 ]
@@ -1614,7 +1640,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "itertools",
- "log",
+ "log 0.4.16",
  "smallvec",
  "wasmparser",
  "wasmtime-types",
@@ -2047,6 +2073,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 
 [[package]]
+name = "devise"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74e04ba2d03c5fa0d954c061fc8c9c288badadffc272ebb87679a89846de3ed3"
+dependencies = [
+ "devise_codegen",
+ "devise_core",
+]
+
+[[package]]
+name = "devise_codegen"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "066ceb7928ca93a9bedc6d0e612a8a0424048b0ab1f75971b203d01420c055d7"
+dependencies = [
+ "devise_core",
+ "quote 0.6.13",
+]
+
+[[package]]
+name = "devise_core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf41c59b22b5e3ec0ea55c7847e5f358d340f3a8d6d53a5cf4f1564967f96487"
+dependencies = [
+ "bitflags",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,7 +2393,7 @@ checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
- "log",
+ "log 0.4.16",
  "regex",
  "termcolor",
 ]
@@ -2429,7 +2487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
 dependencies = [
  "env_logger",
- "log",
+ "log 0.4.16",
 ]
 
 [[package]]
@@ -2441,7 +2499,7 @@ dependencies = [
  "either",
  "futures 0.3.21",
  "futures-timer",
- "log",
+ "log 0.4.16",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.11.2",
@@ -2591,7 +2649,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "linregress",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "paste",
  "scale-info",
@@ -2621,7 +2679,7 @@ dependencies = [
  "itertools",
  "kvdb",
  "linked-hash-map",
- "log",
+ "log 0.4.16",
  "memory-db",
  "parity-scale-codec",
  "prettytable-rs",
@@ -2713,7 +2771,7 @@ dependencies = [
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
- "log",
+ "log 0.4.16",
  "once_cell",
  "parity-scale-codec",
  "paste",
@@ -2801,7 +2859,7 @@ name = "frame-system"
 version = "4.0.0-dev"
 dependencies = [
  "frame-support",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -3062,7 +3120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -3135,7 +3193,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "fnv",
- "log",
+ "log 0.4.16",
  "regex",
 ]
 
@@ -3204,7 +3262,7 @@ version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d6a30320f094710245150395bc763ad23128d6a1ebbad7594dc4164b62c56b"
 dependencies = [
- "log",
+ "log 0.4.16",
  "pest",
  "pest_derive",
  "quick-error 2.0.1",
@@ -3416,7 +3474,7 @@ dependencies = [
  "deadpool",
  "futures 0.3.21",
  "http-types",
- "log",
+ "log 0.4.16",
  "rustls 0.18.1",
 ]
 
@@ -3449,7 +3507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6cd45a270dff33553602fd84beb02c89460ee32db638715f10d9060389fd6a"
 dependencies = [
  "rustls 0.19.1",
- "unicase",
+ "unicase 2.6.0",
  "webpki 0.21.4",
  "webpki-roots 0.21.1",
 ]
@@ -3477,6 +3535,25 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.10.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+dependencies = [
+ "base64 0.9.3",
+ "httparse",
+ "language-tags 0.2.2",
+ "log 0.3.9",
+ "mime 0.2.6",
+ "num_cpus",
+ "time 0.1.44",
+ "traitobject",
+ "typeable",
+ "unicase 1.4.2",
+ "url 1.7.2",
+]
 
 [[package]]
 name = "hyper"
@@ -3510,8 +3587,8 @@ checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
  "ct-logs",
  "futures-util",
- "hyper",
- "log",
+ "hyper 0.14.18",
+ "log 0.4.16",
  "rustls 0.19.1",
  "rustls-native-certs 0.5.0",
  "tokio",
@@ -3526,7 +3603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.1.0",
- "hyper",
+ "hyper 0.14.18",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -3593,7 +3670,7 @@ dependencies = [
  "if-addrs",
  "ipnet",
  "libc",
- "log",
+ "log 0.4.16",
  "winapi 0.3.9",
 ]
 
@@ -3606,7 +3683,7 @@ dependencies = [
  "crossbeam-utils",
  "globset",
  "lazy_static",
- "log",
+ "log 0.4.16",
  "memchr",
  "regex",
  "same-file",
@@ -3970,7 +4047,7 @@ dependencies = [
  "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-pubsub",
- "log",
+ "log 0.4.16",
  "serde",
  "serde_json",
  "url 1.7.2",
@@ -3985,7 +4062,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-executor",
  "futures-util",
- "log",
+ "log 0.4.16",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4020,13 +4097,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
  "futures 0.3.21",
- "hyper",
+ "hyper 0.14.18",
  "jsonrpc-core",
  "jsonrpc-server-utils",
- "log",
+ "log 0.4.16",
  "net2",
  "parking_lot 0.11.2",
- "unicase",
+ "unicase 2.6.0",
 ]
 
 [[package]]
@@ -4038,7 +4115,7 @@ dependencies = [
  "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-server-utils",
- "log",
+ "log 0.4.16",
  "parity-tokio-ipc",
  "parking_lot 0.11.2",
  "tower-service",
@@ -4053,7 +4130,7 @@ dependencies = [
  "futures 0.3.21",
  "jsonrpc-core",
  "lazy_static",
- "log",
+ "log 0.4.16",
  "parking_lot 0.11.2",
  "rand 0.7.3",
  "serde",
@@ -4070,11 +4147,11 @@ dependencies = [
  "globset",
  "jsonrpc-core",
  "lazy_static",
- "log",
+ "log 0.4.16",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.9",
- "unicase",
+ "unicase 2.6.0",
 ]
 
 [[package]]
@@ -4086,7 +4163,7 @@ dependencies = [
  "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-server-utils",
- "log",
+ "log 0.4.16",
  "parity-ws",
  "parking_lot 0.11.2",
  "slab",
@@ -4168,7 +4245,7 @@ dependencies = [
  "beef",
  "futures-channel",
  "futures-util",
- "hyper",
+ "hyper 0.14.18",
  "jsonrpsee-types 0.8.0",
  "rustc-hash",
  "serde",
@@ -4191,7 +4268,7 @@ dependencies = [
  "beef",
  "futures-channel",
  "futures-util",
- "hyper",
+ "hyper 0.14.18",
  "jsonrpsee-types 0.10.1",
  "rustc-hash",
  "serde",
@@ -4287,7 +4364,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
- "log",
+ "log 0.4.16",
 ]
 
 [[package]]
@@ -4319,7 +4396,7 @@ checksum = "ca7fbdfd71cd663dceb0faf3367a99f8cf724514933e9867cec4995b6027cbc1"
 dependencies = [
  "fs-swap",
  "kvdb",
- "log",
+ "log 0.4.16",
  "num_cpus",
  "owning_ref",
  "parity-util-mem",
@@ -4328,6 +4405,12 @@ dependencies = [
  "rocksdb",
  "smallvec",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "language-tags"
@@ -4455,7 +4538,7 @@ dependencies = [
  "instant",
  "lazy_static",
  "libsecp256k1 0.7.0",
- "log",
+ "log 0.4.16",
  "multiaddr",
  "multihash 0.14.0",
  "multistream-select",
@@ -4494,7 +4577,7 @@ dependencies = [
  "async-std-resolver",
  "futures 0.3.21",
  "libp2p-core",
- "log",
+ "log 0.4.16",
  "smallvec",
  "trust-dns-resolver",
 ]
@@ -4510,7 +4593,7 @@ dependencies = [
  "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.16",
  "prost 0.9.0",
  "prost-build 0.9.0",
  "rand 0.7.3",
@@ -4532,7 +4615,7 @@ dependencies = [
  "hex_fmt",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.16",
  "prost 0.9.0",
  "prost-build 0.9.0",
  "rand 0.7.3",
@@ -4552,7 +4635,7 @@ dependencies = [
  "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.16",
  "lru 0.6.6",
  "prost 0.9.0",
  "prost-build 0.9.0",
@@ -4574,7 +4657,7 @@ dependencies = [
  "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.16",
  "prost 0.9.0",
  "prost-build 0.9.0",
  "rand 0.7.3",
@@ -4600,7 +4683,7 @@ dependencies = [
  "lazy_static",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.16",
  "rand 0.8.5",
  "smallvec",
  "socket2 0.4.4",
@@ -4631,7 +4714,7 @@ dependencies = [
  "bytes 1.1.0",
  "futures 0.3.21",
  "libp2p-core",
- "log",
+ "log 0.4.16",
  "nohash-hasher",
  "parking_lot 0.11.2",
  "rand 0.7.3",
@@ -4650,7 +4733,7 @@ dependencies = [
  "futures 0.3.21",
  "lazy_static",
  "libp2p-core",
- "log",
+ "log 0.4.16",
  "prost 0.9.0",
  "prost-build 0.9.0",
  "rand 0.8.5",
@@ -4670,7 +4753,7 @@ dependencies = [
  "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.16",
  "rand 0.7.3",
  "void",
  "wasm-timer",
@@ -4686,7 +4769,7 @@ dependencies = [
  "bytes 1.1.0",
  "futures 0.3.21",
  "libp2p-core",
- "log",
+ "log 0.4.16",
  "prost 0.9.0",
  "prost-build 0.9.0",
  "unsigned-varint 0.7.1",
@@ -4700,7 +4783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f1a458bbda880107b5b36fcb9b5a1ef0c329685da0e203ed692a8ebe64cc92c"
 dependencies = [
  "futures 0.3.21",
- "log",
+ "log 0.4.16",
  "pin-project 1.0.10",
  "rand 0.7.3",
  "salsa20",
@@ -4719,7 +4802,7 @@ dependencies = [
  "futures-timer",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.16",
  "pin-project 1.0.10",
  "prost 0.9.0",
  "prost-build 0.9.0",
@@ -4741,7 +4824,7 @@ dependencies = [
  "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.16",
  "prost 0.9.0",
  "prost-build 0.9.0",
  "rand 0.8.5",
@@ -4763,7 +4846,7 @@ dependencies = [
  "futures 0.3.21",
  "libp2p-core",
  "libp2p-swarm",
- "log",
+ "log 0.4.16",
  "lru 0.7.5",
  "rand 0.7.3",
  "smallvec",
@@ -4780,7 +4863,7 @@ dependencies = [
  "either",
  "futures 0.3.21",
  "libp2p-core",
- "log",
+ "log 0.4.16",
  "rand 0.7.3",
  "smallvec",
  "void",
@@ -4810,7 +4893,7 @@ dependencies = [
  "ipnet",
  "libc",
  "libp2p-core",
- "log",
+ "log 0.4.16",
  "socket2 0.4.4",
 ]
 
@@ -4823,7 +4906,7 @@ dependencies = [
  "async-std",
  "futures 0.3.21",
  "libp2p-core",
- "log",
+ "log 0.4.16",
 ]
 
 [[package]]
@@ -4850,7 +4933,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-rustls",
  "libp2p-core",
- "log",
+ "log 0.4.16",
  "quicksink",
  "rw-stream-sink",
  "soketto 0.7.1",
@@ -5019,6 +5102,15 @@ dependencies = [
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.16",
+]
+
+[[package]]
+name = "log"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
@@ -5125,7 +5217,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d13fa57adcc4f3aca91e511b3cdaa58ed8cbcbf97f20e342a11218c76e127f51"
 dependencies = [
- "log",
+ "log 0.4.16",
  "serde",
 ]
 
@@ -5202,6 +5294,15 @@ dependencies = [
 
 [[package]]
 name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+dependencies = [
+ "log 0.3.9",
+]
+
+[[package]]
+name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
@@ -5212,8 +5313,8 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
- "mime",
- "unicase",
+ "mime 0.3.16",
+ "unicase 2.6.0",
 ]
 
 [[package]]
@@ -5243,7 +5344,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log",
+ "log 0.4.16",
  "miow 0.2.2",
  "net2",
  "slab",
@@ -5257,7 +5358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
- "log",
+ "log 0.4.16",
  "miow 0.3.7",
  "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -5271,7 +5372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
- "log",
+ "log 0.4.16",
  "mio 0.6.23",
  "slab",
 ]
@@ -5393,7 +5494,7 @@ checksum = "56a336acba8bc87c8876f6425407dbbe6c417bf478b22015f8fb0994ef3bc0ab"
 dependencies = [
  "bytes 1.1.0",
  "futures 0.3.21",
- "log",
+ "log 0.4.16",
  "pin-project 1.0.10",
  "smallvec",
  "unsigned-varint 0.7.1",
@@ -5455,7 +5556,7 @@ checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
- "log",
+ "log 0.4.16",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -5598,7 +5699,7 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
  "memchr",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -5894,7 +5995,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
@@ -5918,7 +6019,7 @@ dependencies = [
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
@@ -5936,7 +6037,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -5950,7 +6051,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
@@ -5967,7 +6068,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
@@ -5985,7 +6086,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -6002,7 +6103,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "pallet-contracts-primitives",
  "pallet-contracts-proc-macro",
  "parity-scale-codec",
@@ -6065,7 +6166,7 @@ dependencies = [
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "rand 0.7.3",
  "scale-info",
@@ -6086,7 +6187,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -6103,7 +6204,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -6140,7 +6241,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
@@ -6188,7 +6289,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -6225,7 +6326,7 @@ version = "4.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
@@ -6319,7 +6420,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "scale-info",
  "sp-io",
@@ -6334,7 +6435,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log",
+ "log 0.4.16",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -6383,7 +6484,7 @@ dependencies = [
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -6427,7 +6528,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
@@ -6444,7 +6545,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
@@ -6536,7 +6637,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -6554,7 +6655,7 @@ dependencies = [
  "fs2",
  "hex",
  "libc",
- "log",
+ "log 0.4.16",
  "lz4",
  "memmap2 0.2.3",
  "parking_lot 0.11.2",
@@ -6602,7 +6703,7 @@ checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
 dependencies = [
  "futures 0.3.21",
  "libc",
- "log",
+ "log 0.4.16",
  "rand 0.7.3",
  "tokio",
  "winapi 0.3.9",
@@ -6665,7 +6766,7 @@ dependencies = [
  "byteorder",
  "bytes 0.4.12",
  "httparse",
- "log",
+ "log 0.4.16",
  "mio 0.6.23",
  "mio-extras",
  "rand 0.7.3",
@@ -6759,6 +6860,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
  "crypto-mac 0.11.1",
+]
+
+[[package]]
+name = "pear"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5320f212db967792b67cfe12bd469d08afd6318a249bd917d5c19bc92200ab8a"
+dependencies = [
+ "pear_codegen",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc1c836fdc3d1ef87c348b237b5b5c4dff922156fb2d968f57734f9669768ca"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+ "version_check 0.9.4",
+ "yansi",
 ]
 
 [[package]]
@@ -6871,7 +6994,7 @@ dependencies = [
  "insta",
  "itertools",
  "lazy_static",
- "log",
+ "log 0.4.16",
  "maxminddb",
  "num-bigint 0.4.3",
  "num-traits",
@@ -6925,7 +7048,7 @@ dependencies = [
  "derive_more",
  "frame-system",
  "insta",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "phala-crypto",
  "phala-mq",
@@ -6991,7 +7114,7 @@ dependencies = [
  "derive_more",
  "environmental",
  "hex",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "phala-serde-more",
  "scale-info",
@@ -7014,7 +7137,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.21",
  "hex-literal",
- "log",
+ "log 0.4.16",
  "nix",
  "node-executor",
  "node-inspect",
@@ -7093,7 +7216,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "log",
+ "log 0.4.16",
  "pallet-mq-runtime-api",
  "parity-scale-codec",
  "phala-mq",
@@ -7133,7 +7256,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex-literal",
- "log",
+ "log 0.4.16",
  "native-nostd-hasher",
  "node-primitives",
  "pallet-authority-discovery",
@@ -7217,7 +7340,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "libsecp256k1 0.3.5",
- "log",
+ "log 0.4.16",
  "pallet-balances",
  "pallet-randomness-collective-flip",
  "pallet-timestamp",
@@ -7235,6 +7358,14 @@ dependencies = [
  "untrusted",
  "webpki 0.22.0",
  "webpki 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phala-rocket-middleware"
+version = "0.1.0"
+dependencies = [
+ "log 0.4.16",
+ "rocket",
 ]
 
 [[package]]
@@ -7306,7 +7437,7 @@ dependencies = [
  "frame-system",
  "futures 0.3.21",
  "hex",
- "log",
+ "log 0.4.16",
  "pallet-balances",
  "pallet-grandpa",
  "pallet-indices",
@@ -7444,7 +7575,7 @@ dependencies = [
  "http_req",
  "impl-serde",
  "insta",
- "log",
+ "log 0.4.16",
  "once_cell",
  "pallet-balances",
  "pallet-contracts",
@@ -7553,7 +7684,7 @@ checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "log",
+ "log 0.4.16",
  "wepoll-ffi",
  "winapi 0.3.9",
 ]
@@ -7682,7 +7813,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.9",
 ]
 
 [[package]]
@@ -7692,7 +7823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
- "toml",
+ "toml 0.5.9",
 ]
 
 [[package]]
@@ -7705,7 +7836,7 @@ dependencies = [
  "proc-macro2 1.0.37",
  "quote 1.0.18",
  "syn 1.0.91",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -7716,7 +7847,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.37",
  "quote 1.0.18",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -7786,7 +7917,7 @@ dependencies = [
  "bytes 1.1.0",
  "heck 0.3.3",
  "itertools",
- "log",
+ "log 0.4.16",
  "multimap",
  "petgraph 0.5.1",
  "prost 0.8.0",
@@ -7805,7 +7936,7 @@ dependencies = [
  "heck 0.3.3",
  "itertools",
  "lazy_static",
- "log",
+ "log 0.4.16",
  "multimap",
  "petgraph 0.6.0",
  "prost 0.9.0",
@@ -7880,7 +8011,7 @@ dependencies = [
  "either",
  "heck 0.3.3",
  "itertools",
- "log",
+ "log 0.4.16",
  "multimap",
  "proc-macro2 1.0.37",
  "prost 0.8.0",
@@ -7906,7 +8037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c8ac87af529432d3a4f0e2b3bbf08af49f28f09cc73ed7e551161bdaef5f78d"
 dependencies = [
  "byteorder",
- "log",
+ "log 0.4.16",
  "parity-wasm 0.41.0",
 ]
 
@@ -8197,7 +8328,7 @@ version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
- "log",
+ "log 0.4.16",
  "rustc-hash",
  "smallvec",
 ]
@@ -8246,7 +8377,7 @@ version = "0.10.0-dev"
 dependencies = [
  "env_logger",
  "jsonrpsee 0.10.1",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "serde",
  "serde_json",
@@ -8277,7 +8408,7 @@ dependencies = [
  "clap 3.1.10",
  "env_logger",
  "hex",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "phactory",
  "phactory-api",
@@ -8307,13 +8438,13 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper",
+ "hyper 0.14.18",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
- "log",
- "mime",
+ "log 0.4.16",
+ "mime 0.3.16",
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.2.8",
@@ -8409,6 +8540,59 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rocket"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a7ab1dfdc75bb8bd2be381f37796b1b300c45a3c9145b34d86715e8dd90bf28"
+dependencies = [
+ "atty",
+ "base64 0.13.0",
+ "log 0.4.16",
+ "memchr",
+ "num_cpus",
+ "pear",
+ "rocket_codegen",
+ "rocket_http",
+ "state",
+ "time 0.1.44",
+ "toml 0.4.10",
+ "version_check 0.9.4",
+ "yansi",
+]
+
+[[package]]
+name = "rocket_codegen"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729e687d6d2cf434d174da84fb948f7fef4fac22d20ce94ca61c28b72dbcf9f"
+dependencies = [
+ "devise",
+ "glob",
+ "indexmap",
+ "quote 0.6.13",
+ "rocket_http",
+ "version_check 0.9.4",
+ "yansi",
+]
+
+[[package]]
+name = "rocket_http"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6131e6e6d38a9817f4a494ff5da95971451c2eb56a53915579fc9c80f6ef0117"
+dependencies = [
+ "cookie 0.11.4",
+ "hyper 0.10.16",
+ "indexmap",
+ "pear",
+ "percent-encoding 1.0.1",
+ "smallvec",
+ "state",
+ "time 0.1.44",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -8550,7 +8734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
  "base64 0.12.3",
- "log",
+ "log 0.4.16",
  "ring 0.16.20",
  "sct 0.6.1",
  "webpki 0.21.4",
@@ -8563,7 +8747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.0",
- "log",
+ "log 0.4.16",
  "ring 0.16.20",
  "sct 0.6.1",
  "webpki 0.21.4",
@@ -8575,7 +8759,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
- "log",
+ "log 0.4.16",
  "ring 0.16.20",
  "sct 0.7.0",
  "webpki 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8647,6 +8831,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "salsa20"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8668,7 +8858,7 @@ dependencies = [
 name = "sc-allocator"
 version = "4.1.0-dev"
 dependencies = [
- "log",
+ "log 0.4.16",
  "sp-core",
  "sp-wasm-interface",
  "thiserror",
@@ -8683,7 +8873,7 @@ dependencies = [
  "futures-timer",
  "ip_network",
  "libp2p",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "prost 0.9.0",
  "prost-build 0.9.0",
@@ -8706,7 +8896,7 @@ version = "0.10.0-dev"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "sc-block-builder",
  "sc-client-api",
@@ -8773,7 +8963,7 @@ dependencies = [
  "futures 0.3.21",
  "hex",
  "libp2p",
- "log",
+ "log 0.4.16",
  "names",
  "parity-scale-codec",
  "rand 0.7.3",
@@ -8807,7 +8997,7 @@ dependencies = [
  "fnv",
  "futures 0.3.21",
  "hash-db",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "sc-executor",
@@ -8836,7 +9026,7 @@ dependencies = [
  "kvdb-memorydb",
  "kvdb-rocksdb",
  "linked-hash-map",
- "log",
+ "log 0.4.16",
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.0",
@@ -8859,7 +9049,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "libp2p",
- "log",
+ "log 0.4.16",
  "parking_lot 0.12.0",
  "sc-client-api",
  "sc-utils",
@@ -8881,7 +9071,7 @@ dependencies = [
  "async-trait",
  "fork-tree",
  "futures 0.3.21",
- "log",
+ "log 0.4.16",
  "merlin",
  "num-bigint 0.2.6",
  "num-rational 0.2.4",
@@ -8958,7 +9148,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.21",
  "futures-timer",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
@@ -9031,7 +9221,7 @@ dependencies = [
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
 dependencies = [
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "sc-allocator",
  "sc-executor-common",
@@ -9048,7 +9238,7 @@ version = "0.10.0-dev"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parity-wasm 0.42.2",
  "sc-allocator",
@@ -9071,7 +9261,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "hex",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "rand 0.8.5",
@@ -9108,7 +9298,7 @@ dependencies = [
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-pubsub",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "sc-client-api",
  "sc-finality-grandpa",
@@ -9128,7 +9318,7 @@ dependencies = [
  "ansi_term",
  "futures 0.3.21",
  "futures-timer",
- "log",
+ "log 0.4.16",
  "parity-util-mem",
  "sc-client-api",
  "sc-network",
@@ -9170,7 +9360,7 @@ dependencies = [
  "libp2p",
  "linked-hash-map",
  "linked_hash_set",
- "log",
+ "log 0.4.16",
  "lru 0.7.5",
  "parity-scale-codec",
  "parking_lot 0.12.0",
@@ -9207,7 +9397,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "libp2p",
- "log",
+ "log 0.4.16",
  "lru 0.7.5",
  "sc-network",
  "sp-runtime",
@@ -9224,7 +9414,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "hex",
- "hyper",
+ "hyper 0.14.18",
  "hyper-rustls",
  "num_cpus",
  "once_cell",
@@ -9248,7 +9438,7 @@ version = "4.0.0-dev"
 dependencies = [
  "futures 0.3.21",
  "libp2p",
- "log",
+ "log 0.4.16",
  "sc-utils",
  "serde_json",
  "wasm-timer",
@@ -9258,7 +9448,7 @@ dependencies = [
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
 dependencies = [
- "log",
+ "log 0.4.16",
  "substrate-prometheus-endpoint",
 ]
 
@@ -9270,7 +9460,7 @@ dependencies = [
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "sc-block-builder",
@@ -9301,7 +9491,7 @@ dependencies = [
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-pubsub",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "sc-chain-spec",
@@ -9327,7 +9517,7 @@ dependencies = [
  "jsonrpc-ipc-server",
  "jsonrpc-pubsub",
  "jsonrpc-ws-server",
- "log",
+ "log 0.4.16",
  "serde_json",
  "substrate-prometheus-endpoint",
  "tokio",
@@ -9345,7 +9535,7 @@ dependencies = [
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.12.0",
@@ -9405,7 +9595,7 @@ dependencies = [
  "futures 0.3.21",
  "hex",
  "hex-literal",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "sc-block-builder",
@@ -9437,7 +9627,7 @@ dependencies = [
 name = "sc-state-db"
 version = "0.10.0-dev"
 dependencies = [
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parity-util-mem",
  "parity-util-mem-derive",
@@ -9472,7 +9662,7 @@ version = "6.0.0-dev"
 dependencies = [
  "futures 0.3.21",
  "libc",
- "log",
+ "log 0.4.16",
  "rand 0.7.3",
  "rand_pcg 0.2.1",
  "regex",
@@ -9491,7 +9681,7 @@ dependencies = [
  "chrono",
  "futures 0.3.21",
  "libp2p",
- "log",
+ "log 0.4.16",
  "parking_lot 0.12.0",
  "pin-project 1.0.10",
  "rand 0.7.3",
@@ -9510,7 +9700,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "libc",
- "log",
+ "log 0.4.16",
  "once_cell",
  "parking_lot 0.12.0",
  "regex",
@@ -9548,7 +9738,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "linked-hash-map",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.12.0",
@@ -9572,7 +9762,7 @@ name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
 dependencies = [
  "futures 0.3.21",
- "log",
+ "log 0.4.16",
  "serde",
  "sp-blockchain",
  "sp-runtime",
@@ -9586,7 +9776,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "lazy_static",
- "log",
+ "log 0.4.16",
  "parking_lot 0.12.0",
  "prometheus",
 ]
@@ -10164,7 +10354,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures 0.3.21",
  "httparse",
- "log",
+ "log 0.4.16",
  "rand 0.7.3",
  "sha-1 0.9.8",
 ]
@@ -10180,7 +10370,7 @@ dependencies = [
  "flate2",
  "futures 0.3.21",
  "httparse",
- "log",
+ "log 0.4.16",
  "rand 0.8.5",
  "sha-1 0.9.8",
 ]
@@ -10190,7 +10380,7 @@ name = "sp-api"
 version = "4.0.0-dev"
 dependencies = [
  "hash-db",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "sp-api-proc-macro",
  "sp-core",
@@ -10277,7 +10467,7 @@ name = "sp-blockchain"
 version = "4.0.0-dev"
 dependencies = [
  "futures 0.3.21",
- "log",
+ "log 0.4.16",
  "lru 0.7.5",
  "parity-scale-codec",
  "parking_lot 0.12.0",
@@ -10296,7 +10486,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.21",
  "futures-timer",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "sp-core",
  "sp-inherents",
@@ -10387,7 +10577,7 @@ dependencies = [
  "impl-serde",
  "lazy_static",
  "libsecp256k1 0.7.0",
- "log",
+ "log 0.4.16",
  "merlin",
  "num-traits",
  "parity-scale-codec",
@@ -10470,7 +10660,7 @@ name = "sp-finality-grandpa"
 version = "4.0.0-dev"
 dependencies = [
  "finality-grandpa",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -10502,7 +10692,7 @@ dependencies = [
  "futures 0.3.21",
  "hash-db",
  "libsecp256k1 0.7.0",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "secp256k1 0.21.3",
@@ -10600,7 +10790,7 @@ dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "parity-util-mem",
  "paste",
@@ -10645,7 +10835,7 @@ dependencies = [
 name = "sp-sandbox"
 version = "0.10.0-dev"
 dependencies = [
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "sp-core",
  "sp-io",
@@ -10690,7 +10880,7 @@ name = "sp-state-machine"
 version = "0.12.0"
 dependencies = [
  "hash-db",
- "log",
+ "log 0.4.16",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.0",
@@ -10726,7 +10916,7 @@ dependencies = [
 name = "sp-tasks"
 version = "4.0.0-dev"
 dependencies = [
- "log",
+ "log 0.4.16",
  "sp-core",
  "sp-externalities",
  "sp-io",
@@ -10740,7 +10930,7 @@ version = "4.0.0-dev"
 dependencies = [
  "async-trait",
  "futures-timer",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "sp-api",
  "sp-inherents",
@@ -10773,7 +10963,7 @@ name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
 dependencies = [
  "async-trait",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -10829,7 +11019,7 @@ name = "sp-wasm-interface"
 version = "6.0.0"
 dependencies = [
  "impl-trait-for-tuples",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "sp-std",
  "wasmi",
@@ -10898,7 +11088,7 @@ dependencies = [
  "indexmap",
  "itoa 1.0.1",
  "libc",
- "log",
+ "log 0.4.16",
  "md-5",
  "memchr",
  "num-bigint 0.3.3",
@@ -10981,8 +11171,14 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
- "version_check",
+ "version_check 0.9.4",
 ]
+
+[[package]]
+name = "state"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3015a7d0a5fd5105c91c3710d42f9ccf0abfb287d62206484dcc67f9569a6483"
 
 [[package]]
 name = "static_assertions"
@@ -11161,7 +11357,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
@@ -11178,8 +11374,8 @@ name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
 dependencies = [
  "futures-util",
- "hyper",
- "log",
+ "hyper 0.14.18",
+ "log 0.4.16",
  "prometheus",
  "thiserror",
  "tokio",
@@ -11219,7 +11415,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
- "log",
+ "log 0.4.16",
  "memory-db",
  "pallet-babe",
  "pallet-timestamp",
@@ -11280,7 +11476,7 @@ dependencies = [
  "sp-maybe-compressed-blob",
  "strum",
  "tempfile",
- "toml",
+ "toml 0.5.9",
  "walkdir",
  "wasm-gc-api",
 ]
@@ -11303,7 +11499,7 @@ dependencies = [
  "futures 0.3.21",
  "hex",
  "jsonrpsee 0.8.0",
- "log",
+ "log 0.4.16",
  "num-traits",
  "parity-scale-codec",
  "scale-info",
@@ -11363,7 +11559,7 @@ dependencies = [
  "getrandom 0.2.6",
  "http-client",
  "http-types",
- "log",
+ "log 0.4.16",
  "mime_guess",
  "once_cell",
  "pin-project-lite 0.2.8",
@@ -11592,7 +11788,7 @@ dependencies = [
  "standback",
  "stdweb",
  "time-macros 0.1.1",
- "version_check",
+ "version_check 0.9.4",
  "winapi 0.3.9",
 ]
 
@@ -11765,7 +11961,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "log",
+ "log 0.4.16",
  "pin-project-lite 0.2.8",
  "tokio",
 ]
@@ -11783,6 +11979,15 @@ dependencies = [
  "pin-project-lite 0.2.8",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -11827,7 +12032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
+ "log 0.4.16",
  "pin-project-lite 0.2.8",
  "tracing-attributes",
  "tracing-core",
@@ -11871,7 +12076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
- "log",
+ "log 0.4.16",
  "tracing-core",
 ]
 
@@ -11909,6 +12114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "traitobject"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+
+[[package]]
 name = "trie-db"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11916,7 +12127,7 @@ checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
 dependencies = [
  "hash-db",
  "hashbrown 0.12.0",
- "log",
+ "log 0.4.16",
  "rustc-hex",
  "smallvec",
 ]
@@ -11946,7 +12157,7 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "log",
+ "log 0.4.16",
  "rand 0.8.5",
  "smallvec",
  "thiserror",
@@ -11964,7 +12175,7 @@ dependencies = [
  "futures-util",
  "ipconfig",
  "lazy_static",
- "log",
+ "log 0.4.16",
  "lru-cache",
  "parking_lot 0.11.2",
  "resolv-conf",
@@ -11985,7 +12196,7 @@ version = "0.10.0-dev"
 dependencies = [
  "clap 3.1.10",
  "jsonrpsee 0.10.1",
- "log",
+ "log 0.4.16",
  "parity-scale-codec",
  "remote-externalities",
  "sc-chain-spec",
@@ -12016,7 +12227,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
- "toml",
+ "toml 0.5.9",
 ]
 
 [[package]]
@@ -12036,6 +12247,12 @@ dependencies = [
  "rand 0.8.5",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
@@ -12067,7 +12284,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
 dependencies = [
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -12122,11 +12339,20 @@ dependencies = [
 
 [[package]]
 name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+dependencies = [
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -12272,7 +12498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
 dependencies = [
  "ctor",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -12286,6 +12512,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -12331,7 +12563,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log",
+ "log 0.4.16",
  "try-lock",
 ]
 
@@ -12371,7 +12603,7 @@ checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log",
+ "log 0.4.16",
  "proc-macro2 1.0.37",
  "quote 1.0.18",
  "syn 1.0.91",
@@ -12425,7 +12657,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c32691b6c7e6c14e7f8fd55361a9088b507aa49620fcd06c09b3a1082186b9"
 dependencies = [
- "log",
+ "log 0.4.16",
  "parity-wasm 0.32.0",
  "rustc-demangle",
 ]
@@ -12508,7 +12740,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "log",
+ "log 0.4.16",
  "object 0.27.1",
  "once_cell",
  "paste",
@@ -12537,11 +12769,11 @@ dependencies = [
  "bincode",
  "directories-next",
  "file-per-thread-logger",
- "log",
+ "log 0.4.16",
  "rustix",
  "serde",
  "sha2 0.9.9",
- "toml",
+ "toml 0.5.9",
  "winapi 0.3.9",
  "zstd",
 ]
@@ -12559,7 +12791,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-wasm",
  "gimli",
- "log",
+ "log 0.4.16",
  "more-asserts",
  "object 0.27.1",
  "target-lexicon",
@@ -12578,7 +12810,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "indexmap",
- "log",
+ "log 0.4.16",
  "more-asserts",
  "object 0.27.1",
  "serde",
@@ -12600,7 +12832,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpp_demangle",
  "gimli",
- "log",
+ "log 0.4.16",
  "object 0.27.1",
  "region",
  "rustc-demangle",
@@ -12637,7 +12869,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "indexmap",
  "libc",
- "log",
+ "log 0.4.16",
  "mach",
  "memoffset",
  "more-asserts",
@@ -12944,12 +13176,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
 dependencies = [
  "futures 0.3.21",
- "log",
+ "log 0.4.16",
  "nohash-hasher",
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "static_assertions",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
 	"crates/phala-types",
 	"crates/phala-async-executor",
 	"crates/phala-allocator",
+	"crates/phala-rocket-middleware",
 	"crates/pink",
 	"crates/pink/pink-extension",
 	"crates/phaxt",

--- a/crates/phala-rocket-middleware/Cargo.toml
+++ b/crates/phala-rocket-middleware/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "phala-rocket-middleware"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rocket = "0.4.7"
+log = "0.4.16"

--- a/crates/phala-rocket-middleware/src/lib.rs
+++ b/crates/phala-rocket-middleware/src/lib.rs
@@ -1,0 +1,3 @@
+pub use time_meter::TimeMeter;
+
+mod time_meter;

--- a/crates/phala-rocket-middleware/src/time_meter.rs
+++ b/crates/phala-rocket-middleware/src/time_meter.rs
@@ -1,0 +1,29 @@
+use std::time::Instant;
+
+use rocket::fairing::{Fairing, Info, Kind};
+use rocket::{Data, Request, Response};
+
+/// Measuring the time it takes to process a request.
+pub struct TimeMeter;
+
+struct StartTime(Instant);
+
+impl Fairing for TimeMeter {
+    fn info(&self) -> Info {
+        Info {
+            name: "Time meter",
+            kind: Kind::Request | Kind::Response,
+        }
+    }
+
+    fn on_request(&self, request: &mut Request, _data: &Data) {
+        let _t = request.local_cache(move || StartTime(Instant::now()));
+    }
+
+    fn on_response(&self, request: &Request, response: &mut Response) {
+        let start_time = request.local_cache(|| StartTime(Instant::now()));
+        let cost = start_time.0.elapsed().as_micros().to_string();
+        log::info!(target: "measuring", "{} {} cost {} microseconds", request.method(), request.uri(), cost);
+        response.set_raw_header("X-Cost-Time", cost);
+    }
+}

--- a/standalone/pruntime/Cargo.toml
+++ b/standalone/pruntime/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 
 base64 = "0.13.0"
 
-env_logger = {version = "0.9.0", default-features = false, features = ["termcolor"]}
+env_logger = {version = "0.9.0", features = ["termcolor"]}
 lazy_static = {version = "1.4.0", default-features = false}
 parity-scale-codec = {version = "3.0", default-features = false}
 rocket_contrib = {version = "0.4.5", features = ["json"]}
@@ -33,3 +33,4 @@ phactory = {path = "../../crates/phactory"}
 phactory-api = {path = "../../crates/phactory/api"}
 phactory-pal = {path = "../../crates/phactory/pal"}
 phala-allocator = {path = "../../crates/phala-allocator"}
+phala-rocket-middleware = {path = "../../crates/phala-rocket-middleware"}


### PR DESCRIPTION
New command line argument:
```
        --measure-rpc-time
            Measuring the time it takes to process each RPC call
```
This would mount the meter middleware onto rocket server. That would print log like:
```
[2022-04-25T07:20:31Z INFO  measuring] GET /get_info cost 886 micro seconds
```
And a header in the HTTP response:
```
HTTP/1.1 200 OK
X-Cost-Time: 886
```