### PR TITLE
Exclude sidevm examples from the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10608,47 +10608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
-name = "sidevm-host"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "env_logger",
- "pink-sidevm-host-runtime",
- "tokio",
-]
-
-[[package]]
-name = "sidevm-httpserver"
-version = "0.1.0"
-dependencies = [
- "futures 0.3.21",
- "log 0.4.16",
- "once_cell",
- "pink-sidevm",
- "tokio",
-]
-
-[[package]]
-name = "sidevm-recv-messages"
-version = "0.1.0"
-dependencies = [
- "log 0.4.16",
- "once_cell",
- "pink-sidevm",
- "tokio",
-]
-
-[[package]]
-name = "sidevm-timer"
-version = "0.1.0"
-dependencies = [
- "log 0.4.16",
- "once_cell",
- "pink-sidevm",
- "tokio",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ exclude = [
 	"native-nostd-hasher",
 	"standalone/pruntime",
 	"crates/pink/examples",
+	"crates/pink/sidevm/examples",
 ]
 
 members = [
@@ -62,10 +63,6 @@ members = [
 	"crates/pink/sidevm/macro",
 	"crates/pink/sidevm/logger",
 	"crates/pink/sidevm/sidevm",
-	"crates/pink/sidevm/examples/timer",
-	"crates/pink/sidevm/examples/httpserver",
-	"crates/pink/sidevm/examples/host",
-	"crates/pink/sidevm/examples/recv_messages",
 	"crates/phala-serde-more",
 	"crates/rustfmt-snippet",
 	"pallets/phala",

--- a/crates/pink/sidevm/examples/host/Cargo.toml
+++ b/crates/pink/sidevm/examples/host/Cargo.toml
@@ -1,3 +1,6 @@
+# workaround for https://github.com/rust-lang/cargo/issues/6745
+[workspace]
+
 [package]
 edition = "2021"
 name = "sidevm-host"

--- a/crates/pink/sidevm/examples/httpserver/Cargo.toml
+++ b/crates/pink/sidevm/examples/httpserver/Cargo.toml
@@ -1,3 +1,6 @@
+# workaround for https://github.com/rust-lang/cargo/issues/6745
+[workspace]
+
 [package]
 edition = "2021"
 name = "sidevm-httpserver"

--- a/crates/pink/sidevm/examples/recv_messages/Cargo.toml
+++ b/crates/pink/sidevm/examples/recv_messages/Cargo.toml
@@ -1,3 +1,6 @@
+# workaround for https://github.com/rust-lang/cargo/issues/6745
+[workspace]
+
 [package]
 edition = "2021"
 name = "sidevm-recv-messages"

--- a/crates/pink/sidevm/examples/timer/Cargo.toml
+++ b/crates/pink/sidevm/examples/timer/Cargo.toml
@@ -1,3 +1,6 @@
+# workaround for https://github.com/rust-lang/cargo/issues/6745
+[workspace]
+
 [package]
 edition = "2021"
 name = "sidevm-timer"


### PR DESCRIPTION
Exclude those examples because they don't compile under macOS due to undefined `sidevm_ocall` and `sidevm_ocall_fastreturn`.

We can resolve the compilation error by marking the two functions as `extern_weak` once the Rust [linkage](https://github.com/rust-lang/rust/issues/29603) feature being stablized.

This fixes #762.