### PR TITLE
headers-cache: Inspect block numbers in cache DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,6 +3543,8 @@ dependencies = [
  "pherry",
  "rocket",
  "rocksdb",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/standalone/headers-cache/Cargo.toml
+++ b/standalone/headers-cache/Cargo.toml
@@ -15,4 +15,6 @@ env_logger = "0.9.0"
 rocket = "0.5.0-rc.1"
 scale = { package = 'parity-scale-codec', version = "3.0" }
 rocksdb = "0.18"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 

--- a/standalone/headers-cache/src/db.rs
+++ b/standalone/headers-cache/src/db.rs
@@ -4,6 +4,50 @@ use anyhow::Result;
 use rocksdb::DB;
 use std::mem::size_of;
 
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct Counters {
+    pub header: Option<BlockNumber>,
+    pub para_header: Option<BlockNumber>,
+    pub storage_changes: Option<BlockNumber>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct Metadata {
+    pub genesis: Vec<BlockNumber>,
+    pub recent_imported: Counters,
+    pub higest: Counters,
+}
+
+macro_rules! update_field {
+    ($self:ident, $field:ident, $value:expr) => {{
+        $self.recent_imported.$field = Some($value);
+        let higest = $self.higest.$field.unwrap_or_default().max($value);
+        $self.higest.$field = Some(higest);
+    }};
+}
+
+impl Metadata {
+    pub fn update_header(&mut self, block: BlockNumber) {
+        update_field!(self, header, block);
+    }
+
+    pub fn update_para_header(&mut self, block: BlockNumber) {
+        update_field!(self, para_header, block);
+    }
+
+    pub fn update_storage_changes(&mut self, block: BlockNumber) {
+        update_field!(self, storage_changes, block);
+    }
+
+    pub fn put_genesis(&mut self, block: BlockNumber) {
+        if !self.genesis.contains(&block) {
+            self.genesis.push(block);
+        }
+    }
+}
+
 pub struct CacheDB(DB);
 
 fn mk_key(prefix: u8, block_number: BlockNumber) -> [u8; size_of::<BlockNumber>() + 1] {
@@ -61,5 +105,22 @@ impl CacheDB {
 
     pub fn put_genesis(&self, block_number: BlockNumber, value: &[u8]) -> Result<()> {
         self.put(b'g', block_number, value)
+    }
+
+    pub fn get_metadata(&self) -> Result<Option<Metadata>> {
+        let metadata = self
+            .0
+            .get(b"m-metadata")?
+            .map(|encoded| {
+                let result: Result<Metadata> = serde_json::from_slice(&encoded).map_err(Into::into);
+                result
+            })
+            .transpose()?;
+        Ok(metadata)
+    }
+
+    pub fn put_metadata(&self, metadata: Metadata) -> Result<()> {
+        let encoded = serde_json::to_vec(&metadata)?;
+        self.0.put(b"m-metadata", &encoded).map_err(Into::into)
     }
 }


### PR DESCRIPTION
# Usage
```bash
$ ./headers-cache inspect-db
{
  "genesis": [
    8325311
  ],
  "recent_imported": {
    "header": 8346148,
    "para_header": 1573035,
    "storage_changes": null
  },
  "higest": {
    "header": 8756226,
    "para_header": 1573035,
    "storage_changes": null
  }
}

$ ./headers-cache inspect-db | jq .higest.header
8756226
```