### PR TITLE
pruntime: Don't wait for other threads while rocket exited

### DIFF
--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -131,9 +131,8 @@ async fn main() -> Result<(), rocket::Error> {
     let bench_cores: u32 = args.cores.unwrap_or_else(|| num_cpus::get() as _);
     info!("Bench cores: {}", bench_cores);
 
-    let mut v = vec![];
     for i in 0..bench_cores {
-        let child = thread::Builder::new()
+        thread::Builder::new()
             .name(format!("bench-{}", i))
             .spawn(move || {
                 set_thread_idle_policy();
@@ -143,7 +142,6 @@ async fn main() -> Result<(), rocket::Error> {
                 }
             })
             .expect("Failed to launch benchmark thread");
-        v.push(child);
     }
 
     let _: rocket::Rocket<rocket::Ignite> = api_server::rocket(&args)
@@ -151,9 +149,6 @@ async fn main() -> Result<(), rocket::Error> {
         .await
         .expect("Failed to launch API server");
 
-    for child in v {
-        let _ = child.join();
-    }
     info!("pRuntime quited");
 
     Ok(())


### PR DESCRIPTION
This is a better solution than falling back to the behavior of `rocket 0.4`. Because it can still gracefully wait for the ongoing taking checkpoint progress to complete.