### PR TITLE
pink-extension: Fix extension mocking codec error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7842,7 +7842,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "ink_env",
  "ink_lang",

--- a/crates/pink/pink-extension/Cargo.toml
+++ b/crates/pink/pink-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pink-extension"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2018"
 description = "Phala's ink! for writing fat contracts"
 license = "Apache-2.0"

--- a/crates/pink/pink-extension/src/chain_extension/test.rs
+++ b/crates/pink/pink-extension/src/chain_extension/test.rs
@@ -17,7 +17,8 @@ where
     }
 
     fn call(&mut self, input: &[u8], output: &mut Vec<u8>) -> u32 {
-        let input = In::decode(&mut &input[..]).expect("decode input");
+        let input: Vec<u8> = Decode::decode(&mut &input[..]).expect("mock decode input failed");
+        let input = In::decode(&mut &input[..]).expect("mock decode input failed");
         let out = (self.call)(input);
         out.encode_to(output);
         0


### PR DESCRIPTION
Ink! has changed its mocking input codec ABI in 3.0.0.