### PR TITLE
sidevm ocall: Flatten the Result<Poll<T>> into Result<T>

### DIFF
--- a/crates/pink/sidevm/env/src/lib.rs
+++ b/crates/pink/sidevm/env/src/lib.rs
@@ -49,10 +49,8 @@ pub enum OcallError {
     UnsupportedOperation = 8,
     IoError = 9,
     ResourceLimited = 10,
-    /// Reserved for future use
-    Reserved11 = 11,
-    /// Reserved for future use
-    Reserved12 = 12,
+    Pending = 11,
+    EndOfFile = 12,
     /// Reserved for future use
     Reserved13 = 13,
     /// Reserved for future use

--- a/crates/pink/sidevm/env/src/ocall_def.rs
+++ b/crates/pink/sidevm/env/src/ocall_def.rs
@@ -1,85 +1,6 @@
 use super::*;
 use crate::args_stack::{I32Convertible, RetDecode, StackedArgs};
 
-/// Poll state for a dynamic returned buffer (for the ocall `fn poll`).
-#[derive(Encode, Decode)]
-pub enum Poll<T> {
-    /// Represents that a value is not ready yet.
-    Pending,
-    /// Represents that a value is immediately ready.
-    Ready(T),
-}
-
-impl<T> Poll<T> {
-    /// Maps a `Poll<T>` to `Poll<U>` by applying a function to a contained value.
-    pub fn map<U, F>(self, f: F) -> Poll<U>
-    where
-        F: FnOnce(T) -> U,
-    {
-        match self {
-            Poll::Ready(t) => Poll::Ready(f(t)),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-impl<T> From<std::task::Poll<T>> for Poll<T> {
-    fn from(poll: std::task::Poll<T>) -> Self {
-        match poll {
-            std::task::Poll::Ready(t) => Poll::Ready(t),
-            std::task::Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-impl<T> From<Poll<T>> for std::task::Poll<T> {
-    fn from(poll: Poll<T>) -> Self {
-        match poll {
-            Poll::Pending => std::task::Poll::Pending,
-            Poll::Ready(t) => std::task::Poll::Ready(t),
-        }
-    }
-}
-
-// Poll state for poll_read/poll_write.
-impl I32Convertible for Poll<u32> {
-    fn to_i32(&self) -> i32 {
-        match self {
-            // In theory, the n could be u32::MAX which is the same binary representation as -1.
-            // But in practice, no buffer in wasm32 can have a size of u32::MAX or greater.
-            Self::Ready(n) => *n as i32,
-            Self::Pending => -1,
-        }
-    }
-
-    fn from_i32(i: i32) -> Result<Self> {
-        Ok(match i {
-            -1 => Self::Pending,
-            n => Self::Ready(n as u32),
-        })
-    }
-}
-
-impl I32Convertible for Poll<()> {
-    fn to_i32(&self) -> i32 {
-        match self {
-            Poll::Pending => -1,
-            Poll::Ready(_) => 0,
-        }
-    }
-
-    fn from_i32(i: i32) -> Result<Self>
-    where
-        Self: Sized,
-    {
-        match i {
-            -1 => Ok(Self::Pending),
-            0 => Ok(Self::Ready(())),
-            _ => Err(OcallError::InvalidEncoding),
-        }
-    }
-}
-
 /// All ocall definitions for pink Sidevm.
 #[pink_sidevm_macro::ocall]
 pub trait OcallFuncs {
@@ -89,19 +10,19 @@ pub trait OcallFuncs {
 
     /// Poll given resource by id and return a dynamic sized data.
     #[ocall(id = 102, fast_input)]
-    fn poll(resource_id: i32) -> Result<Poll<Option<Vec<u8>>>>;
+    fn poll(resource_id: i32) -> Result<Vec<u8>>;
 
     /// Poll given resource to read data. Low level support for AsyncRead.
     #[ocall(id = 103, fast_input, fast_return)]
-    fn poll_read(resource_id: i32, data: &mut [u8]) -> Result<Poll<u32>>;
+    fn poll_read(resource_id: i32, data: &mut [u8]) -> Result<u32>;
 
     /// Poll given resource to write data. Low level support for AsyncWrite.
     #[ocall(id = 104, fast_input, fast_return)]
-    fn poll_write(resource_id: i32, data: &[u8]) -> Result<Poll<u32>>;
+    fn poll_write(resource_id: i32, data: &[u8]) -> Result<u32>;
 
     /// Shutdown a socket
     #[ocall(id = 105, fast_input, fast_return)]
-    fn poll_shutdown(resource_id: i32) -> Result<Poll<()>>;
+    fn poll_shutdown(resource_id: i32) -> Result<()>;
 
     /// Mark a task as ready for next polling
     #[ocall(id = 109, fast_input, fast_return)]
@@ -130,7 +51,7 @@ pub trait OcallFuncs {
 
     /// Accept incoming TCP connections.
     #[ocall(id = 211, fast_input)]
-    fn tcp_accept(resource_id: i32) -> Result<Poll<i32>>;
+    fn tcp_accept(resource_id: i32) -> Result<i32>;
 
     /// Print log message.
     #[ocall(id = 220, fast_input, fast_return)]

--- a/crates/pink/sidevm/sidevm/src/time.rs
+++ b/crates/pink/sidevm/sidevm/src/time.rs
@@ -30,10 +30,12 @@ impl Future for Sleep {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let rv = ocall::poll_read(self.id.0, &mut []).expect("Poll timer failed");
+        use env::OcallError;
+        let rv = ocall::poll_read(self.id.0, &mut []);
         match rv {
-            env::Poll::Ready(_) => Poll::Ready(()),
-            env::Poll::Pending => Poll::Pending,
+            Ok(_) => Poll::Ready(()),
+            Err(OcallError::Pending) => Poll::Pending,
+            Err(err) => panic!("unexpected error: {:?}", err),
         }
     }
 }


### PR DESCRIPTION
This makes the ocalls simpler and easier to turn more types to support fast io.