### PR TITLE
pruntime: add option "--remove-corrupted-checkpoint"

### DIFF
--- a/crates/phactory/api/src/ecall_args.rs
+++ b/crates/phactory/api/src/ecall_args.rs
@@ -28,8 +28,8 @@ pub struct InitArgs {
     /// Checkpoint interval in seconds
     pub checkpoint_interval: u64,
 
-    /// Skip corrupted checkpoint, and start to sync blocks from the beginning.
-    pub skip_corrupted_checkpoint: bool,
+    /// Remove corrupted checkpoint.
+    pub remove_corrupted_checkpoint: bool,
 
     /// Run the database garbage collection at given interval in blocks
     #[cfg_attr(feature = "serde", serde(default))]

--- a/standalone/pruntime/app/src/main.rs
+++ b/standalone/pruntime/app/src/main.rs
@@ -86,9 +86,9 @@ struct Args {
     #[structopt(default_value = "300")]
     checkpoint_interval: u64,
 
-    /// Skip corrupted checkpoint, and start to sync blocks from the beginning.
+    /// Remove corrupted checkpoint.
     #[structopt(long)]
-    skip_corrupted_checkpoint: bool,
+    remove_corrupted_checkpoint: bool,
 
     /// Measuring the time it takes to process each RPC call.
     #[structopt(long)]
@@ -656,7 +656,7 @@ async fn main() {
         geoip_city_db: args.geoip_city_db,
         enable_checkpoint: !args.disable_checkpoint,
         checkpoint_interval: args.checkpoint_interval,
-        skip_corrupted_checkpoint: args.skip_corrupted_checkpoint,
+        remove_corrupted_checkpoint: args.remove_corrupted_checkpoint,
         gc_interval: args.gc_interval,
     };
     info!("init_args: {:#?}", init_args);

--- a/standalone/pruntime/enclave/src/lib.rs
+++ b/standalone/pruntime/enclave/src/lib.rs
@@ -72,7 +72,11 @@ pub extern "C" fn ecall_init(args: *const u8, args_len: usize) -> sgx_status_t {
         .init();
 
     if args.enable_checkpoint {
-        match Phactory::restore_from_checkpoint(&SgxPlatform, &args.sealing_path) {
+        match Phactory::restore_from_checkpoint(
+            &SgxPlatform,
+            &args.sealing_path,
+            args.remove_corrupted_checkpoint,
+        ) {
             Ok(Some(mut factory)) => {
                 info!("Loaded checkpoint");
                 factory.set_args(args.clone());
@@ -81,10 +85,7 @@ pub extern "C" fn ecall_init(args: *const u8, args_len: usize) -> sgx_status_t {
             }
             Err(err) => {
                 error!("Failed to load checkpoint: {:?}", err);
-                if !args.skip_corrupted_checkpoint {
-                    return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
-                }
-                info!("Skipped corrupted checkpoint");
+                return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
             }
             Ok(None) => {
                 info!("No checkpoint found");


### PR DESCRIPTION
And removed the previous option `--skip-corrupted-checkpoint` since it is not safe.
This fixes #727 