### PR TITLE
sidevm ocalls: Opt-out the fast_input/fast_return

### DIFF
--- a/crates/pink/sidevm/env/src/ocall_def.rs
+++ b/crates/pink/sidevm/env/src/ocall_def.rs
@@ -5,43 +5,43 @@ use crate::args_stack::{I32Convertible, RetDecode, StackedArgs};
 #[pink_sidevm_macro::ocall]
 pub trait OcallFuncs {
     /// Close given resource by id.
-    #[ocall(id = 101, fast_input, fast_return)]
+    #[ocall(id = 101)]
     fn close(resource_id: i32) -> Result<()>;
 
     /// Poll given resource by id and return a dynamic sized data.
-    #[ocall(id = 102, fast_input)]
+    #[ocall(id = 102, encode_output)]
     fn poll(resource_id: i32) -> Result<Vec<u8>>;
 
     /// Poll given resource to read data. Low level support for AsyncRead.
-    #[ocall(id = 103, fast_input, fast_return)]
+    #[ocall(id = 103)]
     fn poll_read(resource_id: i32, data: &mut [u8]) -> Result<u32>;
 
     /// Poll given resource to write data. Low level support for AsyncWrite.
-    #[ocall(id = 104, fast_input, fast_return)]
+    #[ocall(id = 104)]
     fn poll_write(resource_id: i32, data: &[u8]) -> Result<u32>;
 
     /// Shutdown a socket
-    #[ocall(id = 105, fast_input, fast_return)]
+    #[ocall(id = 105)]
     fn poll_shutdown(resource_id: i32) -> Result<()>;
 
     /// Poll given resource to generate a new resource id.
-    #[ocall(id = 106, fast_input, fast_return)]
+    #[ocall(id = 106)]
     fn poll_res(resource_id: i32) -> Result<i32>;
 
     /// Mark a task as ready for next polling
-    #[ocall(id = 109, fast_input, fast_return)]
+    #[ocall(id = 109)]
     fn mark_task_ready(task_id: i32) -> Result<()>;
 
     /// Get the next waken up task id.
-    #[ocall(id = 110, fast_input, fast_return)]
+    #[ocall(id = 110)]
     fn next_ready_task() -> Result<i32>;
 
     /// Enable logging for ocalls
-    #[ocall(id = 111, fast_input, fast_return)]
+    #[ocall(id = 111)]
     fn enable_ocall_trace(enable: bool) -> Result<()>;
 
     /// Create a timer given a duration of time in milliseconds.
-    #[ocall(id = 201, fast_input, fast_return)]
+    #[ocall(id = 201)]
     fn create_timer(timeout: i32) -> Result<i32>;
 
     /// Create a TCP socket, bind to given address and listen to incoming connections.
@@ -50,18 +50,18 @@ pub trait OcallFuncs {
     /// for sockfd may grow.
     ///
     /// Invoke tcp_accept on the returned resource_id to accept incoming connections.
-    #[ocall(id = 210, fast_input, fast_return)]
+    #[ocall(id = 210)]
     fn tcp_listen(addr: &str, backlog: i32) -> Result<i32>;
 
     /// Accept incoming TCP connections.
-    #[ocall(id = 211, fast_input, fast_return)]
+    #[ocall(id = 211)]
     fn tcp_accept(resource_id: i32) -> Result<i32>;
 
     /// Initiate a TCP connection to a remote endpoint.
-    #[ocall(id = 212, fast_input, fast_return)]
+    #[ocall(id = 212)]
     fn tcp_connect(&mut self, addr: &str) -> Result<i32>;
 
     /// Print log message.
-    #[ocall(id = 220, fast_input, fast_return)]
+    #[ocall(id = 220)]
     fn log(level: log::Level, message: &str) -> Result<()>;
 }

--- a/crates/pink/sidevm/env/src/tests.rs
+++ b/crates/pink/sidevm/env/src/tests.rs
@@ -4,25 +4,25 @@ use super::*;
 use std::cell::Cell;
 #[pink_sidevm_macro::ocall]
 pub trait TestOcall {
-    #[ocall(id = 100)]
+    #[ocall(id = 100, encode_input, encode_output)]
     fn echo(input: Vec<u8>) -> Result<Vec<u8>>;
 
-    #[ocall(id = 101)]
+    #[ocall(id = 101, encode_input, encode_output)]
     fn add(a: u32, b: u32) -> Result<u32>;
 
-    #[ocall(id = 102, fast_input, fast_return)]
+    #[ocall(id = 102)]
     fn add_fi_fo(a: u32, b: u32) -> Result<u32>;
 
-    #[ocall(id = 103, fast_input)]
+    #[ocall(id = 103, encode_output)]
     fn add_fi(a: u32, b: u32) -> Result<u32>;
 
-    #[ocall(id = 104, fast_return)]
+    #[ocall(id = 104, encode_input)]
     fn add_fo(a: u32, b: u32) -> Result<u32>;
 
-    #[ocall(id = 105, fast_input)]
+    #[ocall(id = 105, encode_output)]
     fn sub_fi(a: i32, b: i32) -> Result<i32>;
 
-    #[ocall(id = 106, fast_input, fast_return)]
+    #[ocall(id = 106)]
     fn copy(dst: &mut [u8], src: &[u8]) -> Result<()>;
 }
 

--- a/crates/pink/sidevm/macro/src/tests.rs
+++ b/crates/pink/sidevm/macro/src/tests.rs
@@ -2,16 +2,16 @@
 fn test_ocall() {
     let stream = crate::macro_ocall::patch(syn::parse_quote! {
         pub trait Ocall {
-            #[ocall(id = 101)]
+            #[ocall(id = 101, encode_input, encode_output)]
             fn call_slow(a: i32, b: i32) -> i32;
 
-            #[ocall(id = 103, fast_input)]
+            #[ocall(id = 103, encode_output)]
             fn call_fi(a: i32, b: i32) -> i32;
 
-            #[ocall(id = 104, fast_return)]
+            #[ocall(id = 104, encode_input)]
             fn call_fo(a: i32, b: i32) -> i32;
 
-            #[ocall(id = 102, fast_input, fast_return)]
+            #[ocall(id = 102)]
             fn poll_fi_fo(a: i32, b: i32) -> i32;
         }
     });


### PR DESCRIPTION
Since most of the ocalls are fast_input/fast_return, let's make it opt-out rather than opt-in.