### PR TITLE
Kusama headers cache server for pherry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +1731,15 @@ dependencies = [
  "smallvec",
  "wasmparser 0.83.0",
  "wasmtime-types",
+]
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
 ]
 
 [[package]]
@@ -3438,6 +3453,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers-cache"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap 3.1.15",
+ "env_logger",
+ "log",
+ "parity-scale-codec",
+ "pherry",
+ "rocket",
+ "rusty-leveldb",
+ "tokio",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,6 +4092,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "integer-encoding"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
 
 [[package]]
 name = "integer-sqrt"
@@ -9200,6 +9237,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
+name = "rusty-leveldb"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19365c4619fa0892aef573e6ee1b569b1161ac1ac3da765f550a17645192615e"
+dependencies = [
+ "crc 1.8.1",
+ "errno",
+ "fs2",
+ "integer-encoding",
+ "rand 0.7.3",
+ "snap",
+]
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11460,7 +11511,7 @@ dependencies = [
  "byteorder",
  "bytes 1.1.0",
  "chrono",
- "crc",
+ "crc 2.1.0",
  "crossbeam-queue",
  "dirs 4.0.0",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,12 +1043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,15 +1725,6 @@ dependencies = [
  "smallvec",
  "wasmparser 0.83.0",
  "wasmtime-types",
-]
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
 ]
 
 [[package]]
@@ -3464,7 +3449,7 @@ dependencies = [
  "parity-scale-codec",
  "pherry",
  "rocket",
- "rusty-leveldb",
+ "rocksdb",
  "tokio",
 ]
 
@@ -4092,12 +4077,6 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
-
-[[package]]
-name = "integer-encoding"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
 
 [[package]]
 name = "integer-sqrt"
@@ -5098,6 +5077,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "tikv-jemalloc-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -9237,20 +9217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
-name = "rusty-leveldb"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19365c4619fa0892aef573e6ee1b569b1161ac1ac3da765f550a17645192615e"
-dependencies = [
- "crc 1.8.1",
- "errno",
- "fs2",
- "integer-encoding",
- "rand 0.7.3",
- "snap",
-]
-
-[[package]]
 name = "rw-stream-sink"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11511,7 +11477,7 @@ dependencies = [
  "byteorder",
  "bytes 1.1.0",
  "chrono",
- "crc 2.1.0",
+ "crc",
  "crossbeam-queue",
  "dirs 4.0.0",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
 	"standalone/runtime",
 	"standalone/pherry",
 	"standalone/replay",
+	"standalone/headers-cache",
 	"crates/phala-trie-storage",
 	"crates/phala-mq",
 	"crates/phala-crypto",

--- a/crates/phactory/api/Cargo.toml
+++ b/crates/phactory/api/Cargo.toml
@@ -28,7 +28,7 @@ sp-runtime = { path = "../../../substrate/primitives/runtime", default-features 
 # for pruntime_client
 async-trait = { version = "0.1.51", optional = true }
 anyhow = { version = "1.0.43", optional = true }
-log = { version = "0.4.14", optional = true }
+log = { version = "0.4.14" }
 reqwest = { version = "0.11.4", optional = true }
 
 primitive-types = { version = "0.11.0", optional = true, default-features = false }
@@ -58,7 +58,6 @@ sgx = []
 pruntime-client = [
     "async-trait",
     "anyhow",
-    "log",
     "reqwest",
 ]
 

--- a/crates/phactory/api/src/blocks.rs
+++ b/crates/phactory/api/src/blocks.rs
@@ -42,6 +42,7 @@ pub type BlockHeaderWithChanges =
     GenericBlockHeaderWithChanges<chain::BlockNumber, RuntimeHasher>;
 pub type Headers = Vec<Header<chain::BlockNumber, RuntimeHasher>>;
 pub type HeadersToSync = Vec<HeaderToSync>;
+pub type BlockHeader = chain::Header;
 
 pub type RawStorageKey = Vec<u8>;
 

--- a/crates/phactory/api/src/ecall_args.rs
+++ b/crates/phactory/api/src/ecall_args.rs
@@ -1,6 +1,5 @@
-
-use parity_scale_codec::{Encode, Decode};
 use alloc::string::{String, ToString};
+use parity_scale_codec::{Decode, Encode};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Encode, Decode, Default, Clone)]
@@ -34,6 +33,10 @@ pub struct InitArgs {
 
     /// Max number of checkpoint files kept
     pub max_checkpoint_files: u32,
+
+    /// Run the database garbage collection at given interval in blocks
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub gc_interval: chain::BlockNumber,
 }
 
 pub fn git_revision() -> String {

--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -201,6 +201,11 @@ where
 
         let changes = &block.storage_changes;
 
+        log::debug!(
+            "calc root ({}, {})",
+            changes.main_storage_changes.len(),
+            changes.child_storage_changes.len()
+        );
         let (state_root, transaction) = storage.calc_root_if_changes(
             &changes.main_storage_changes,
             &changes.child_storage_changes,
@@ -214,7 +219,9 @@ where
             });
         }
 
+        log::debug!("apply changes");
         storage.apply_changes(state_root, transaction);
+        log::debug!("applied");
 
         self.block_number_next += 1;
         state_roots.pop_front();

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -57,6 +57,7 @@ pub use side_task::SideTaskManager;
 pub use storage::{Storage, StorageExt};
 pub use system::gk;
 pub use types::BlockInfo;
+pub use chain::BlockNumber;
 
 pub mod benchmark;
 
@@ -229,6 +230,9 @@ pub struct Phactory<Platform> {
     #[serde(skip)]
     #[serde(default = "Instant::now")]
     last_checkpoint: Instant,
+    #[serde(skip)]
+    #[serde(default)]
+    last_storage_purge_at: chain::BlockNumber,
 }
 
 impl<Platform: pal::Platform> Phactory<Platform> {
@@ -245,6 +249,7 @@ impl<Platform: pal::Platform> Phactory<Platform> {
             system: None,
             side_task_man: Default::default(),
             last_checkpoint: Instant::now(),
+            last_storage_purge_at: 0,
         }
     }
 

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -222,10 +222,20 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
                 .storage_synchronizer
                 .feed_block(&block, &mut state.chain_storage)
                 .map_err(from_display)?;
-
+            info!("State synced");
             state.purge_mq();
             self.handle_inbound_messages(block.block_header.number)?;
             self.poll_side_tasks(block.block_header.number)?;
+            if block
+                .block_header
+                .number
+                .saturating_sub(self.last_storage_purge_at)
+                >= self.args.gc_interval
+            {
+                self.last_storage_purge_at = block.block_header.number;
+                info!("Purging database");
+                self.runtime_state()?.chain_storage.purge();
+            }
             last_block = block.block_header.number;
 
             if let Err(e) = self.maybe_take_checkpoint(last_block) {

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -166,6 +166,12 @@ where
     pub fn apply_changes(&mut self, root: H::Out, transaction: MemoryDB<H>) {
         let mut storage = core::mem::take(self).0.into_storage();
         storage.consolidate(transaction);
+        let _ = core::mem::replace(&mut self.0, TrieBackend::new(storage, root));
+    }
+
+    pub fn purge(&mut self) {
+        let root = *self.0.root();
+        let mut storage = core::mem::take(self).0.into_storage();
         storage.purge();
         let _ = core::mem::replace(&mut self.0, TrieBackend::new(storage, root));
     }

--- a/crates/phaxt/src/lib.rs
+++ b/crates/phaxt/src/lib.rs
@@ -22,6 +22,7 @@ pub type RelaychainApi = kusama::RuntimeApi<DefaultConfig, ExtrinsicParams>;
 pub type ExtrinsicParams = DefaultExtrinsicParams<DefaultConfig>;
 pub type ExtrinsicParamsBuilder = DefaultExtrinsicParamsBuilder<DefaultConfig>;
 pub use subxt::DefaultConfig as Config;
+pub type RpcClient = subxt::Client<Config>;
 
 pub use subxt;
 pub use subxt::sp_core::storage::{StorageData, StorageKey};

--- a/standalone/headers-cache/Cargo.toml
+++ b/standalone/headers-cache/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "headers-cache"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+pherry = { path = "../pherry" }
+
+log = "0.4.14"
+anyhow = "1.0.43"
+clap = { version = "3", features = ["derive"] }
+tokio = { version = "1.9.0", features = ["full"] }
+chrono = { version = "0.4.19" }
+env_logger = "0.9.0"
+rocket = "0.4.7"
+rocket_codegen = "0.4.5"
+scale = { package = 'parity-scale-codec', version = "3.0" }
+rusty-leveldb = "0.3"
+

--- a/standalone/headers-cache/Cargo.toml
+++ b/standalone/headers-cache/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "headers-cache"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pherry = { path = "../pherry" }

--- a/standalone/headers-cache/Cargo.toml
+++ b/standalone/headers-cache/Cargo.toml
@@ -12,8 +12,7 @@ clap = { version = "3", features = ["derive"] }
 tokio = { version = "1.9.0", features = ["full"] }
 chrono = { version = "0.4.19" }
 env_logger = "0.9.0"
-rocket = "0.4.7"
-rocket_codegen = "0.4.5"
+rocket = "0.5.0-rc.1"
 scale = { package = 'parity-scale-codec', version = "3.0" }
 rusty-leveldb = "0.3"
 

--- a/standalone/headers-cache/Cargo.toml
+++ b/standalone/headers-cache/Cargo.toml
@@ -14,5 +14,5 @@ chrono = { version = "0.4.19" }
 env_logger = "0.9.0"
 rocket = "0.5.0-rc.1"
 scale = { package = 'parity-scale-codec', version = "3.0" }
-rusty-leveldb = "0.3"
+rocksdb = "0.18"
 

--- a/standalone/headers-cache/README.md
+++ b/standalone/headers-cache/README.md
@@ -1,0 +1,46 @@
+# Basic Usage
+## 1. Grab genesis and headers from the chain
+```
+headers-cache grab genesis --from-block <number> genesis.bin
+headers-cache grab headers --from-block <number> headers.bin
+```
+## 2. Import the grabbed file into the database.
+```
+# Kill the ` headers-cache serve` if it is running.
+killall headers-cache
+headers-cache import genesis genesis.bin
+headers-cache import headers headers.bin
+```
+## 3. Start the cache server
+```
+ROCKET_PORT=8002 headers-cache serve
+```
+## 4. Start pherry and tell it to consider the cache server.
+```
+pherry ... --headers-cache-uri http://localhost:8002
+```
+
+# Cache parachain headers and storage changes.
+Parachain headers and storage changes can also be cached in `headers-cache` (by #773)
+## Grab and import parachain headers
+```
+headers-cache grab para-headers --from-block <number> para-headers.bin
+headers-cache import para-headers para-headers.bin
+```
+## Grab and import storage changes
+```
+headers-cache grab storage-changes--from-block <number> storage-changes.bin
+headers-cache import storage-changes storage-changes.bin
+```
+
+# Trouble shooting
+## IO error: While open a file for appending: cache.db/001021.sst: Too many open files
+While importing data to the database, the rocksdb would open many files. We can increase the fd limitation by:
+```
+ulimit -Sn unlimited
+```
+or
+```
+sudo ulimit -n unlimited
+```
+and then try to import again.

--- a/standalone/headers-cache/src/db.rs
+++ b/standalone/headers-cache/src/db.rs
@@ -6,7 +6,7 @@ use rusty_leveldb::DB;
 
 pub struct CacheDB(pub DB);
 
-fn genesis_key(block_number: BlockNumber) -> [u8; 11] {
+fn genesis_key(block_number: BlockNumber) -> [u8; 7 + std::mem::size_of::<BlockNumber>()] {
     let mut key = *b"genesis****";
     key[7..].copy_from_slice(&block_number.to_be_bytes());
     key

--- a/standalone/headers-cache/src/db.rs
+++ b/standalone/headers-cache/src/db.rs
@@ -8,6 +8,19 @@ impl CacheDB {
     pub fn open(path: &str) -> Result<Self> {
         Ok(CacheDB(DB::open(path, Default::default())?))
     }
+
+    pub fn get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
+        self.0.get(key)
+    }
+
+    pub fn get_genesis(&mut self) -> Option<Vec<u8>> {
+        self.get(b"genesis")
+    }
+
+    pub fn put_genesis(&mut self, value: &[u8]) -> Result<()> {
+        self.0.put(b"genesis", value)?;
+        Ok(())
+    }
 }
 
 impl cache::DB for CacheDB {

--- a/standalone/headers-cache/src/db.rs
+++ b/standalone/headers-cache/src/db.rs
@@ -1,39 +1,65 @@
 use crate::BlockNumber;
 
-use super::cache;
 use anyhow::Result;
-use rusty_leveldb::DB;
+use rocksdb::DB;
+use std::mem::size_of;
 
-pub struct CacheDB(pub DB);
+pub struct CacheDB(DB);
 
-fn genesis_key(block_number: BlockNumber) -> [u8; 7 + std::mem::size_of::<BlockNumber>()] {
-    let mut key = *b"genesis****";
-    key[7..].copy_from_slice(&block_number.to_be_bytes());
+fn mk_key(prefix: u8, block_number: BlockNumber) -> [u8; size_of::<BlockNumber>() + 1] {
+    let mut key = [prefix; size_of::<BlockNumber>() + 1];
+    key[1..].copy_from_slice(&block_number.to_be_bytes());
     key
 }
 
 impl CacheDB {
     pub fn open(path: &str) -> Result<Self> {
-        Ok(CacheDB(DB::open(path, Default::default())?))
+        Ok(CacheDB(DB::open_default(path)?))
     }
 
-    pub fn get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
-        self.0.get(key)
-    }
-
-    pub fn get_genesis(&mut self, block_number: BlockNumber) -> Option<Vec<u8>> {
-        self.get(&genesis_key(block_number))
-    }
-
-    pub fn put_genesis(&mut self, value: &[u8], block_number: BlockNumber) -> Result<()> {
-        self.0.put(&genesis_key(block_number), value)?;
+    pub fn flush(&mut self) -> Result<()> {
+        self.0.flush()?;
         Ok(())
     }
-}
 
-impl cache::DB for CacheDB {
-    fn put(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
-        self.0.put(key, value)?;
+    fn get(&mut self, prefix: u8, block: BlockNumber) -> Option<Vec<u8>> {
+        self.0.get(&mk_key(prefix, block)).ok().flatten()
+    }
+
+    fn put(&mut self, prefix: u8, block: BlockNumber, value: &[u8]) -> Result<()> {
+        self.0.put(&mk_key(prefix, block), value)?;
         Ok(())
+    }
+
+    pub fn get_header(&mut self, block: BlockNumber) -> Option<Vec<u8>> {
+        self.get(b'h', block)
+    }
+
+    pub fn put_header(&mut self, block: BlockNumber, value: &[u8]) -> Result<()> {
+        self.put(b'h', block, value)
+    }
+
+    pub fn get_para_header(&mut self, block: BlockNumber) -> Option<Vec<u8>> {
+        self.get(b'p', block)
+    }
+
+    pub fn put_para_header(&mut self, block: BlockNumber, value: &[u8]) -> Result<()> {
+        self.put(b'p', block, value)
+    }
+
+    pub fn get_storage_changes(&mut self, block: BlockNumber) -> Option<Vec<u8>> {
+        self.get(b'c', block)
+    }
+
+    pub fn put_storage_changes(&mut self, block: BlockNumber, value: &[u8]) -> Result<()> {
+        self.put(b'c', block, value)
+    }
+
+    pub fn get_genesis(&mut self, block: BlockNumber) -> Option<Vec<u8>> {
+        self.get(b'g', block)
+    }
+
+    pub fn put_genesis(&mut self, block_number: BlockNumber, value: &[u8]) -> Result<()> {
+        self.put(b'g', block_number, value)
     }
 }

--- a/standalone/headers-cache/src/db.rs
+++ b/standalone/headers-cache/src/db.rs
@@ -1,0 +1,18 @@
+use super::cache;
+use anyhow::Result;
+use rusty_leveldb::DB;
+
+pub struct CacheDB(pub DB);
+
+impl CacheDB {
+    pub fn open(path: &str) -> Result<Self> {
+        Ok(CacheDB(DB::open(path, Default::default())?))
+    }
+}
+
+impl cache::DB for CacheDB {
+    fn put(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.0.put(key, value)?;
+        Ok(())
+    }
+}

--- a/standalone/headers-cache/src/db.rs
+++ b/standalone/headers-cache/src/db.rs
@@ -1,8 +1,16 @@
+use crate::BlockNumber;
+
 use super::cache;
 use anyhow::Result;
 use rusty_leveldb::DB;
 
 pub struct CacheDB(pub DB);
+
+fn genesis_key(block_number: BlockNumber) -> [u8; 11] {
+    let mut key = *b"genesis****";
+    key[7..].copy_from_slice(&block_number.to_be_bytes());
+    key
+}
 
 impl CacheDB {
     pub fn open(path: &str) -> Result<Self> {
@@ -13,12 +21,12 @@ impl CacheDB {
         self.0.get(key)
     }
 
-    pub fn get_genesis(&mut self) -> Option<Vec<u8>> {
-        self.get(b"genesis")
+    pub fn get_genesis(&mut self, block_number: BlockNumber) -> Option<Vec<u8>> {
+        self.get(&genesis_key(block_number))
     }
 
-    pub fn put_genesis(&mut self, value: &[u8]) -> Result<()> {
-        self.0.put(b"genesis", value)?;
+    pub fn put_genesis(&mut self, value: &[u8], block_number: BlockNumber) -> Result<()> {
+        self.0.put(&genesis_key(block_number), value)?;
         Ok(())
     }
 }

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -1,0 +1,107 @@
+use scale::Encode;
+use std::fs::File;
+use std::io::Write;
+
+use clap::{AppSettings, Parser, Subcommand};
+use pherry::headers_cache as cache;
+
+mod db;
+
+#[derive(Parser)]
+#[clap(about = "Cache server for relaychain headers", version, author)]
+#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
+pub struct Args {
+    /// The relaychain RPC endpoint
+    #[clap(long, default_value = "ws://localhost:9945")]
+    node_uri: String,
+    /// The block number to be treated as genesis
+    #[clap(long, default_value = "cache.db")]
+    db: String,
+    #[clap(subcommand)]
+    action: Action,
+}
+
+#[derive(Subcommand)]
+enum Action {
+    /// Grap headers from the chain and dump them to a file
+    Grab {
+        /// The block number to start at
+        #[clap(long, default_value_t = 1)]
+        from_block: u32,
+        /// Number of headers to grab
+        #[clap(long, default_value_t = u32::MAX)]
+        count: u32,
+        /// Minimum number of blocks between justification
+        #[clap(default_value_t = 1000)]
+        justification_interval: u32,
+        /// The file to write the headers to
+        #[clap(default_value = "headers.bin")]
+        output: String,
+    },
+    /// Import headers from a file into the cache database
+    Import {
+        /// The file to read from
+        #[clap(default_value = "headers.bin")]
+        input: String,
+    },
+    /// Grab genesis info from the chain and dump it to a file
+    GrabGenesis {
+        /// The block number to be treated as genesis
+        #[clap(long, default_value_t = 1)]
+        block: u32,
+        /// The file to write the result to
+        #[clap(default_value = "genesis.bin")]
+        output: String,
+    },
+    /// Import genesis info from a file into the cache database
+    ImportGenesis {
+        /// The genesis file to read from
+        #[clap(default_value = "genesis.bin")]
+        input: String,
+    },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let args = Args::parse();
+    match args.action {
+        Action::Grab {
+            from_block,
+            count,
+            justification_interval,
+            output,
+        } => {
+            let output = File::create(output)?;
+            let api = pherry::subxt_connect(&args.node_uri).await?.into();
+            let count = cache::grap_headers_to_file(
+                &api,
+                from_block,
+                count,
+                justification_interval,
+                output,
+            )
+            .await?;
+            println!("{} headers written", count);
+        }
+        Action::GrabGenesis { block, output } => {
+            let mut output = File::create(output)?;
+            let api = pherry::subxt_connect(&args.node_uri).await?.into();
+            let info = cache::fetch_genesis_info(&api, block).await?;
+            output.write_all(info.encode().as_ref())?;
+        }
+        Action::Import { input } => {
+            let input = File::open(input)?;
+            let mut cache = db::CacheDB::open(&args.db)?;
+            let count = cache::import_headers(input, &mut cache).await?;
+            println!("{} headers imported", count);
+        }
+        Action::ImportGenesis { input } => {
+            let mut cache = db::CacheDB::open(&args.db)?;
+            cache.0.put(b"genesis", &std::fs::read(input)?)?;
+            println!("done");
+        }
+    }
+    Ok(())
+}

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -185,7 +185,7 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Action::Serve { db } => {
-            web_api::serve(&db)?;
+            web_api::serve(&db).await?;
         }
         Action::ShowSetId { uri, block } => {
             let api = pherry::subxt_connect(&uri).await?.into();

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -67,7 +67,7 @@ enum Grab {
         node_uri: String,
         /// The block number to be treated as genesis
         #[clap(long, default_value_t = 0)]
-        block: BlockNumber,
+        from_block: BlockNumber,
         /// The file to write the result to
         #[clap(default_value = "genesis.bin")]
         output: String,
@@ -155,12 +155,12 @@ async fn main() -> anyhow::Result<()> {
             }
             Grab::Genesis {
                 node_uri,
-                block,
+                from_block,
                 output,
             } => {
                 let api = pherry::subxt_connect(&node_uri).await?.into();
                 let mut output = File::create(output)?;
-                let info = cache::fetch_genesis_info(&api, block).await?;
+                let info = cache::fetch_genesis_info(&api, from_block).await?;
                 output.write_all(info.encode().as_ref())?;
             }
         },

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(decl_macro)] // for rocket
-
 use std::fs::File;
 use std::io::Write;
 

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -1,8 +1,10 @@
 #![feature(decl_macro)] // for rocket
 
-use scale::Encode;
 use std::fs::File;
 use std::io::Write;
+
+use anyhow::Context;
+use scale::{Decode, Encode};
 
 use clap::{AppSettings, Parser, Subcommand};
 use pherry::headers_cache as cache;
@@ -10,60 +12,86 @@ use pherry::headers_cache as cache;
 mod db;
 mod web_api;
 
+type BlockNumber = u32;
+
 #[derive(Parser)]
 #[clap(about = "Cache server for relaychain headers", version, author)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 pub struct Args {
-    /// The relaychain RPC endpoint
-    #[clap(long, default_value = "ws://localhost:9945")]
-    node_uri: String,
-    /// The block number to be treated as genesis
-    #[clap(long, default_value = "cache.db")]
-    db: String,
     #[clap(subcommand)]
     action: Action,
 }
 
 #[derive(Subcommand)]
-enum Action {
+enum Import {
+    /// Import headers from given file to database.
+    Headers {
+        /// The grabbed headers file to read from
+        #[clap(default_value = "headers.bin")]
+        input: String,
+    },
+    /// Import genesis from given file to database.
+    Genesis {
+        /// The grabbed genesis file to read from
+        #[clap(default_value = "genesis.bin")]
+        input: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum Grab {
     /// Grap headers from the chain and dump them to a file
-    Grab {
+    Headers {
         /// The block number to start at
         #[clap(long, default_value_t = 1)]
-        from_block: u32,
+        from_block: BlockNumber,
         /// Number of headers to grab
-        #[clap(long, default_value_t = u32::MAX)]
-        count: u32,
+        #[clap(long, default_value_t = BlockNumber::MAX)]
+        count: BlockNumber,
         /// Minimum number of blocks between justification
         #[clap(default_value_t = 1000)]
-        justification_interval: u32,
+        justification_interval: BlockNumber,
         /// The file to write the headers to
         #[clap(default_value = "headers.bin")]
         output: String,
     },
-    /// Import headers from a file into the cache database
-    Import {
-        /// The file to read from
-        #[clap(default_value = "headers.bin")]
-        input: String,
-    },
-    /// Grab genesis info from the chain and dump it to a file
-    GrabGenesis {
+    Genesis {
         /// The block number to be treated as genesis
-        #[clap(long, default_value_t = 1)]
-        block: u32,
+        #[clap(long, default_value_t = 0)]
+        block: BlockNumber,
         /// The file to write the result to
         #[clap(default_value = "genesis.bin")]
         output: String,
     },
-    /// Import genesis info from a file into the cache database
-    ImportGenesis {
-        /// The genesis file to read from
-        #[clap(default_value = "genesis.bin")]
-        input: String,
+}
+
+#[derive(Subcommand)]
+enum Action {
+    /// Grab genesis or headers from the blockchain and dump it to a file
+    Grab {
+        /// The relaychain RPC endpoint
+        #[clap(long, default_value = "ws://localhost:9945")]
+        node_uri: String,
+
+        /// What to grab
+        #[clap(subcommand)]
+        what: Grab,
+    },
+    /// Import genesis or headers from a file into the cache database
+    Import {
+        /// The database file to use
+        #[clap(long, default_value = "cache.db")]
+        db: String,
+        /// What type of data to import
+        #[clap(subcommand)]
+        what: Import,
     },
     /// Run the cache server
-    Serve,
+    Serve {
+        /// The database file to use
+        #[clap(long, default_value = "cache.db")]
+        db: String,
+    },
 }
 
 #[tokio::main]
@@ -72,43 +100,52 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
     match args.action {
-        Action::Grab {
-            from_block,
-            count,
-            justification_interval,
-            output,
-        } => {
-            let output = File::create(output)?;
-            let api = pherry::subxt_connect(&args.node_uri).await?.into();
-            let count = cache::grap_headers_to_file(
-                &api,
-                from_block,
-                count,
-                justification_interval,
-                output,
-            )
-            .await?;
-            println!("{} headers written", count);
+        Action::Grab { node_uri, what } => {
+            let api = pherry::subxt_connect(&node_uri).await?.into();
+            match what {
+                Grab::Headers {
+                    from_block,
+                    count,
+                    justification_interval,
+                    output,
+                } => {
+                    let output = File::create(output)?;
+                    let count = cache::grap_headers_to_file(
+                        &api,
+                        from_block,
+                        count,
+                        justification_interval,
+                        output,
+                    )
+                    .await?;
+                    println!("{} headers written", count);
+                }
+                Grab::Genesis { block, output } => {
+                    let mut output = File::create(output)?;
+                    let info = cache::fetch_genesis_info(&api, block).await?;
+                    output.write_all(info.encode().as_ref())?;
+                }
+            }
         }
-        Action::GrabGenesis { block, output } => {
-            let mut output = File::create(output)?;
-            let api = pherry::subxt_connect(&args.node_uri).await?.into();
-            let info = cache::fetch_genesis_info(&api, block).await?;
-            output.write_all(info.encode().as_ref())?;
+        Action::Import { db, what } => {
+            let mut cache = db::CacheDB::open(&db)?;
+            match what {
+                Import::Headers { input } => {
+                    let input = File::open(&input)?;
+                    let count = cache::import_headers(input, &mut cache).await?;
+                    println!("{} headers imported", count);
+                }
+                Import::Genesis { input } => {
+                    let data = std::fs::read(input)?;
+                    let info = cache::GenesisBlockInfo::decode(&mut &data[..])
+                        .context("Failed to decode the genesis data")?;
+                    cache.put_genesis(&data, info.block_header.number)?;
+                    println!("genesis at {} put", info.block_header.number);
+                }
+            }
         }
-        Action::Import { input } => {
-            let input = File::open(input)?;
-            let mut cache = db::CacheDB::open(&args.db)?;
-            let count = cache::import_headers(input, &mut cache).await?;
-            println!("{} headers imported", count);
-        }
-        Action::ImportGenesis { input } => {
-            let mut cache = db::CacheDB::open(&args.db)?;
-            cache.put_genesis(&std::fs::read(input)?)?;
-            println!("done");
-        }
-        Action::Serve => {
-            web_api::serve(&args.db)?;
+        Action::Serve { db } => {
+            web_api::serve(&db)?;
         }
     }
     Ok(())

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -26,9 +26,9 @@ pub struct Args {
 enum Import {
     /// Import headers from given file to database.
     Headers {
-        /// The grabbed headers file to read from
+        /// The grabbed headers files to read from
         #[clap(default_value = "headers.bin")]
-        input: String,
+        input_files: Vec<String>,
     },
     /// Import genesis from given file to database.
     Genesis {
@@ -148,10 +148,13 @@ async fn main() -> anyhow::Result<()> {
         Action::Import { db, what } => {
             let mut cache = db::CacheDB::open(&db)?;
             match what {
-                Import::Headers { input } => {
-                    let input = File::open(&input)?;
-                    let count = cache::import_headers(input, &mut cache).await?;
-                    println!("{} headers imported", count);
+                Import::Headers { input_files } => {
+                    for filename in input_files {
+                        println!("Importing headers from {}", filename);
+                        let input = File::open(&filename)?;
+                        let count = cache::import_headers(input, &mut cache).await?;
+                        println!("{} headers imported", count);
+                    }
                 }
                 Import::Genesis { input } => {
                     let data = std::fs::read(input)?;

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -199,13 +199,14 @@ async fn main() -> anyhow::Result<()> {
                 let mut file_size = 0;
                 let mut first = 0;
                 let mut last = 0;
-                let count = cache::read_items(&mut input, |hdr, data| {
-                    outfile.write_all(data)?;
+                let count = cache::read_items(&mut input, |record| {
+                    let hdr = record.header()?;
+                    let len = record.write(&mut outfile)?;
                     if first == 0 {
                         first = hdr.number;
                     }
                     last = hdr.number;
-                    file_size += data.len();
+                    file_size += len;
                     Ok(file_size >= limit)
                 })?;
                 drop(outfile);

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(decl_macro)] // for rocket
+
 use scale::Encode;
 use std::fs::File;
 use std::io::Write;
@@ -6,6 +8,7 @@ use clap::{AppSettings, Parser, Subcommand};
 use pherry::headers_cache as cache;
 
 mod db;
+mod web_api;
 
 #[derive(Parser)]
 #[clap(about = "Cache server for relaychain headers", version, author)]
@@ -59,6 +62,8 @@ enum Action {
         #[clap(default_value = "genesis.bin")]
         input: String,
     },
+    /// Run the cache server
+    Serve,
 }
 
 #[tokio::main]
@@ -99,8 +104,11 @@ async fn main() -> anyhow::Result<()> {
         }
         Action::ImportGenesis { input } => {
             let mut cache = db::CacheDB::open(&args.db)?;
-            cache.0.put(b"genesis", &std::fs::read(input)?)?;
+            cache.put_genesis(&std::fs::read(input)?)?;
             println!("done");
+        }
+        Action::Serve => {
+            web_api::serve(&args.db)?;
         }
     }
     Ok(())

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -45,7 +45,7 @@ enum Grab {
         /// The relaychain RPC endpoint
         #[clap(long, default_value = "ws://localhost:9945")]
         node_uri: String,
-        /// The block number to start at
+        /// The parachain RPC endpoint
         #[clap(long, default_value = "ws://localhost:9944")]
         para_node_uri: String,
         /// The block number to start at
@@ -54,7 +54,7 @@ enum Grab {
         /// Number of headers to grab
         #[clap(long, default_value_t = BlockNumber::MAX)]
         count: BlockNumber,
-        /// Minimum number of blocks between justification
+        /// Prefered minimum number of blocks between justification
         #[clap(long, default_value_t = 1000)]
         justification_interval: BlockNumber,
         /// The file to write the headers to

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -1,0 +1,40 @@
+use std::sync::Mutex;
+
+use rocket::response::status::NotFound;
+use rocket::State;
+use rocket::{get, routes};
+
+use crate::db::CacheDB;
+
+struct App {
+    db: Mutex<CacheDB>,
+}
+
+#[get("/genesis")]
+fn get_genesis(app: State<App>) -> Result<Vec<u8>, NotFound<String>> {
+    app.db
+        .lock()
+        .unwrap()
+        .get_genesis()
+        .ok_or(NotFound(format!("genesis not found")))
+}
+
+#[get("/header/<block_number>")]
+fn get_header(app: State<App>, block_number: u32) -> Result<Vec<u8>, NotFound<String>> {
+    let key = block_number.to_be_bytes();
+    app.db
+        .lock()
+        .unwrap()
+        .get(&key)
+        .ok_or(NotFound(format!("header not found")))
+}
+
+pub(crate) fn serve(db: &str) -> anyhow::Result<()> {
+    rocket::ignite()
+        .manage(App {
+            db: Mutex::new(CacheDB::open(db)?),
+        })
+        .mount("/", routes![get_genesis, get_header,])
+        .launch();
+    Ok(())
+}

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -4,6 +4,8 @@ use rocket::response::status::NotFound;
 use rocket::State;
 use rocket::{get, routes};
 
+use scale::{Decode, Encode};
+
 use crate::db::CacheDB;
 use crate::BlockNumber;
 
@@ -30,12 +32,38 @@ fn get_header(app: State<App>, block_number: BlockNumber) -> Result<Vec<u8>, Not
         .ok_or(NotFound(format!("header not found")))
 }
 
+#[get("/headers/<start>")]
+fn get_headers(app: State<App>, start: BlockNumber) -> Result<Vec<u8>, NotFound<String>> {
+    let mut headers = vec![];
+    let mut db = app.db.lock().unwrap();
+    for block in start..start + 10000 {
+        let key = block.to_be_bytes();
+        match db.get(&key) {
+            Some(data) => {
+                let info = crate::cache::BlockInfo::decode(&mut &data[..])
+                    .or(Err(NotFound("Codec error".into())))?;
+                let end = info.justification.is_some();
+                headers.push(info);
+                if end {
+                    break;
+                }
+            }
+            None => {
+                log::warn!("{} not found", block);
+                return Err(NotFound("header not found".into()));
+            }
+        }
+    }
+    log::info!("Got {} headers", headers.len());
+    Ok(headers.encode())
+}
+
 pub(crate) fn serve(db: &str) -> anyhow::Result<()> {
     rocket::ignite()
         .manage(App {
             db: Mutex::new(CacheDB::open(db)?),
         })
-        .mount("/", routes![get_genesis, get_header,])
+        .mount("/", routes![get_genesis, get_header, get_headers])
         .launch();
     Ok(())
 }

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -5,22 +5,23 @@ use rocket::State;
 use rocket::{get, routes};
 
 use crate::db::CacheDB;
+use crate::BlockNumber;
 
 struct App {
     db: Mutex<CacheDB>,
 }
 
-#[get("/genesis")]
-fn get_genesis(app: State<App>) -> Result<Vec<u8>, NotFound<String>> {
+#[get("/genesis/<block_number>")]
+fn get_genesis(app: State<App>, block_number: BlockNumber) -> Result<Vec<u8>, NotFound<String>> {
     app.db
         .lock()
         .unwrap()
-        .get_genesis()
+        .get_genesis(block_number)
         .ok_or(NotFound(format!("genesis not found")))
 }
 
 #[get("/header/<block_number>")]
-fn get_header(app: State<App>, block_number: u32) -> Result<Vec<u8>, NotFound<String>> {
+fn get_header(app: State<App>, block_number: BlockNumber) -> Result<Vec<u8>, NotFound<String>> {
     let key = block_number.to_be_bytes();
     app.db
         .lock()

--- a/standalone/pherry/src/chain_client.rs
+++ b/standalone/pherry/src/chain_client.rs
@@ -9,7 +9,7 @@ use phactory_api::blocks::StorageProof;
 use phala_node_rpc_ext::MakeInto as _;
 use phala_trie_storage::ser::StorageChanges;
 use phala_types::messaging::MessageOrigin;
-use phaxt::{rpc::ExtraRpcExt as _, subxt};
+use phaxt::{rpc::ExtraRpcExt as _, subxt, RpcClient};
 use serde_json::to_value;
 use subxt::rpc::{rpc_params, ClientT};
 
@@ -49,12 +49,11 @@ pub async fn read_proofs(
 
 /// Fetch storage changes made by given block.
 pub async fn fetch_storage_changes(
-    api: &ParachainApi,
+    client: &RpcClient,
     from: &Hash,
     to: &Hash,
 ) -> Result<Vec<StorageChanges>> {
-    let response = api
-        .client
+    let response = client
         .extra_rpc()
         .get_storage_changes(from, to)
         .await?

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -8,7 +8,7 @@ use phaxt::{
 };
 use std::io::{Read, Write};
 
-use log::{debug, info};
+use log::info;
 
 pub use phactory_api::blocks::GenesisBlockInfo;
 
@@ -245,8 +245,8 @@ impl Client {
         Ok(T::decode(&mut &body[..])?)
     }
 
-    pub async fn get_header(&self, block_number: BlockNumber) -> Result<BlockInfo> {
-        let url = format!("{}/header/{}", self.base_uri, block_number);
+    pub async fn get_headers(&self, block_number: BlockNumber) -> Result<Vec<BlockInfo>> {
+        let url = format!("{}/headers/{}", self.base_uri, block_number);
         self.request(&url).await
     }
 

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -1,0 +1,196 @@
+use crate::GRANDPA_ENGINE_ID;
+use anyhow::{anyhow, Result};
+use codec::{Decode, Encode};
+use phactory_api::blocks::{AuthoritySetChange, GenesisBlockInfo};
+use phaxt::{
+    subxt::{self, rpc::NumberOrHex},
+    BlockNumber, Header, RelaychainApi,
+};
+use std::{
+    io::{Read, Write},
+    mem::replace,
+};
+
+#[derive(Decode, Encode)]
+pub struct BlockInfo {
+    pub header: Header,
+    pub justification: Option<Vec<u8>>,
+    pub authority_set_change: Option<AuthoritySetChange>,
+}
+
+pub trait DB {
+    fn put(&mut self, key: &[u8], value: &[u8]) -> Result<()>;
+}
+
+/// Import header logs into database.
+pub async fn import_headers(mut input: impl Read, to_db: &mut impl DB) -> Result<u32> {
+    let mut count = 0_u32;
+    let mut buffer = vec![0u8; 1024 * 100];
+    loop {
+        let mut length_buf = [0u8; 4];
+        if input.read(&mut length_buf)? != 4 {
+            break;
+        }
+        let length = u32::from_be_bytes(length_buf) as usize;
+        if length > buffer.len() {
+            buffer.resize(length, 0);
+        }
+        let buf = &mut buffer[..length];
+        input.read_exact(buf)?;
+        let header: Header = Decode::decode(&mut &buf[..])?;
+        to_db.put(&header.number.to_be_bytes(), buf)?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+/// Dump headers from the chain to a log file.
+pub async fn grap_headers_to_file(
+    api: &RelaychainApi,
+    start_at: BlockNumber,
+    count: BlockNumber,
+    justification_interval: BlockNumber,
+    mut output: impl Write,
+) -> Result<BlockNumber> {
+    grab_headers(api, start_at, count, justification_interval, |info| {
+        let encoded = info.encode();
+        let length = encoded.len() as u32;
+        output.write_all(length.to_be_bytes().as_ref())?;
+        output.write_all(&encoded)?;
+        Ok(())
+    })
+    .await
+}
+
+async fn grab_headers(
+    api: &RelaychainApi,
+    start_at: BlockNumber,
+    count: BlockNumber,
+    justification_interval: u32,
+    mut f: impl FnMut(BlockInfo) -> Result<()>,
+) -> Result<BlockNumber> {
+    if start_at == 0 {
+        anyhow::bail!("start block must be > 0");
+    }
+    if count == 0 {
+        return Ok(0);
+    }
+    let (mut last_header, mut last_header_hash) =
+        crate::get_header_at(&api.client, Some(start_at)).await?;
+    let mut last_justifications = None;
+    let mut last_set = api
+        .storage()
+        .grandpa()
+        .current_set_id(Some(last_header_hash))
+        .await?;
+    let mut skip_justitication = justification_interval;
+    let mut grabbed = 0;
+
+    for block_number in start_at + 1.. {
+        let header;
+        let justifications;
+        let hash;
+        if skip_justitication == 0 {
+            let (block, header_hash) =
+                match crate::get_block_at(&api.client, Some(block_number)).await {
+                    Ok(x) => x,
+                    Err(e) => {
+                        if e.to_string().contains("not found") {
+                            break;
+                        }
+                        return Err(e);
+                    }
+                };
+            header = block.block.header;
+            justifications = block.justifications;
+            hash = header_hash;
+        } else {
+            let (hdr, hdr_hash) = match crate::get_header_at(&api.client, Some(block_number)).await
+            {
+                Ok(x) => x,
+                Err(e) => {
+                    if e.to_string().contains("not found") {
+                        break;
+                    }
+                    return Err(e);
+                }
+            };
+            header = hdr;
+            hash = hdr_hash;
+            justifications = None;
+        };
+        if header.parent_hash != last_header_hash {
+            anyhow::bail!(
+                "parent hash mismatch, block={}, parent={}, last={}",
+                header.number,
+                header.parent_hash,
+                last_header_hash
+            );
+        }
+        let set_id = api.storage().grandpa().current_set_id(Some(hash)).await?;
+        let authority_set_change = if last_set != set_id {
+            if last_justifications.is_none() {
+                last_justifications = api
+                    .client
+                    .rpc()
+                    .block(Some(last_header_hash.clone()))
+                    .await?
+                    .ok_or(anyhow!("No justification for block changing set_id"))?
+                    .justifications;
+            }
+            Some(crate::get_authority_with_proof_at(&api, last_header_hash).await?)
+        } else {
+            None
+        };
+
+        skip_justitication = skip_justitication.saturating_sub(1);
+
+        let last_header = replace(&mut last_header, header);
+        let last_justifications = replace(&mut last_justifications, justifications);
+        last_set = set_id;
+        last_header_hash = hash;
+
+        let justification = last_justifications
+            .map(|v| v.into_justification(GRANDPA_ENGINE_ID))
+            .flatten();
+
+        if justification.is_some() {
+            skip_justitication = justification_interval;
+        }
+
+        f(BlockInfo {
+            header: last_header,
+            justification,
+            authority_set_change,
+        })?;
+        grabbed += 1;
+        if count == grabbed {
+            break;
+        }
+    }
+    Ok(grabbed)
+}
+
+pub async fn fetch_genesis_info(
+    api: &RelaychainApi,
+    genesis_block_number: BlockNumber,
+) -> Result<GenesisBlockInfo> {
+    let genesis_block = crate::get_block_at(&api.client, Some(genesis_block_number))
+        .await?
+        .0
+        .block;
+    let hash = api
+        .client
+        .rpc()
+        .block_hash(Some(subxt::BlockNumber::from(NumberOrHex::Number(
+            genesis_block_number as _,
+        ))))
+        .await?
+        .expect("No genesis block?");
+    let set_proof = crate::get_authority_with_proof_at(api, hash).await?;
+    Ok(GenesisBlockInfo {
+        block_header: genesis_block.header,
+        authority_set: set_proof.authority_set,
+        proof: set_proof.authority_proof,
+    })
+}

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -1,7 +1,7 @@
 use crate::GRANDPA_ENGINE_ID;
 use anyhow::{anyhow, Result};
 use codec::{Decode, Encode};
-use phactory_api::blocks::{AuthoritySetChange, GenesisBlockInfo};
+use phactory_api::blocks::AuthoritySetChange;
 use phaxt::{
     subxt::{self, rpc::NumberOrHex},
     BlockNumber, Header, RelaychainApi,
@@ -10,6 +10,8 @@ use std::{
     io::{Read, Write},
     mem::replace,
 };
+
+pub use phactory_api::blocks::GenesisBlockInfo;
 
 #[derive(Decode, Encode)]
 pub struct BlockInfo {
@@ -53,6 +55,9 @@ pub async fn grap_headers_to_file(
     mut output: impl Write,
 ) -> Result<BlockNumber> {
     grab_headers(api, start_at, count, justification_interval, |info| {
+        if info.header.number % 1024 == 0 {
+            log::info!("Grabbed to {}", info.header.number);
+        }
         let encoded = info.encode();
         let length = encoded.len() as u32;
         output.write_all(length.to_be_bytes().as_ref())?;

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -635,6 +635,14 @@ async fn get_finalized_header(
     last_header_hash: Hash,
 ) -> Result<Option<(Header, Vec<Vec<u8>> /*proof*/)>> {
     let para_id = get_paraid(para_api, None).await?;
+    get_finalized_header_with_paraid(api, para_id, last_header_hash).await
+}
+
+async fn get_finalized_header_with_paraid(
+    api: &RelaychainApi,
+    para_id: u32,
+    last_header_hash: Hash,
+) -> Result<Option<(Header, Vec<Vec<u8>> /*proof*/)>> {
     let para_head_storage_key = chain_client::paras_heads_key(para_id);
 
     let raw_header = api

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -23,11 +23,12 @@ pub mod types;
 
 use crate::error::Error;
 use crate::types::{
-    BlockNumber, BlockWithChanges, Hash, Header, NotifyReq, NumberOrHex, ParachainApi, PrClient,
+    Block, BlockNumber, Hash, Header, NotifyReq, NumberOrHex, ParachainApi, PrClient,
     RelaychainApi, SignedBlock, SrSigner,
 };
 use phactory_api::blocks::{
-    self, AuthoritySet, AuthoritySetChange, BlockHeaderWithChanges, HeaderToSync, StorageProof,
+    self, AuthoritySet, AuthoritySetChange, BlockHeader, BlockHeaderWithChanges, HeaderToSync,
+    StorageProof,
 };
 use phactory_api::prpc::{self, InitRuntimeResponse};
 use phactory_api::pruntime_client;
@@ -192,6 +193,13 @@ struct Args {
     #[clap(long, help = "URI to fetch cached headers from")]
     #[clap(default_value = "")]
     headers_cache_uri: String,
+
+    #[clap(
+        default_value = "20",
+        long,
+        help = "The batch size to get storage changes from the chain."
+    )]
+    get_changes_batch_size: BlockNumber,
 }
 
 struct RunningFlags {
@@ -200,7 +208,7 @@ struct RunningFlags {
 }
 
 struct BlockSyncState {
-    blocks: Vec<BlockWithChanges>,
+    blocks: Vec<Block>,
     /// Tracks the latest known authority set id at a certain block.
     authory_set_state: Option<(BlockNumber, SetId)>,
 }
@@ -235,7 +243,7 @@ async fn get_block_at<T: subxt::Config>(
     Ok((block, hash))
 }
 
-async fn get_header_at<T: subxt::Config>(
+pub async fn get_header_at<T: subxt::Config>(
     client: &subxt::Client<T>,
     h: Option<u32>,
 ) -> Result<(T::Header, T::Hash)> {
@@ -249,34 +257,49 @@ async fn get_header_at<T: subxt::Config>(
     Ok((header, hash))
 }
 
-async fn get_block_without_storage_changes(
-    api: &RelaychainApi,
-    h: Option<u32>,
-) -> Result<BlockWithChanges> {
+async fn get_block_without_storage_changes(api: &RelaychainApi, h: Option<u32>) -> Result<Block> {
     let (block, hash) = get_block_at(&api.client, h).await?;
     info!("get_block: Got block {:?} hash {}", h, hash.to_string());
-    return Ok(BlockWithChanges {
-        block,
-        storage_changes: Default::default(),
-    });
+    return Ok(block);
 }
 
-pub async fn get_block_with_storage_changes(
+pub async fn batch_get_storage_changes(
     api: &ParachainApi,
-    h: Option<u32>,
-) -> Result<BlockWithChanges> {
-    let (block, hash) = get_block_at(&api.client, h).await?;
-    info!(
-        "get_block (w/changes): Got block {:?} hash {}",
-        h,
-        hash.to_string()
-    );
-    let hash = block.block.header.hash();
-    let storage_changes = chain_client::fetch_storage_changes(api, &hash).await?;
-    return Ok(BlockWithChanges {
-        block,
-        storage_changes,
-    });
+    from: BlockNumber,
+    to: BlockNumber,
+    batch_size: BlockNumber,
+) -> Result<Vec<BlockHeaderWithChanges>> {
+    info!("batch_get_changes from {from} to {to} ({} blocks)", to as i64 - from as i64 + 1);
+
+    let mut changes = vec![];
+
+    for from in (from..=to).step_by(batch_size as _) {
+        let to = to.min(from + batch_size - 1);
+        let from_hash = get_header_hash(&api.client, Some(from)).await?;
+        let to_hash = get_header_hash(&api.client, Some(to)).await?;
+        info!("batch_get_changes one batch from {from:?} to {to:?}");
+        let storage_changes =
+            chain_client::fetch_storage_changes(api, &from_hash, &to_hash).await?;
+        changes.extend(
+            storage_changes
+                .into_iter()
+                .enumerate()
+                .map(|(offset, storage_changes)| {
+                    BlockHeaderWithChanges {
+                        // Headers are synced separately. Only the `number` is used in pRuntime while syncing blocks.
+                        block_header: BlockHeader {
+                            number: from + offset as BlockNumber,
+                            parent_hash: Default::default(),
+                            state_root: Default::default(),
+                            extrinsics_root: Default::default(),
+                            digest: Default::default(),
+                        },
+                        storage_changes,
+                    }
+                }),
+        );
+    }
+    Ok(changes)
 }
 
 async fn get_authority_with_proof_at(
@@ -330,7 +353,7 @@ async fn get_paraid(api: &ParachainApi, hash: Option<Hash>) -> Result<u32, Error
 async fn bisec_setid_change(
     api: &RelaychainApi,
     last_set: (BlockNumber, SetId),
-    known_blocks: &Vec<BlockWithChanges>,
+    known_blocks: &Vec<Block>,
 ) -> Result<Option<BlockNumber>> {
     debug!("bisec_setid_change(last_set: {:?})", last_set);
     if known_blocks.is_empty() {
@@ -340,8 +363,8 @@ async fn bisec_setid_change(
     // Run binary search only on blocks with justification
     let headers: Vec<&Header> = known_blocks
         .iter()
-        .filter(|b| b.block.block.header.number > last_block && b.block.justifications.is_some())
-        .map(|b| &b.block.block.header)
+        .filter(|b| b.block.header.number > last_block && b.justifications.is_some())
+        .map(|b| &b.block.header)
         .collect();
     let mut l = 0i64;
     let mut r = (headers.len() as i64) - 1;
@@ -401,37 +424,6 @@ async fn req_dispatch_block(
     Ok(resp)
 }
 
-/// Syncs only the events to pRuntime till `sync_to`
-async fn sync_events_only(
-    pr: &PrClient,
-    sync_state: &mut BlockSyncState,
-    sync_to: BlockNumber,
-    batch_window: usize,
-) -> Result<()> {
-    let block_buf = &mut sync_state.blocks;
-    // Count the blocks to sync
-    let mut n = 0usize;
-    for bwe in block_buf.iter() {
-        if bwe.block.block.header.number <= sync_to {
-            n += 1;
-        } else {
-            break;
-        }
-    }
-    let blocks: Vec<BlockHeaderWithChanges> = block_buf
-        .drain(..n)
-        .map(|bwe| BlockHeaderWithChanges {
-            block_header: bwe.block.block.header,
-            storage_changes: bwe.storage_changes,
-        })
-        .collect();
-    for chunk in blocks.chunks(batch_window) {
-        let r = req_dispatch_block(pr, chunk.to_vec()).await?;
-        debug!("  ..dispatch_block: {:?}", r);
-    }
-    Ok(())
-}
-
 const GRANDPA_ENGINE_ID: sp_runtime::ConsensusEngineId = *b"FRNK";
 
 async fn batch_sync_block(
@@ -442,6 +434,7 @@ async fn batch_sync_block(
     batch_window: usize,
     info: &prpc::PhactoryInfo,
     parachain: bool,
+    get_changes_batch_size: BlockNumber,
 ) -> Result<usize> {
     let block_buf = &mut sync_state.blocks;
     if block_buf.is_empty() {
@@ -452,13 +445,39 @@ async fn batch_sync_block(
     let mut next_para_headernum = info.para_headernum;
 
     let mut synced_blocks: usize = 0;
+
+    let hdr_synced_to = if parachain {
+        next_para_headernum - 1
+    } else {
+        next_headernum - 1
+    };
+    macro_rules! sync_blocks_to {
+        ($to: expr) => {
+            if next_blocknum <= $to {
+                let headers_with_changes = batch_get_storage_changes(
+                    &paraclient,
+                    next_blocknum,
+                    $to,
+                    get_changes_batch_size,
+                )
+                .await?;
+
+                let (count, next) =
+                    dispatch_blocks(pr, batch_window, headers_with_changes, next_blocknum).await?;
+                next_blocknum = next;
+                synced_blocks += count;
+            };
+        };
+    }
+    sync_blocks_to!(hdr_synced_to);
+
     while !block_buf.is_empty() {
         // Current authority set id
         let last_set = if let Some(set) = sync_state.authory_set_state {
             set
         } else {
             // Construct the authority set from the last block we have synced (the genesis)
-            let number = &block_buf.first().unwrap().block.block.header.number - 1;
+            let number = &block_buf.first().unwrap().block.header.number - 1;
             let hash = api.client.rpc().block_hash(Some(number.into())).await?;
             let set_id = api
                 .storage()
@@ -472,10 +491,10 @@ async fn batch_sync_block(
         };
         // Find the next set id change
         let set_id_change_at = bisec_setid_change(api, last_set, block_buf).await?;
-        let last_number_in_buff = block_buf.last().unwrap().block.block.header.number;
+        let last_number_in_buff = block_buf.last().unwrap().block.header.number;
         // Search
         // Find the longest batch within the window
-        let first_block_number = block_buf.first().unwrap().block.block.header.number;
+        let first_block_number = block_buf.first().unwrap().block.header.number;
         // TODO: fix the potential overflow here
         let end_buffer = block_buf.len() as isize - 1;
         let end_set_id_change = match set_id_change_at {
@@ -486,7 +505,6 @@ async fn batch_sync_block(
         let mut header_idx = header_end;
         while header_idx >= 0 {
             if block_buf[header_idx as usize]
-                .block
                 .justifications
                 .as_ref()
                 .map(|v| v.get(GRANDPA_ENGINE_ID))
@@ -501,19 +519,17 @@ async fn batch_sync_block(
             warn!(
                 "Cannot find justification within window (from: {}, to: {})",
                 first_block_number,
-                block_buf.last().unwrap().block.block.header.number,
+                block_buf.last().unwrap().block.header.number,
             );
             break;
         }
         // send out the longest batch and remove it from the input buffer
-        let mut block_batch: Vec<BlockWithChanges> =
-            block_buf.drain(..=(header_idx as usize)).collect();
+        let block_batch: Vec<Block> = block_buf.drain(..=(header_idx as usize)).collect();
         let header_batch: Vec<HeaderToSync> = block_batch
             .iter()
             .map(|b| HeaderToSync {
-                header: b.block.block.header.clone(),
+                header: b.block.header.clone(),
                 justification: b
-                    .block
                     .justifications
                     .clone()
                     .map(|v| v.into_justification(GRANDPA_ENGINE_ID))
@@ -559,7 +575,7 @@ async fn batch_sync_block(
         info!("  ..sync_header: {:?}", r);
         next_headernum = r.synced_to + 1;
 
-        if parachain {
+        let hdr_synced_to = if parachain {
             let hdr_synced_to =
                 match get_finalized_header(api, paraclient, last_header_hash).await? {
                     Some((fin_header, proof)) => {
@@ -575,20 +591,12 @@ async fn batch_sync_block(
                     None => 0,
                 };
             next_para_headernum = hdr_synced_to + 1;
-            let mut para_blocks = Vec::new();
-            if next_blocknum <= hdr_synced_to {
-                for b in next_blocknum..=hdr_synced_to {
-                    let block = get_block_with_storage_changes(&paraclient, Some(b)).await?;
-                    para_blocks.push(block.clone());
-                }
-            }
-            block_batch = para_blocks;
-        }
+            hdr_synced_to
+        } else {
+            r.synced_to
+        };
 
-        let (count, next) =
-            dispatch_blocks(pr, batch_window, &mut block_batch, next_blocknum).await?;
-        next_blocknum = next;
-        synced_blocks += count;
+        sync_blocks_to!(hdr_synced_to);
 
         sync_state.authory_set_state = Some(match set_id_change_at {
             // set_id changed at next block
@@ -603,7 +611,7 @@ async fn batch_sync_block(
 async fn dispatch_blocks(
     pr: &PrClient,
     batch_window: usize,
-    block_batch: &mut Vec<BlockWithChanges>,
+    mut block_batch: Vec<BlockHeaderWithChanges>,
     mut next_blocknum: BlockNumber,
 ) -> Result<(usize, BlockNumber)> {
     let mut count = 0;
@@ -612,13 +620,8 @@ async fn dispatch_blocks(
         let end_batch = block_batch.len() as isize - 1;
         let batch_end = cmp::min(dispatch_window as isize, end_batch);
         if batch_end >= 0 {
-            let dispatch_batch: Vec<BlockHeaderWithChanges> = block_batch
-                .drain(..=(batch_end as usize))
-                .map(|bwe| BlockHeaderWithChanges {
-                    block_header: bwe.block.block.header,
-                    storage_changes: bwe.storage_changes,
-                })
-                .collect();
+            let dispatch_batch: Vec<BlockHeaderWithChanges> =
+                block_batch.drain(..=(batch_end as usize)).collect();
             let blocks_count = dispatch_batch.len();
             let r = req_dispatch_block(pr, dispatch_batch).await?;
             debug!("  ..dispatch_block: {:?}", r);
@@ -1046,6 +1049,7 @@ async fn bridge(
                     info.para_headernum,
                     cached_headers,
                     args.sync_blocks,
+                    args.get_changes_batch_size,
                 )
                 .await?;
                 continue;
@@ -1055,7 +1059,7 @@ async fn bridge(
         let latest_block = get_block_at(&api.client, None).await?.0.block;
         // remove the blocks not needed in the buffer. info.blocknum is the next required block
         while let Some(ref b) = sync_state.blocks.first() {
-            if b.block.block.header.number >= info.blocknum {
+            if b.block.header.number >= info.blocknum {
                 break;
             }
             sync_state.blocks.remove(0);
@@ -1073,7 +1077,7 @@ async fn bridge(
 
         // fill the sync buffer to catch up the chain tip
         let next_block = match sync_state.blocks.last() {
-            Some(b) => b.block.block.header.number + 1,
+            Some(b) => b.block.header.number + 1,
             None => {
                 if args.parachain {
                     info.headernum
@@ -1093,29 +1097,13 @@ async fn bridge(
             }
         };
 
-        // TODO.kevin: batch request blocks and changes.
         for b in next_block..=batch_end {
-            let block = if args.parachain {
-                get_block_without_storage_changes(&api, Some(b)).await?
-            } else {
-                // api and para_api are connected to the same node in solochain mode
-                get_block_with_storage_changes(&para_api, Some(b)).await?
-            };
+            let block = get_block_without_storage_changes(&api, Some(b)).await?;
 
-            if block.block.justifications.is_some() {
-                debug!(
-                    "block with justification at: {}",
-                    block.block.block.header.number
-                );
+            if block.justifications.is_some() {
+                debug!("block with justification at: {}", block.block.header.number);
             }
             sync_state.blocks.push(block.clone());
-        }
-
-        let next_headernum = info.para_headernum;
-
-        // if the header syncs faster than the event, let the events to catch up
-        if next_headernum > info.blocknum {
-            sync_events_only(&pr, &mut sync_state, next_headernum - 1, args.sync_blocks).await?;
         }
 
         // send the blocks to pRuntime in batch
@@ -1127,6 +1115,7 @@ async fn bridge(
             args.sync_blocks,
             &info,
             args.parachain,
+            args.get_changes_batch_size,
         )
         .await?;
 
@@ -1261,6 +1250,7 @@ async fn mk_params(
 pub async fn pherry_main() {
     env_logger::builder()
         .filter_level(log::LevelFilter::Info)
+        .format_timestamp_micros()
         .parse_default_env()
         .init();
 
@@ -1301,6 +1291,7 @@ async fn sync_with_cached_headers(
     next_para_headernum: BlockNumber,
     mut headers: Vec<headers_cache::BlockInfo>,
     batch_window: usize,
+    get_changes_batch_size: BlockNumber,
 ) -> Result<()> {
     let last_header = match headers.last_mut() {
         Some(header) => header,
@@ -1328,14 +1319,16 @@ async fn sync_with_cached_headers(
             para_header.proof,
         )
         .await?;
-        let mut para_blocks = Vec::new();
         if next_blocknum <= hdr_synced_to {
-            for b in next_blocknum..=hdr_synced_to {
-                let block = get_block_with_storage_changes(&para_api, Some(b)).await?;
-                para_blocks.push(block.clone());
-            }
+            let blocks = batch_get_storage_changes(
+                &para_api,
+                next_blocknum,
+                hdr_synced_to,
+                get_changes_batch_size,
+            )
+            .await?;
+            let _ = dispatch_blocks(pr, batch_window, blocks, 0).await?;
         }
-        let _ = dispatch_blocks(pr, batch_window, &mut para_blocks, 0).await?;
     }
     Ok(())
 }

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -19,6 +19,7 @@ mod notify_client;
 
 pub mod chain_client;
 pub mod types;
+pub mod headers_cache;
 
 use crate::error::Error;
 use crate::types::{
@@ -227,6 +228,20 @@ async fn get_block_at<T: subxt::Config>(
         .ok_or(Error::BlockNotFound)?;
 
     Ok((block, hash))
+}
+
+async fn get_header_at<T: subxt::Config>(
+    client: &subxt::Client<T>,
+    h: Option<u32>,
+) -> Result<(T::Header, T::Hash)> {
+    let hash = get_header_hash(client, h).await?;
+    let header = client
+        .rpc()
+        .header(Some(hash.clone()))
+        .await?
+        .ok_or(Error::BlockNotFound)?;
+
+    Ok((header, hash))
 }
 
 async fn get_block_without_storage_changes(

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -1027,6 +1027,7 @@ async fn bridge(
         .await
         .ok();
 
+        // Sync the relaychain and parachain data from the cache service as much as possible
         if let (true, Some(cache)) = (args.parachain, &cache_client) {
             info!("Fetching headers at {} from cache...", info.headernum);
             let cached_headers = cache.get_headers(info.headernum).await.unwrap_or_default();

--- a/standalone/pherry/src/prefetcher.rs
+++ b/standalone/pherry/src/prefetcher.rs
@@ -1,0 +1,67 @@
+use anyhow::Result;
+use phactory_api::blocks::BlockHeaderWithChanges;
+use phaxt::{BlockNumber, RpcClient};
+use tokio::task::JoinHandle;
+
+struct StoragePrefetchState {
+    from: BlockNumber,
+    to: BlockNumber,
+    handle: JoinHandle<Result<Vec<BlockHeaderWithChanges>>>,
+}
+
+pub struct PrefetchClient {
+    prefetching_storage_changes: Option<StoragePrefetchState>,
+}
+
+impl PrefetchClient {
+    pub fn new() -> Self {
+        Self {
+            prefetching_storage_changes: None,
+        }
+    }
+
+    pub async fn fetch_storage_changes(
+        &mut self,
+        client: &RpcClient,
+        cache: Option<&crate::CacheClient>,
+        from: BlockNumber,
+        to: BlockNumber,
+    ) -> Result<Vec<BlockHeaderWithChanges>> {
+        let count = to + 1 - from;
+        let result = if let Some(state) = self.prefetching_storage_changes.take() {
+            if state.from == from && state.to == to {
+                log::info!("use prefetched storage changes ({from}-{to})",);
+                state.handle.await?.ok()
+            } else {
+                log::info!(
+                    "cancelling the prefetch ({}-{}), requesting ({from}-{to})",
+                    state.from,
+                    state.to,
+                );
+                state.handle.abort();
+                None
+            }
+        } else {
+            None
+        };
+
+        let result = if let Some(result) = result {
+            result
+        } else {
+            crate::fetch_storage_changes(client, cache, from, to).await?
+        };
+        let next_from = from + count;
+        let next_to = next_from + count - 1;
+        let client = client.clone();
+        let cache = cache.cloned();
+        self.prefetching_storage_changes = Some(StoragePrefetchState {
+            from: next_from,
+            to: next_to,
+            handle: tokio::spawn(async move {
+                log::info!("prefetching ({next_from}-{next_to})");
+                crate::fetch_storage_changes(&client, (&cache).as_ref(), next_from, next_to).await
+            }),
+        });
+        Ok(result)
+    }
+}

--- a/standalone/pherry/src/types.rs
+++ b/standalone/pherry/src/types.rs
@@ -1,7 +1,4 @@
-use phactory_api::{
-    blocks::{StorageChanges, StorageProof},
-    pruntime_client,
-};
+use phactory_api::{blocks::StorageProof, pruntime_client};
 use serde::{Deserialize, Serialize};
 use sp_core::sr25519;
 use sp_runtime::{generic::SignedBlock as SpSignedBlock, OpaqueExtrinsic};
@@ -10,20 +7,14 @@ pub use sp_core::storage::{StorageData, StorageKey};
 
 pub use khala::runtime_types::phala_mq::types::*;
 pub use phaxt::{self, *};
-pub use sp_runtime::generic::Block;
 pub use subxt::rpc::NumberOrHex;
 
 pub type PrClient = pruntime_client::PRuntimeClient;
 pub type SrSigner = subxt::PairSigner<phaxt::Config, sr25519::Pair>;
 
-pub type SignedBlock<Hdr, Ext> = SpSignedBlock<Block<Hdr, Ext>>;
+pub type SignedBlock<Hdr, Ext> = SpSignedBlock<sp_runtime::generic::Block<Hdr, Ext>>;
 
-#[derive(Clone, Debug)]
-pub struct BlockWithChanges {
-    pub block: SignedBlock<Header, OpaqueExtrinsic>,
-    pub storage_changes: StorageChanges,
-}
-
+pub type Block = SignedBlock<Header, OpaqueExtrinsic>;
 // API: notify
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -4188,6 +4188,7 @@ dependencies = [
  "base64 0.13.0",
  "derive_more",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "phala-crypto",
  "phala-mq",

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(decl_macro)]
-
 mod api_server;
 mod pal_gramine;
 mod ra;

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -9,6 +9,7 @@ use clap::{AppSettings, Parser};
 use log::{error, info};
 
 use phactory_api::ecall_args::{git_revision, InitArgs};
+use phactory::BlockNumber;
 
 #[derive(Parser, Debug, Clone)]
 #[clap(about = "The Phala TEE worker app.", version, author)]
@@ -66,6 +67,11 @@ struct Args {
     /// Measuring the time it takes to process each RPC call.
     #[clap(long)]
     measure_rpc_time: bool,
+
+    /// Run the database garbage collection at given interval in blocks
+    #[clap(long)]
+    #[clap(default_value_t = 100)]
+    gc_interval: BlockNumber,
 }
 
 #[rocket::main]
@@ -99,7 +105,7 @@ async fn main() {
     }
 
     let env = env_logger::Env::default().default_filter_or(&args.log_filter);
-    env_logger::Builder::from_env(env).init();
+    env_logger::Builder::from_env(env).format_timestamp_micros().init();
 
     let init_args = {
         let args = args.clone();
@@ -114,6 +120,7 @@ async fn main() {
             checkpoint_interval: args.checkpoint_interval,
             remove_corrupted_checkpoint: args.remove_corrupted_checkpoint,
             max_checkpoint_files: args.max_checkpoint_files,
+            gc_interval: args.gc_interval,
         }
     };
     info!("init_args: {:#?}", init_args);

--- a/standalone/replay/src/replay_gk.rs
+++ b/standalone/replay/src/replay_gk.rs
@@ -18,9 +18,7 @@ use phala_mq::Path as MqPath;
 use phala_trie_storage::TrieStorage;
 use phala_types::WorkerPublicKey;
 use phaxt::rpc::ExtraRpcExt as _;
-use pherry::types::{
-    phaxt, subxt, BlockNumber, Hashing, NumberOrHex, ParachainApi, StorageKey,
-};
+use pherry::types::{phaxt, subxt, BlockNumber, Hashing, NumberOrHex, ParachainApi, StorageKey};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Mutex};
 
@@ -80,6 +78,7 @@ impl ReplayFactory {
         }
 
         self.storage.apply_changes(state_root, transaction);
+        self.storage.purge();
         self.handle_inbound_messages(header.number, event_tx)
             .await?;
         self.current_block = header.number;
@@ -286,10 +285,12 @@ pub async fn replay(args: Args) -> Result<()> {
                 }
             }
             log::info!("Fetching block {}", block_number);
-            match pherry::batch_get_storage_changes(&api, block_number, block_number, 1).await {
+            match pherry::fetch_storage_changes(&api.client, None, block_number, block_number).await
+            {
                 Ok(mut blocks) => {
                     let mut block = blocks.pop().expect("Expected one block");
-                    let (header, _hash) = pherry::get_header_at(&api.client, Some(block_number)).await?;
+                    let (header, _hash) =
+                        pherry::get_header_at(&api.client, Some(block_number)).await?;
                     block.block_header = header;
                     log::info!("Replaying block {}", block_number);
                     let mut factory = factory.lock().await;

--- a/standalone/replay/src/replay_gk.rs
+++ b/standalone/replay/src/replay_gk.rs
@@ -12,13 +12,14 @@ use std::{
 use anyhow::Error;
 use anyhow::Result;
 use phactory::{gk, BlockInfo, SideTaskManager, StorageExt};
+use phactory_api::blocks::BlockHeaderWithChanges;
 use phala_mq::MessageDispatcher;
 use phala_mq::Path as MqPath;
 use phala_trie_storage::TrieStorage;
 use phala_types::WorkerPublicKey;
 use phaxt::rpc::ExtraRpcExt as _;
 use pherry::types::{
-    phaxt, subxt, BlockNumber, BlockWithChanges, Hashing, NumberOrHex, ParachainApi, StorageKey,
+    phaxt, subxt, BlockNumber, Hashing, NumberOrHex, ParachainApi, StorageKey,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Mutex};
@@ -65,14 +66,14 @@ impl ReplayFactory {
 
     async fn dispatch_block(
         &mut self,
-        block: BlockWithChanges,
+        block: BlockHeaderWithChanges,
         event_tx: &Option<RecordSender>,
     ) -> Result<(), &'static str> {
         let (state_root, transaction) = self.storage.calc_root_if_changes(
             &block.storage_changes.main_storage_changes,
             &block.storage_changes.child_storage_changes,
         );
-        let header = &block.block.block.header;
+        let header = &block.block_header;
 
         if header.state_root != state_root {
             return Err("State root mismatch");
@@ -81,7 +82,7 @@ impl ReplayFactory {
         self.storage.apply_changes(state_root, transaction);
         self.handle_inbound_messages(header.number, event_tx)
             .await?;
-        self.current_block = block.block.block.header.number;
+        self.current_block = header.number;
         Ok(())
     }
 
@@ -285,8 +286,11 @@ pub async fn replay(args: Args) -> Result<()> {
                 }
             }
             log::info!("Fetching block {}", block_number);
-            match pherry::get_block_with_storage_changes(&api, Some(block_number)).await {
-                Ok(block) => {
+            match pherry::batch_get_storage_changes(&api, block_number, block_number, 1).await {
+                Ok(mut blocks) => {
+                    let mut block = blocks.pop().expect("Expected one block");
+                    let (header, _hash) = pherry::get_header_at(&api.client, Some(block_number)).await?;
+                    block.block_header = header;
                     log::info!("Replaying block {}", block_number);
                     let mut factory = factory.lock().await;
                     factory


### PR DESCRIPTION
This PR introduce a new cache server component named `headers-cache`.
And pherry now can fetch relaychain headers from `headers-cache`. 
With this cache, miners can turn off the `--archive` of their kusama nodes.

# Basic Usage
## 1. Grab genesis and headers from the chain
```
headers-cache grab genesis --from-block <number> genesis.bin
headers-cache grab headers --from-block <number> headers.bin
```
## 2. Import the grabbed file into the database.
```
# Kill the ` headers-cache serve` if it is running.
killall headers-cache
headers-cache import genesis genesis.bin
headers-cache import headers headers.bin
```
## 3. Start the cache server
```
ROCKET_PORT=8002 headers-cache serve
```
## 4. Start pherry and tell it to consider the cache server.
```
pherry ... --headers-cache-uri http://localhost:8002
```

# Cache parachain headers and storage changes.
Parachain headers and storage changes can also be cached in `headers-cache` (by #773)
## Grab and import parachain headers
```
headers-cache grab para-headers --from-block <number> para-headers.bin
headers-cache import para-headers para-headers.bin
```
## Grab and import storage changes
```
headers-cache grab storage-changes --from-block <number> storage-changes.bin
headers-cache import storage-changes storage-changes.bin
```

# Trouble shooting
## IO error: While open a file for appending: cache.db/001021.sst: Too many open files
While importing data to the database, the rocksdb would open many files. We can increase the fd limitation by:
```
ulimit -Sn unlimited
```
or
```
sudo ulimit -n unlimited
```
and then try to import again.
