### PR TITLE
More pherry sync speed improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,12 +1043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,15 +1725,6 @@ dependencies = [
  "smallvec",
  "wasmparser 0.83.0",
  "wasmtime-types",
-]
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
 ]
 
 [[package]]
@@ -3464,7 +3449,7 @@ dependencies = [
  "parity-scale-codec",
  "pherry",
  "rocket",
- "rusty-leveldb",
+ "rocksdb",
  "tokio",
 ]
 
@@ -4092,12 +4077,6 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
-
-[[package]]
-name = "integer-encoding"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
 
 [[package]]
 name = "integer-sqrt"
@@ -5098,6 +5077,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "tikv-jemalloc-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -9237,20 +9217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
-name = "rusty-leveldb"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19365c4619fa0892aef573e6ee1b569b1161ac1ac3da765f550a17645192615e"
-dependencies = [
- "crc 1.8.1",
- "errno",
- "fs2",
- "integer-encoding",
- "rand 0.7.3",
- "snap",
-]
-
-[[package]]
 name = "rw-stream-sink"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11511,7 +11477,7 @@ dependencies = [
  "byteorder",
  "bytes 1.1.0",
  "chrono",
- "crc 2.1.0",
+ "crc",
  "crossbeam-queue",
  "dirs 4.0.0",
  "either",

--- a/crates/phactory/api/Cargo.toml
+++ b/crates/phactory/api/Cargo.toml
@@ -28,7 +28,7 @@ sp-runtime = { path = "../../../substrate/primitives/runtime", default-features 
 # for pruntime_client
 async-trait = { version = "0.1.51", optional = true }
 anyhow = { version = "1.0.43", optional = true }
-log = { version = "0.4.14", optional = true }
+log = { version = "0.4.14" }
 reqwest = { version = "0.11.4", optional = true }
 
 primitive-types = { version = "0.11.0", optional = true, default-features = false }
@@ -58,7 +58,6 @@ sgx = []
 pruntime-client = [
     "async-trait",
     "anyhow",
-    "log",
     "reqwest",
 ]
 

--- a/crates/phactory/api/src/ecall_args.rs
+++ b/crates/phactory/api/src/ecall_args.rs
@@ -1,6 +1,5 @@
-
-use parity_scale_codec::{Encode, Decode};
 use alloc::string::{String, ToString};
+use parity_scale_codec::{Decode, Encode};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Encode, Decode, Default, Clone)]
@@ -34,6 +33,10 @@ pub struct InitArgs {
 
     /// Max number of checkpoint files kept
     pub max_checkpoint_files: u32,
+
+    /// Run the database garbage collection at given interval in blocks
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub gc_interval: chain::BlockNumber,
 }
 
 pub fn git_revision() -> String {

--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -201,6 +201,11 @@ where
 
         let changes = &block.storage_changes;
 
+        log::debug!(
+            "calc root ({}, {})",
+            changes.main_storage_changes.len(),
+            changes.child_storage_changes.len()
+        );
         let (state_root, transaction) = storage.calc_root_if_changes(
             &changes.main_storage_changes,
             &changes.child_storage_changes,
@@ -214,7 +219,9 @@ where
             });
         }
 
+        log::debug!("apply changes");
         storage.apply_changes(state_root, transaction);
+        log::debug!("applied");
 
         self.block_number_next += 1;
         state_roots.pop_front();

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -57,6 +57,7 @@ pub use side_task::SideTaskManager;
 pub use storage::{Storage, StorageExt};
 pub use system::gk;
 pub use types::BlockInfo;
+pub use chain::BlockNumber;
 
 pub mod benchmark;
 
@@ -229,6 +230,9 @@ pub struct Phactory<Platform> {
     #[serde(skip)]
     #[serde(default = "Instant::now")]
     last_checkpoint: Instant,
+    #[serde(skip)]
+    #[serde(default)]
+    last_storage_purge_at: chain::BlockNumber,
 }
 
 impl<Platform: pal::Platform> Phactory<Platform> {
@@ -245,6 +249,7 @@ impl<Platform: pal::Platform> Phactory<Platform> {
             system: None,
             side_task_man: Default::default(),
             last_checkpoint: Instant::now(),
+            last_storage_purge_at: 0,
         }
     }
 

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -222,10 +222,20 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
                 .storage_synchronizer
                 .feed_block(&block, &mut state.chain_storage)
                 .map_err(from_display)?;
-
+            info!("State synced");
             state.purge_mq();
             self.handle_inbound_messages(block.block_header.number)?;
             self.poll_side_tasks(block.block_header.number)?;
+            if block
+                .block_header
+                .number
+                .saturating_sub(self.last_storage_purge_at)
+                >= self.args.gc_interval
+            {
+                self.last_storage_purge_at = block.block_header.number;
+                info!("Purging database");
+                self.runtime_state()?.chain_storage.purge();
+            }
             last_block = block.block_header.number;
 
             if let Err(e) = self.maybe_take_checkpoint(last_block) {

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -166,6 +166,12 @@ where
     pub fn apply_changes(&mut self, root: H::Out, transaction: MemoryDB<H>) {
         let mut storage = core::mem::take(self).0.into_storage();
         storage.consolidate(transaction);
+        let _ = core::mem::replace(&mut self.0, TrieBackend::new(storage, root));
+    }
+
+    pub fn purge(&mut self) {
+        let root = *self.0.root();
+        let mut storage = core::mem::take(self).0.into_storage();
         storage.purge();
         let _ = core::mem::replace(&mut self.0, TrieBackend::new(storage, root));
     }

--- a/crates/phaxt/src/lib.rs
+++ b/crates/phaxt/src/lib.rs
@@ -22,6 +22,7 @@ pub type RelaychainApi = kusama::RuntimeApi<DefaultConfig, ExtrinsicParams>;
 pub type ExtrinsicParams = DefaultExtrinsicParams<DefaultConfig>;
 pub type ExtrinsicParamsBuilder = DefaultExtrinsicParamsBuilder<DefaultConfig>;
 pub use subxt::DefaultConfig as Config;
+pub type RpcClient = subxt::Client<Config>;
 
 pub use subxt;
 pub use subxt::sp_core::storage::{StorageData, StorageKey};

--- a/standalone/headers-cache/Cargo.toml
+++ b/standalone/headers-cache/Cargo.toml
@@ -14,5 +14,5 @@ chrono = { version = "0.4.19" }
 env_logger = "0.9.0"
 rocket = "0.5.0-rc.1"
 scale = { package = 'parity-scale-codec', version = "3.0" }
-rusty-leveldb = "0.3"
+rocksdb = "0.18"
 

--- a/standalone/headers-cache/README.md
+++ b/standalone/headers-cache/README.md
@@ -1,0 +1,46 @@
+# Basic Usage
+## 1. Grab genesis and headers from the chain
+```
+headers-cache grab genesis --from-block <number> genesis.bin
+headers-cache grab headers --from-block <number> headers.bin
+```
+## 2. Import the grabbed file into the database.
+```
+# Kill the ` headers-cache serve` if it is running.
+killall headers-cache
+headers-cache import genesis genesis.bin
+headers-cache import headers headers.bin
+```
+## 3. Start the cache server
+```
+ROCKET_PORT=8002 headers-cache serve
+```
+## 4. Start pherry and tell it to consider the cache server.
+```
+pherry ... --headers-cache-uri http://localhost:8002
+```
+
+# Cache parachain headers and storage changes.
+Parachain headers and storage changes can also be cached in `headers-cache` (by #773)
+## Grab and import parachain headers
+```
+headers-cache grab para-headers --from-block <number> para-headers.bin
+headers-cache import para-headers para-headers.bin
+```
+## Grab and import storage changes
+```
+headers-cache grab storage-changes--from-block <number> storage-changes.bin
+headers-cache import storage-changes storage-changes.bin
+```
+
+# Trouble shooting
+## IO error: While open a file for appending: cache.db/001021.sst: Too many open files
+While importing data to the database, the rocksdb would open many files. We can increase the fd limitation by:
+```
+ulimit -Sn unlimited
+```
+or
+```
+sudo ulimit -n unlimited
+```
+and then try to import again.

--- a/standalone/headers-cache/src/db.rs
+++ b/standalone/headers-cache/src/db.rs
@@ -47,6 +47,14 @@ impl CacheDB {
         self.put(b'p', block, value)
     }
 
+    pub fn get_storage_changes(&mut self, block: BlockNumber) -> Option<Vec<u8>> {
+        self.get(b'c', block)
+    }
+
+    pub fn put_storage_changes(&mut self, block: BlockNumber, value: &[u8]) -> Result<()> {
+        self.put(b'c', block, value)
+    }
+
     pub fn get_genesis(&mut self, block: BlockNumber) -> Option<Vec<u8>> {
         self.get(b'g', block)
     }

--- a/standalone/headers-cache/src/db.rs
+++ b/standalone/headers-cache/src/db.rs
@@ -1,7 +1,7 @@
 use crate::BlockNumber;
 
 use anyhow::Result;
-use rusty_leveldb::DB;
+use rocksdb::DB;
 use std::mem::size_of;
 
 pub struct CacheDB(DB);
@@ -14,11 +14,16 @@ fn mk_key(prefix: u8, block_number: BlockNumber) -> [u8; size_of::<BlockNumber>(
 
 impl CacheDB {
     pub fn open(path: &str) -> Result<Self> {
-        Ok(CacheDB(DB::open(path, Default::default())?))
+        Ok(CacheDB(DB::open_default(path)?))
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        self.0.flush()?;
+        Ok(())
     }
 
     fn get(&mut self, prefix: u8, block: BlockNumber) -> Option<Vec<u8>> {
-        self.0.get(&mk_key(prefix, block))
+        self.0.get(&mk_key(prefix, block)).ok().flatten()
     }
 
     fn put(&mut self, prefix: u8, block: BlockNumber, value: &[u8]) -> Result<()> {

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -246,12 +246,12 @@ async fn main() -> anyhow::Result<()> {
             loop {
                 let mut outfile = File::create(&tmpfile)?;
                 let mut file_size = 0;
-                let mut first = 0;
+                let mut first = u32::MAX;
                 let mut last = 0;
                 let count = cache::read_items(&mut input, |record| {
                     let hdr = record.header()?;
                     let len = record.write(&mut outfile)?;
-                    if first == 0 {
+                    if first == u32::MAX {
                         first = hdr.number;
                     }
                     last = hdr.number;

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::Write;
 
 use anyhow::Context;
+use log::info;
 use scale::{Decode, Encode};
 
 use clap::{AppSettings, Parser, Subcommand};
@@ -244,9 +245,8 @@ async fn main() -> anyhow::Result<()> {
                         let count = cache::read_items(input, |record| {
                             let header = record.header()?;
                             cache.put_header(header.number, record.payload())?;
-                            if header.number % 1000 == 0{
-                                cache.flush()?;
-                                println!("Imported {}", header.number);
+                            if header.number % 1000 == 0 {
+                                info!("Imported to {}", header.number);
                             }
                             Ok(false)
                         })?;
@@ -260,9 +260,8 @@ async fn main() -> anyhow::Result<()> {
                         let count = cache::read_items(input, |record| {
                             let header = record.header()?;
                             cache.put_para_header(header.number, record.payload())?;
-                            if header.number % 1000 == 0{
-                                cache.flush()?;
-                                println!("Imported {}", header.number);
+                            if header.number % 1000 == 0 {
+                                info!("Imported to {}", header.number);
                             }
                             Ok(false)
                         })?;
@@ -276,6 +275,9 @@ async fn main() -> anyhow::Result<()> {
                         let count = cache::read_items(input, |record| {
                             let header = record.header()?;
                             cache.put_storage_changes(header.number, record.payload())?;
+                            if header.number % 1000 == 0 {
+                                info!("Imported to {}", header.number);
+                            }
                             Ok(false)
                         })?;
                         println!("{} blocks imported", count);

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -24,11 +24,10 @@ fn get_genesis(app: &State<App>, block_number: BlockNumber) -> Result<Vec<u8>, N
 
 #[get("/header/<block_number>")]
 fn get_header(app: &State<App>, block_number: BlockNumber) -> Result<Vec<u8>, NotFound<String>> {
-    let key = block_number.to_be_bytes();
     app.db
         .lock()
         .unwrap()
-        .get(&key)
+        .get_header(block_number)
         .ok_or(NotFound(format!("header not found")))
 }
 
@@ -37,8 +36,7 @@ fn get_headers(app: &State<App>, start: BlockNumber) -> Result<Vec<u8>, NotFound
     let mut headers = vec![];
     let mut db = app.db.lock().unwrap();
     for block in start..start + 10000 {
-        let key = block.to_be_bytes();
-        match db.get(&key) {
+        match db.get_header(block) {
             Some(data) => {
                 let info = crate::cache::BlockInfo::decode(&mut &data[..])
                     .or(Err(NotFound("Codec error".into())))?;
@@ -58,12 +56,41 @@ fn get_headers(app: &State<App>, start: BlockNumber) -> Result<Vec<u8>, NotFound
     Ok(headers.encode())
 }
 
+#[get("/parachain_headers/<start>/<count>")]
+fn get_parachain_headers(
+    app: &State<App>,
+    start: BlockNumber,
+    count: BlockNumber,
+) -> Result<Vec<u8>, NotFound<String>> {
+    let mut headers = vec![];
+    let mut db = app.db.lock().unwrap();
+    for block in start..start + count {
+        match db.get_para_header(block) {
+            Some(data) => {
+                use pherry::types::Header;
+                let header =
+                    Header::decode(&mut &data[..]).or(Err(NotFound("Codec error".into())))?;
+                headers.push(header);
+            }
+            None => {
+                log::warn!("{} not found", block);
+                return Err(NotFound("header not found".into()));
+            }
+        }
+    }
+    log::info!("Got {} parachain headers", headers.len());
+    Ok(headers.encode())
+}
+
 pub(crate) async fn serve(db: &str) -> anyhow::Result<()> {
     rocket::build()
         .manage(App {
             db: Mutex::new(CacheDB::open(db)?),
         })
-        .mount("/", routes![get_genesis, get_header, get_headers])
+        .mount(
+            "/",
+            routes![get_genesis, get_header, get_headers, get_parachain_headers],
+        )
         .launch()
         .await?;
     Ok(())

--- a/standalone/pherry/src/chain_client.rs
+++ b/standalone/pherry/src/chain_client.rs
@@ -9,7 +9,7 @@ use phactory_api::blocks::StorageProof;
 use phala_node_rpc_ext::MakeInto as _;
 use phala_trie_storage::ser::StorageChanges;
 use phala_types::messaging::MessageOrigin;
-use phaxt::{rpc::ExtraRpcExt as _, subxt};
+use phaxt::{rpc::ExtraRpcExt as _, subxt, RpcClient};
 use serde_json::to_value;
 use subxt::rpc::{rpc_params, ClientT};
 
@@ -49,12 +49,11 @@ pub async fn read_proofs(
 
 /// Fetch storage changes made by given block.
 pub async fn fetch_storage_changes(
-    api: &ParachainApi,
+    client: &RpcClient,
     from: &Hash,
     to: &Hash,
 ) -> Result<Vec<StorageChanges>> {
-    let response = api
-        .client
+    let response = client
         .extra_rpc()
         .get_storage_changes(from, to)
         .await?

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -320,7 +320,7 @@ async fn grab_storage_changes(
     let to = start_at + count - 1;
     let mut grabbed = 0;
 
-    for from in (start_at..to).step_by(batch_size as _) {
+    for from in (start_at..=to).step_by(batch_size as _) {
         let to = to.min(from + batch_size - 1);
         let headers = crate::fetch_storage_changes(&api.client, None, from, to).await?;
         for header in headers {

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -322,7 +322,7 @@ async fn grab_storage_changes(
 
     for from in (start_at..to).step_by(batch_size as _) {
         let to = to.min(from + batch_size - 1);
-        let headers = crate::fetch_storage_changes(&api.client, from, to).await?;
+        let headers = crate::fetch_storage_changes(&api.client, None, from, to).await?;
         for header in headers {
             f(header)?;
             grabbed += 1;
@@ -357,7 +357,7 @@ pub async fn fetch_genesis_info(
 }
 
 #[derive(Clone)]
-pub(crate) struct Client {
+pub struct Client {
     base_uri: String,
 }
 

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -317,11 +317,11 @@ async fn grab_storage_changes(
         return Ok(0);
     }
 
-    let to = start_at + count - 1;
+    let to = start_at.saturating_add(count - 1);
     let mut grabbed = 0;
 
     for from in (start_at..=to).step_by(batch_size as _) {
-        let to = to.min(from + batch_size - 1);
+        let to = to.min(from.saturating_add(batch_size - 1));
         let headers = crate::fetch_storage_changes(&api.client, None, from, to).await?;
         for header in headers {
             f(header)?;

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -36,7 +36,7 @@ impl<'a> Record<'a> {
         Self { payload }
     }
 
-    pub fn read<'buf>(mut input: impl Read, buffer: &'a mut Vec<u8>) -> Result<Option<Self>> {
+    pub fn read(mut input: impl Read, buffer: &'a mut Vec<u8>) -> Result<Option<Self>> {
         let mut len_buf = [0u8; 4];
 
         if input.read(&mut len_buf)? != 4 {

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -1058,6 +1058,8 @@ async fn bridge(
                     cached_headers.len(),
                     cached_headers[0].header.number
                 );
+                sync_state.authory_set_state = None;
+                sync_state.blocks.clear();
                 sync_with_cached_headers(
                     &pr,
                     &para_api,
@@ -1068,8 +1070,6 @@ async fn bridge(
                     args.sync_blocks,
                 )
                 .await?;
-                sync_state.authory_set_state = None;
-                sync_state.blocks.clear();
                 continue;
             }
         }

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -316,7 +316,7 @@ pub async fn batch_sync_storage_changes(
     let mut fetcher = prefetcher::PrefetchClient::new();
 
     for from in (from..=to).step_by(batch_size as _) {
-        let to = to.min(from + batch_size - 1);
+        let to = to.min(from.saturating_add(batch_size - 1));
         let storage_changes = fetcher
             .fetch_storage_changes(&api.client, cache, from, to)
             .await?;

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -263,6 +263,7 @@ pub async fn fetch_storage_changes(
     from: BlockNumber,
     to: BlockNumber,
 ) -> Result<Vec<BlockHeaderWithChanges>> {
+    log::info!("fetch_storage_changes ({from}-{to})");
     if to < from {
         return Ok(vec![]);
     }
@@ -270,7 +271,7 @@ pub async fn fetch_storage_changes(
         let count = to + 1 - from;
         if let Ok(changes) = cache.get_storage_changes(from, count).await {
             log::info!(
-                "Got {} storage changes from cache server, from {from} to {to}",
+                "Got {} storage changes from cache server ({from}-{to})",
                 changes.len()
             );
             return Ok(changes);
@@ -278,7 +279,6 @@ pub async fn fetch_storage_changes(
     }
     let from_hash = get_header_hash(client, Some(from)).await?;
     let to_hash = get_header_hash(client, Some(to)).await?;
-    log::info!("batch_get_changes from {from} to {to}");
     let storage_changes = chain_client::fetch_storage_changes(client, &from_hash, &to_hash)
         .await?
         .into_iter()

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -194,6 +194,10 @@ struct Args {
     #[clap(long, help = "URI to fetch cached headers from")]
     #[clap(default_value = "")]
     headers_cache_uri: String,
+
+    #[clap(long, help = "Stop when synced to given parachain block")]
+    #[clap(default_value_t = BlockNumber::MAX)]
+    to_block: BlockNumber,
 }
 
 struct RunningFlags {
@@ -1025,6 +1029,10 @@ async fn bridge(
         // update the latest pRuntime state
         let info = pr.get_info(()).await?;
         info!("pRuntime get_info response: {:#?}", info);
+        if info.blocknum >= args.to_block {
+            info!("Reached target block: {}", args.to_block);
+            return Ok(());
+        }
 
         // STATUS: header_synced = info.headernum
         // STATUS: block_synced = info.blocknum

--- a/standalone/pherry/src/prefetcher.rs
+++ b/standalone/pherry/src/prefetcher.rs
@@ -30,11 +30,11 @@ impl PrefetchClient {
         let count = to + 1 - from;
         let result = if let Some(state) = self.prefetching_storage_changes.take() {
             if state.from == from && state.to == to {
-                log::info!("reusing prefetching storage changes, from {from}, to {to}",);
+                log::info!("use prefetched storage changes ({from}-{to})",);
                 state.handle.await?.ok()
             } else {
                 log::info!(
-                    "cancelling the prefetch from {}, to {}, requesting from {from}, to {to}",
+                    "cancelling the prefetch ({}-{}), requesting ({from}-{to})",
                     state.from,
                     state.to,
                 );
@@ -58,6 +58,7 @@ impl PrefetchClient {
             from: next_from,
             to: next_to,
             handle: tokio::spawn(async move {
+                log::info!("prefetching ({next_from}-{next_to})");
                 crate::fetch_storage_changes(&client, (&cache).as_ref(), next_from, next_to).await
             }),
         });

--- a/standalone/pherry/src/prefetcher.rs
+++ b/standalone/pherry/src/prefetcher.rs
@@ -23,6 +23,7 @@ impl PrefetchClient {
     pub async fn fetch_storage_changes(
         &mut self,
         client: &RpcClient,
+        cache: Option<&crate::CacheClient>,
         from: BlockNumber,
         to: BlockNumber,
     ) -> Result<Vec<BlockHeaderWithChanges>> {
@@ -47,16 +48,17 @@ impl PrefetchClient {
         let result = if let Some(result) = result {
             result
         } else {
-            crate::fetch_storage_changes(client, from, to).await?
+            crate::fetch_storage_changes(client, cache, from, to).await?
         };
         let next_from = from + count;
         let next_to = next_from + count - 1;
         let client = client.clone();
+        let cache = cache.cloned();
         self.prefetching_storage_changes = Some(StoragePrefetchState {
             from: next_from,
             to: next_to,
             handle: tokio::spawn(async move {
-                crate::fetch_storage_changes(&client, next_from, next_to).await
+                crate::fetch_storage_changes(&client, (&cache).as_ref(), next_from, next_to).await
             }),
         });
         Ok(result)

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -4188,6 +4188,7 @@ dependencies = [
  "base64 0.13.0",
  "derive_more",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "phala-crypto",
  "phala-mq",

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -99,7 +99,7 @@ async fn main() {
     }
 
     let env = env_logger::Env::default().default_filter_or(&args.log_filter);
-    env_logger::Builder::from_env(env).init();
+    env_logger::Builder::from_env(env).format_timestamp_micros().init();
 
     let init_args = {
         let args = args.clone();

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -9,6 +9,7 @@ use clap::{AppSettings, Parser};
 use log::{error, info};
 
 use phactory_api::ecall_args::{git_revision, InitArgs};
+use phactory::BlockNumber;
 
 #[derive(Parser, Debug, Clone)]
 #[clap(about = "The Phala TEE worker app.", version, author)]
@@ -66,6 +67,11 @@ struct Args {
     /// Measuring the time it takes to process each RPC call.
     #[clap(long)]
     measure_rpc_time: bool,
+
+    /// Run the database garbage collection at given interval in blocks
+    #[clap(long)]
+    #[clap(default_value_t = 100)]
+    gc_interval: BlockNumber,
 }
 
 #[rocket::main]
@@ -114,6 +120,7 @@ async fn main() {
             checkpoint_interval: args.checkpoint_interval,
             remove_corrupted_checkpoint: args.remove_corrupted_checkpoint,
             max_checkpoint_files: args.max_checkpoint_files,
+            gc_interval: args.gc_interval,
         }
     };
     info!("init_args: {:#?}", init_args);

--- a/standalone/replay/src/replay_gk.rs
+++ b/standalone/replay/src/replay_gk.rs
@@ -78,6 +78,7 @@ impl ReplayFactory {
         }
 
         self.storage.apply_changes(state_root, transaction);
+        self.storage.purge();
         self.handle_inbound_messages(header.number, event_tx)
             .await?;
         self.current_block = header.number;

--- a/standalone/replay/src/replay_gk.rs
+++ b/standalone/replay/src/replay_gk.rs
@@ -18,9 +18,7 @@ use phala_mq::Path as MqPath;
 use phala_trie_storage::TrieStorage;
 use phala_types::WorkerPublicKey;
 use phaxt::rpc::ExtraRpcExt as _;
-use pherry::types::{
-    phaxt, subxt, BlockNumber, Hashing, NumberOrHex, ParachainApi, StorageKey,
-};
+use pherry::types::{phaxt, subxt, BlockNumber, Hashing, NumberOrHex, ParachainApi, StorageKey};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Mutex};
 
@@ -286,10 +284,11 @@ pub async fn replay(args: Args) -> Result<()> {
                 }
             }
             log::info!("Fetching block {}", block_number);
-            match pherry::batch_get_storage_changes(&api, block_number, block_number, 1).await {
+            match pherry::fetch_storage_changes(&api.client, block_number, block_number).await {
                 Ok(mut blocks) => {
                     let mut block = blocks.pop().expect("Expected one block");
-                    let (header, _hash) = pherry::get_header_at(&api.client, Some(block_number)).await?;
+                    let (header, _hash) =
+                        pherry::get_header_at(&api.client, Some(block_number)).await?;
                     block.block_header = header;
                     log::info!("Replaying block {}", block_number);
                     let mut factory = factory.lock().await;

--- a/standalone/replay/src/replay_gk.rs
+++ b/standalone/replay/src/replay_gk.rs
@@ -284,7 +284,8 @@ pub async fn replay(args: Args) -> Result<()> {
                 }
             }
             log::info!("Fetching block {}", block_number);
-            match pherry::fetch_storage_changes(&api.client, block_number, block_number).await {
+            match pherry::fetch_storage_changes(&api.client, None, block_number, block_number).await
+            {
                 Ok(mut blocks) => {
                     let mut block = blocks.pop().expect("Expected one block");
                     let (header, _hash) =


### PR DESCRIPTION
Two main features were added in this PR.

### 1. Support to cache parachain headers and storage changes in `headers-cache`. (Optional)

- The size of khala headers at the moment is 285M. So it's cheap to add them to the cache server. And can help (not much) on parachain headers fetching speed by batch fetching.
- The size of all storage changes is about 64GB. it could significantly improve the syncing speed if we cache them. 

### 2. Prefetch storage changes in pherry

When syncing storages, pherry first fetches a batch of storage changes from the chain and then sends them into pRuntime. Both the 2 steps cost some time. 
In this PR, pherry prefetches the next batch of `changes` while sending the current batch to the pRuntime, simultaneously.

### 3. Configurable GC interval of database
Default to 100 blocks 