### PR TITLE
Don't overwrite the last state_root if given headers is empty

### DIFF
--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -325,7 +325,10 @@ impl<Validator: BlockValidator> StorageSynchronizer for ParachainSynchronizer<Va
         let last_header =
             self.sync_state
                 .sync_header(headers, authority_set_change, &mut state_roots)?;
-        self.last_relaychain_state_root = state_roots.pop_back();
+        // Don't overwrite the last state_root if given headers is empty
+        if let Some(last_root) = state_roots.pop_back() {
+            self.last_relaychain_state_root = Some(last_root);
+        }
         Ok(last_header)
     }
 

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -214,7 +214,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         let counters = self.runtime_state()?.storage_synchronizer.counters();
         blocks.retain(|b| b.block_header.number >= counters.next_block_number);
 
-        let mut last_block = 0;
+        let mut last_block = counters.next_block_number - 1;
         for block in blocks.into_iter() {
             info!("Dispatching block: {}", block.block_header.number);
             let state = self.runtime_state()?;


### PR DESCRIPTION
Fixup #757.