### PR TITLE
sidevm: Implement guest space waker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4114,6 +4114,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkwell"
+version = "0.1.0-beta.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2223d0eba0ae6d40a3e4680c6a3209143471e1f38b41746ea309aa36dde9f90b"
+dependencies = [
+ "either",
+ "inkwell_internals",
+ "libc",
+ "llvm-sys",
+ "once_cell",
+ "parking_lot 0.11.2",
+ "regex",
+]
+
+[[package]]
+name = "inkwell_internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7090af3d300424caa81976b8c97bca41cd70e861272c072e188ae082fb49f9"
+dependencies = [
+ "proc-macro2 1.0.39",
+ "quote 1.0.18",
+ "syn 1.0.95",
+]
+
+[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5120,6 +5146,19 @@ name = "linux-raw-sys"
 version = "0.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
+
+[[package]]
+name = "llvm-sys"
+version = "120.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b716322964966a62377cf86e64f00ca7043505fdf27bd2ec7d41ae6682d1e7"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex",
+ "semver 0.11.0",
+]
 
 [[package]]
 name = "local-channel"
@@ -7728,7 +7767,7 @@ dependencies = [
 
 [[package]]
 name = "pink-sidevm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "derive_more",
  "futures",
@@ -7771,6 +7810,8 @@ dependencies = [
  "tokio",
  "wasm-instrument",
  "wasmer",
+ "wasmer-compiler-cranelift",
+ "wasmer-compiler-llvm",
  "wasmer-compiler-singlepass",
  "wasmer-engine",
  "wasmer-engine-universal",
@@ -10290,7 +10331,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
 ]
 
 [[package]]
@@ -10299,7 +10340,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -10316,6 +10366,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -13236,6 +13295,31 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-compiler-llvm"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4cb34fc0a8105c706513d7c24cf28d96a751f8471d0ed379b07aea8ad8c8f9c"
+dependencies = [
+ "byteorder",
+ "cc",
+ "inkwell",
+ "itertools",
+ "lazy_static",
+ "libc",
+ "loupe",
+ "object 0.28.4",
+ "rayon",
+ "regex",
+ "rustc_version 0.4.0",
+ "semver 1.0.9",
+ "smallvec",
+ "target-lexicon",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7728,8 +7728,10 @@ dependencies = [
 
 [[package]]
 name = "pink-sidevm"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
+ "derive_more",
+ "futures",
  "hyper",
  "log",
  "pink-sidevm-env",
@@ -7740,10 +7742,11 @@ dependencies = [
 
 [[package]]
 name = "pink-sidevm-env"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cfg-if",
  "derive_more",
+ "futures",
  "log",
  "num_enum",
  "parity-scale-codec",

--- a/crates/pink/examples/start_sidevm/sideprog/Cargo.toml
+++ b/crates/pink/examples/start_sidevm/sideprog/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4.16"
 once_cell = "1.10.0"
-pink-sidevm = {path = "../../../sidevm/sidevm"}
-tokio = {version = "1", features = ["macros", "io-util"]}
+pink-sidevm = {version = "0.1", path = "../../../sidevm/sidevm"}
+tokio = {version = "1", features = ["macros"]}
 futures = "0.3"

--- a/crates/pink/examples/start_sidevm/sideprog/src/lib.rs
+++ b/crates/pink/examples/start_sidevm/sideprog/src/lib.rs
@@ -1,7 +1,7 @@
 use log::info;
 use pink_sidevm as sidevm;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[sidevm::main]
 async fn main() {
@@ -12,7 +12,7 @@ async fn main() {
 
     info!("Listening on {}", address);
 
-    let listener = sidevm::net::TcpListener::listen(address).await.unwrap();
+    let listener = sidevm::net::TcpListener::bind(address).await.unwrap();
 
     loop {
         info!("Waiting for incomming connection or message...");

--- a/crates/pink/sidevm/env/Cargo.toml
+++ b/crates/pink/sidevm/env/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
+description = "The low level protocol between sidevm guest and host"
+homepage = "https://github.com/Phala-Network/phala-blockchain"
+license = "Apache-2.0"
 edition = "2021"
 name = "pink-sidevm-env"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 pink-sidevm-macro = {path = "../macro", version = "0.1.0"}
@@ -12,6 +15,7 @@ num_enum = "0.5.7"
 scale = {package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "std"]}
 tinyvec = {version = "1.5.1", features = ["alloc"]}
 log = "0.4.16"
+futures = "0.3"
 
 [features]
 host = []

--- a/crates/pink/sidevm/env/src/lib.rs
+++ b/crates/pink/sidevm/env/src/lib.rs
@@ -18,7 +18,7 @@ use tinyvec::TinyVec;
 pub use args_stack::RetEncode;
 pub use ocall_def::*;
 pub use pink_sidevm_macro::main;
-pub use tasks::{spawn, TaskHandle};
+pub use tasks::spawn;
 
 mod args_stack;
 mod ocall_def;

--- a/crates/pink/sidevm/env/src/lib.rs
+++ b/crates/pink/sidevm/env/src/lib.rs
@@ -22,7 +22,7 @@ pub use tasks::{spawn, TaskHandle};
 
 mod args_stack;
 mod ocall_def;
-mod tasks;
+pub mod tasks;
 
 cfg_if::cfg_if! {
     if #[cfg(all(not(test), any(target_pointer_width = "32", feature = "host")))] {

--- a/crates/pink/sidevm/env/src/ocall_def.rs
+++ b/crates/pink/sidevm/env/src/ocall_def.rs
@@ -10,23 +10,23 @@ pub trait OcallFuncs {
 
     /// Poll given resource by id and return a dynamic sized data.
     #[ocall(id = 102, encode_output)]
-    fn poll(resource_id: i32) -> Result<Vec<u8>>;
+    fn poll(waker_id: i32, resource_id: i32) -> Result<Vec<u8>>;
 
     /// Poll given resource to read data. Low level support for AsyncRead.
     #[ocall(id = 103)]
-    fn poll_read(resource_id: i32, data: &mut [u8]) -> Result<u32>;
+    fn poll_read(waker_id: i32, resource_id: i32, data: &mut [u8]) -> Result<u32>;
 
     /// Poll given resource to write data. Low level support for AsyncWrite.
     #[ocall(id = 104)]
-    fn poll_write(resource_id: i32, data: &[u8]) -> Result<u32>;
+    fn poll_write(waker_id: i32, resource_id: i32, data: &[u8]) -> Result<u32>;
 
     /// Shutdown a socket
     #[ocall(id = 105)]
-    fn poll_shutdown(resource_id: i32) -> Result<()>;
+    fn poll_shutdown(waker_id: i32, resource_id: i32) -> Result<()>;
 
     /// Poll given resource to generate a new resource id.
     #[ocall(id = 106)]
-    fn poll_res(resource_id: i32) -> Result<i32>;
+    fn poll_res(waker_id: i32, resource_id: i32) -> Result<i32>;
 
     /// Mark a task as ready for next polling
     #[ocall(id = 109)]
@@ -39,6 +39,10 @@ pub trait OcallFuncs {
     /// Enable logging for ocalls
     #[ocall(id = 111)]
     fn enable_ocall_trace(enable: bool) -> Result<()>;
+
+    /// Get awaked wakers
+    #[ocall(id = 112, encode_output)]
+    fn awake_wakers() -> Result<Vec<i32>>;
 
     /// Create a timer given a duration of time in milliseconds.
     #[ocall(id = 201)]
@@ -55,11 +59,11 @@ pub trait OcallFuncs {
 
     /// Accept incoming TCP connections.
     #[ocall(id = 211)]
-    fn tcp_accept(resource_id: i32) -> Result<i32>;
+    fn tcp_accept(waker_id: i32, resource_id: i32) -> Result<i32>;
 
     /// Initiate a TCP connection to a remote endpoint.
     #[ocall(id = 212)]
-    fn tcp_connect(&mut self, addr: &str) -> Result<i32>;
+    fn tcp_connect(addr: &str) -> Result<i32>;
 
     /// Print log message.
     #[ocall(id = 220)]

--- a/crates/pink/sidevm/env/src/ocall_def.rs
+++ b/crates/pink/sidevm/env/src/ocall_def.rs
@@ -40,7 +40,7 @@ pub trait OcallFuncs {
     #[ocall(id = 111)]
     fn enable_ocall_trace(enable: bool) -> Result<()>;
 
-    /// Get awaked wakers
+    /// Get awake wakers
     #[ocall(id = 112, encode_output)]
     fn awake_wakers() -> Result<Vec<i32>>;
 

--- a/crates/pink/sidevm/env/src/tasks.rs
+++ b/crates/pink/sidevm/env/src/tasks.rs
@@ -1,4 +1,5 @@
 use core::panic;
+use std::task::Waker;
 
 use super::*;
 
@@ -19,10 +20,50 @@ thread_local! {
     /// New spawned tasks are pushed to this queue. Since tasks are always spawned from inside a
     /// running task which borrowing the TASKS, it can not be immediately pushed to the TASKS.
     static SPAWNING_TASKS: RefCell<Vec<TaskFuture>> = RefCell::new(vec![]);
+    /// New spawned tasks are pushed to this queue. Since tasks are always spawned from inside a
+    /// running task which borrowing the TASKS, it can not be immediately pushed to the TASKS.
+    static WAKERS: RefCell<Vec<Option<Waker>>> = RefCell::new(vec![]);
 }
 
 // TODO.kevin: Support task joining
 pub struct TaskHandle;
+
+pub fn intern_waker(waker: task::Waker) -> i32 {
+    const MAX_N_WAKERS: usize = (i32::MAX / 2) as usize;
+    WAKERS.with(|wakers| {
+        let mut wakers = wakers.borrow_mut();
+        for (id, waker_ref) in wakers.iter_mut().enumerate() {
+            if waker_ref.is_none() {
+                *waker_ref = Some(waker);
+                return id as i32;
+            }
+        }
+        if wakers.len() < MAX_N_WAKERS {
+            wakers.push(Some(waker));
+            wakers.len() as i32 - 1
+        } else {
+            panic!("Too many wakers");
+        }
+    })
+}
+
+fn wake_waker(waker_id: i32) {
+    WAKERS.with(|wakers| {
+        let wakers = wakers.borrow();
+        if let Some(Some(waker)) = wakers.get(waker_id as usize) {
+            waker.wake_by_ref();
+        }
+    });
+}
+
+fn drop_waker(waker_id: i32) {
+    WAKERS.with(|wakers| {
+        let mut wakers = wakers.borrow_mut();
+        if let Some(waker) = wakers.get_mut(waker_id as usize) {
+            *waker = None;
+        }
+    });
+}
 
 pub fn spawn(fut: impl Future<Output = ()> + 'static) -> TaskHandle {
     SPAWNING_TASKS.with(move |tasks| (*tasks).borrow_mut().push(Box::pin(fut)));
@@ -66,23 +107,28 @@ fn set_current_task(task_id: i32) {
     CURRENT_TASK.with(|id| id.set(task_id))
 }
 
-fn poll_with_dummy_context<F>(f: Pin<&mut F>) -> task::Poll<F::Output>
+fn poll_with_guest_context<F>(f: Pin<&mut F>) -> task::Poll<F::Output>
 where
     F: Future + ?Sized,
 {
-    fn raw_waker() -> task::RawWaker {
+    fn raw_waker(task_id: i32) -> task::RawWaker {
         task::RawWaker::new(
-            &(),
+            task_id as _,
             &task::RawWakerVTable::new(
-                |_| raw_waker(),
-                // Let's forbid to use the Context in wasm.
-                |_| panic!("Dummy waker should never be called"),
-                |_| panic!("Dummy waker should never be called"),
+                |data| raw_waker(data as _),
+                |data| {
+                    let task_id = data as _;
+                    ocall::mark_task_ready(task_id).expect("Mark task ready failed");
+                },
+                |data| {
+                    let task_id = data as _;
+                    ocall::mark_task_ready(task_id).expect("Mark task ready failed");
+                },
                 |_| (),
             ),
         )
     }
-    let waker = unsafe { task::Waker::from_raw(raw_waker()) };
+    let waker = unsafe { task::Waker::from_raw(raw_waker(current_task())) };
     let mut context = task::Context::from_waker(&waker);
     f.poll(&mut context)
 }
@@ -93,6 +139,14 @@ extern "C" fn sidevm_poll() -> i32 {
 
     fn poll() -> task::Poll<()> {
         loop {
+            for waker_id in ocall::awake_wakers().expect("Failed to get awaked wakers") {
+                if waker_id >= 0 {
+                    wake_waker(waker_id);
+                } else {
+                    drop_waker(-1 - waker_id);
+                }
+            }
+
             let task_id = match ocall::next_ready_task() {
                 Ok(id) => id as usize,
                 Err(OcallError::NotFound) => return task::Poll::Pending,
@@ -103,7 +157,7 @@ extern "C" fn sidevm_poll() -> i32 {
                     let mut tasks = tasks.borrow_mut();
                     let task = tasks.get_mut(task_id)?.as_mut()?;
                     set_current_task(task_id as _);
-                    match poll_with_dummy_context(task.as_mut()) {
+                    match poll_with_guest_context(task.as_mut()) {
                         Pending => (),
                         Ready(()) => {
                             tasks[task_id] = None;

--- a/crates/pink/sidevm/env/src/tasks.rs
+++ b/crates/pink/sidevm/env/src/tasks.rs
@@ -20,8 +20,14 @@ thread_local! {
     /// New spawned tasks are pushed to this queue. Since tasks are always spawned from inside a
     /// running task which borrowing the TASKS, it can not be immediately pushed to the TASKS.
     static SPAWNING_TASKS: RefCell<Vec<TaskFuture>> = RefCell::new(vec![]);
-    /// New spawned tasks are pushed to this queue. Since tasks are always spawned from inside a
-    /// running task which borrowing the TASKS, it can not be immediately pushed to the TASKS.
+    /// Wakers might being referenced by the sidevm host runtime.
+    ///
+    /// When a ocall polling some resource, we can not pass the waker to the host runtime,
+    /// because they are in different memory space and in different rust code compilation space.
+    /// So when we poll into the host runtime, we cache the waker in WAKERS, and pass the index,
+    /// which called waker_id, into the host runtime. And then before each guest polling, the
+    /// guest runtime ask the host runtime to see which waker is awaken or dropped in the host
+    /// runtime to deside to awake or drop the waker from this Vec.
     static WAKERS: RefCell<Vec<Option<Waker>>> = RefCell::new(vec![]);
 }
 

--- a/crates/pink/sidevm/env/src/tasks.rs
+++ b/crates/pink/sidevm/env/src/tasks.rs
@@ -169,7 +169,7 @@ extern "C" fn sidevm_poll() -> i32 {
 
     fn poll() -> task::Poll<()> {
         loop {
-            for waker_id in ocall::awake_wakers().expect("Failed to get awaked wakers") {
+            for waker_id in ocall::awake_wakers().expect("Failed to get awake wakers") {
                 if waker_id >= 0 {
                     wake_waker(waker_id);
                 } else {

--- a/crates/pink/sidevm/examples/host/Cargo.toml
+++ b/crates/pink/sidevm/examples/host/Cargo.toml
@@ -7,9 +7,11 @@ name = "sidevm-host"
 version = "0.1.0"
 
 [dependencies]
-pink-sidevm-host-runtime = {path = "../../host-runtime"}
-tokio = {version = "1.17.0", features = ["full"]}
+pink-sidevm-host-runtime = { path = "../../host-runtime", features = [
+    "wasmer-compiler-cranelift",
+] }
+tokio = { version = "1.17.0", features = ["full"] }
 env_logger = "0.9.0"
 anyhow = "1.0.56"
-clap = {version = "3", features = ["derive"]}
+clap = { version = "3", features = ["derive"] }
 once_cell = "1"

--- a/crates/pink/sidevm/examples/host/src/main.rs
+++ b/crates/pink/sidevm/examples/host/src/main.rs
@@ -16,6 +16,9 @@ pub struct Args {
     /// The gas limit for each poll.
     #[clap(long, default_value_t = 1000_000_000_000_u128)]
     gas_per_breath: u128,
+    /// Don't instrument the program.
+    #[clap(long)]
+    no_instrument: bool,
     /// The WASM program to run
     program: String,
 }
@@ -70,9 +73,11 @@ async fn main() -> anyhow::Result<()> {
     });
 
     println!("Reading {}...", args.program);
-    let wasm_bytes = std::fs::read(&args.program)?;
-    println!("Instrumenting...");
-    let wasm_bytes = instrument::instrument(&wasm_bytes)?;
+    let mut wasm_bytes = std::fs::read(&args.program)?;
+    if !args.no_instrument {
+        println!("Instrumenting...");
+        wasm_bytes = instrument::instrument(&wasm_bytes)?;
+    }
     println!("VM running...");
     let (_sender, handle) = spawner
         .start(

--- a/crates/pink/sidevm/examples/httpserver/Cargo.toml
+++ b/crates/pink/sidevm/examples/httpserver/Cargo.toml
@@ -13,5 +13,4 @@ crate-type = ["cdylib"]
 log = "0.4.16"
 once_cell = "1.10.0"
 pink-sidevm = {path = "../../sidevm"}
-tokio = {version = "1", features = ["macros", "io-util"]}
 futures = "0.3"

--- a/crates/pink/sidevm/examples/httpserver/src/lib.rs
+++ b/crates/pink/sidevm/examples/httpserver/src/lib.rs
@@ -1,7 +1,7 @@
 use log::info;
 use pink_sidevm as sidevm;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[sidevm::main]
 async fn main() {
@@ -12,7 +12,7 @@ async fn main() {
 
     info!("Listening on {}", address);
 
-    let listener = sidevm::net::TcpListener::listen(address).await.unwrap();
+    let listener = sidevm::net::TcpListener::bind(address).await.unwrap();
 
     loop {
         info!("Waiting for imcomming connection...");

--- a/crates/pink/sidevm/examples/tcpclient/Cargo.lock
+++ b/crates/pink/sidevm/examples/tcpclient/Cargo.lock
@@ -321,6 +321,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pink-sidevm"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "hyper",
  "log",
  "pink-sidevm-env",
@@ -422,7 +423,6 @@ dependencies = [
  "futures",
  "log",
  "pink-sidevm",
- "tokio",
 ]
 
 [[package]]
@@ -489,21 +489,7 @@ version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
- "bytes",
- "memchr",
  "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/crates/pink/sidevm/examples/tcpclient/Cargo.toml
+++ b/crates/pink/sidevm/examples/tcpclient/Cargo.toml
@@ -12,5 +12,4 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4.16"
 pink-sidevm = {path = "../../sidevm"}
-tokio = {version = "1", features = ["macros", "io-util"]}
 futures = "0.3"

--- a/crates/pink/sidevm/examples/tcpclient/src/lib.rs
+++ b/crates/pink/sidevm/examples/tcpclient/src/lib.rs
@@ -1,7 +1,7 @@
 use log::info;
 use pink_sidevm as sidevm;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[sidevm::main]
 async fn main() {

--- a/crates/pink/sidevm/examples/timer/Cargo.toml
+++ b/crates/pink/sidevm/examples/timer/Cargo.toml
@@ -14,3 +14,4 @@ log = "0.4.16"
 once_cell = "1.10.0"
 pink-sidevm = {path = "../../sidevm"}
 tokio = {version = "1", features = ["macros"]}
+futures = "0.3"

--- a/crates/pink/sidevm/host-runtime/Cargo.toml
+++ b/crates/pink/sidevm/host-runtime/Cargo.toml
@@ -15,6 +15,8 @@ thread_local = "1.1"
 tokio = {version = "1.17.0", features = ["full"]}
 wasmer = "2.2.1"
 wasmer-compiler-singlepass = "2.2.1"
+wasmer-compiler-cranelift = { version = "2.2.1", optional = true }
+wasmer-compiler-llvm = { version = "2.2.1", optional = true }
 wasmer-engine = "2.2.1"
 wasmer-engine-universal = "2.2.1"
 wasmer-tunables = {path = "../../../wasmer-tunables"}

--- a/crates/pink/sidevm/host-runtime/src/async_context.rs
+++ b/crates/pink/sidevm/host-runtime/src/async_context.rs
@@ -13,7 +13,7 @@ thread_local! {
 
 #[derive(Clone)]
 struct TaskEnv {
-    awake_tasks: Weak<TaskSet>,
+    tasks: Weak<TaskSet>,
     this_task: i32,
 }
 
@@ -25,7 +25,7 @@ struct WakerData {
 
 impl Drop for WakerData {
     fn drop(&mut self) {
-        if let Some(tasks) = self.env.awake_tasks.upgrade() {
+        if let Some(tasks) = self.env.tasks.upgrade() {
             // negative means drop it
             tasks
                 .awake_wakers
@@ -38,7 +38,7 @@ impl Drop for WakerData {
 
 impl WakerData {
     fn wake_by_ref(&self) {
-        if let Some(tasks) = self.env.awake_tasks.upgrade() {
+        if let Some(tasks) = self.env.tasks.upgrade() {
             tasks.push_task(self.env.this_task);
             tasks
                 .awake_wakers
@@ -105,7 +105,7 @@ where
 {
     TLS_TASK_ENV.with(|tls_task_env| {
         *tls_task_env.borrow_mut() = Some(TaskEnv {
-            awake_tasks: Arc::downgrade(&awake_tasks),
+            tasks: Arc::downgrade(&awake_tasks),
             this_task: task_id,
         });
     });

--- a/crates/pink/sidevm/host-runtime/src/async_context.rs
+++ b/crates/pink/sidevm/host-runtime/src/async_context.rs
@@ -17,22 +17,40 @@ struct TaskEnv {
     this_task: i32,
 }
 
-#[derive(Clone)]
 struct WakerData {
     env: TaskEnv,
     parent: Waker,
+    guest_waker_id: i32,
+}
+
+impl Drop for WakerData {
+    fn drop(&mut self) {
+        if let Some(tasks) = self.env.awake_tasks.upgrade() {
+            // negative means drop it
+            tasks
+                .awake_wakers
+                .lock()
+                .unwrap()
+                .push_back(-1 - self.guest_waker_id);
+        }
+    }
 }
 
 impl WakerData {
     fn wake_by_ref(&self) {
         if let Some(tasks) = self.env.awake_tasks.upgrade() {
-            tasks.push(self.env.this_task);
+            tasks.push_task(self.env.this_task);
+            tasks
+                .awake_wakers
+                .lock()
+                .unwrap()
+                .push_back(self.guest_waker_id);
         }
         self.parent.wake_by_ref();
     }
 }
 
-fn relay_waker(env: &TaskEnv, parent: &Waker) -> Waker {
+fn relay_waker(env: &TaskEnv, parent: &Waker, guest_waker_id: i32) -> Waker {
     fn raw_waker_from_data(data: Arc<WakerData>) -> RawWaker {
         let vtable = &RawWakerVTable::new(clone_waker, wake_waker, wake_by_ref_waker, drop_waker);
         RawWaker::new(Arc::into_raw(data) as *const (), vtable)
@@ -62,10 +80,10 @@ fn relay_waker(env: &TaskEnv, parent: &Waker) -> Waker {
             drop(Arc::from_raw(data as *const WakerData));
         }
     }
-
     let data = Arc::new(WakerData {
         env: env.clone(),
         parent: parent.clone(),
+        guest_waker_id,
     });
 
     unsafe { Waker::from_raw(raw_waker_from_data(data)) }
@@ -133,7 +151,7 @@ where
 ///
 /// Panics if no task has been set or if the task context has already been
 /// retrived by a surrounding call to get_task_cx.
-pub(crate) fn get_task_cx<F, R>(f: F) -> R
+pub(crate) fn get_task_cx<F, R>(guest_waker_id: i32, f: F) -> R
 where
     F: FnOnce(&mut task::Context) -> R,
 {
@@ -152,16 +170,19 @@ where
             .as_ref()
             .expect("TLS TaskEnv not set. This is a bug.");
         let parent = cx_ptr.as_mut().waker();
-        let waker = relay_waker(env, parent);
+        let waker = relay_waker(env, parent, guest_waker_id);
         let mut cx = task::Context::from_waker(&waker);
         f(&mut cx)
     })
 }
 
 /// Polls a future in the current thread-local task context.
-pub(crate) fn poll_in_task_cx<F: ?Sized>(f: Pin<&mut F>) -> task::Poll<F::Output>
+pub(crate) fn poll_in_task_cx<F: ?Sized>(
+    guest_waker_id: i32,
+    f: Pin<&mut F>,
+) -> task::Poll<F::Output>
 where
     F: Future,
 {
-    get_task_cx(|cx| f.poll(cx))
+    get_task_cx(guest_waker_id, |cx| f.poll(cx))
 }

--- a/crates/pink/sidevm/host-runtime/src/env.rs
+++ b/crates/pink/sidevm/host-runtime/src/env.rs
@@ -68,6 +68,7 @@ pub fn create_env(id: VmId, store: &Store, cache_ops: DynCacheOps) -> (Env, Impo
 
 pub(crate) struct TaskSet {
     awake_tasks: dashmap::DashSet<i32>,
+    /// Guest waker ids that are ready to be woken up, or to be dropped if negative.
     pub(crate) awake_wakers: Mutex<VecDeque<i32>>,
 }
 

--- a/crates/pink/sidevm/host-runtime/src/env.rs
+++ b/crates/pink/sidevm/host-runtime/src/env.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::Cell,
+    collections::VecDeque,
     fmt,
     sync::{Arc, Mutex},
     task::Poll::{Pending, Ready},
@@ -66,25 +67,29 @@ pub fn create_env(id: VmId, store: &Store, cache_ops: DynCacheOps) -> (Env, Impo
 }
 
 pub(crate) struct TaskSet {
-    tasks: dashmap::DashSet<i32>,
+    awaked_tasks: dashmap::DashSet<i32>,
+    pub(crate) awake_wakers: Mutex<VecDeque<i32>>,
 }
 
 impl TaskSet {
     fn with_task0() -> Self {
-        let tasks = dashmap::DashSet::new();
-        tasks.insert(0);
-        Self { tasks }
+        let awaked_tasks = dashmap::DashSet::new();
+        awaked_tasks.insert(0);
+        Self {
+            awaked_tasks,
+            awake_wakers: Default::default(),
+        }
     }
 
-    pub(crate) fn push(&self, task_id: i32) {
-        self.tasks.insert(task_id);
+    pub(crate) fn push_task(&self, task_id: i32) {
+        self.awaked_tasks.insert(task_id);
     }
 
-    pub(crate) fn pop(&self) -> Option<i32> {
-        let item = self.tasks.iter().next().map(|task_id| *task_id);
+    pub(crate) fn pop_task(&self) -> Option<i32> {
+        let item = self.awaked_tasks.iter().next().map(|task_id| *task_id);
         match item {
             Some(task_id) => {
-                self.tasks.remove(&task_id);
+                self.awaked_tasks.remove(&task_id);
                 Some(task_id)
             }
             None => None,
@@ -242,34 +247,38 @@ impl env::OcallFuncs for State {
         }
     }
 
-    fn poll(&mut self, resource_id: i32) -> Result<Vec<u8>> {
-        self.resources.get_mut(resource_id)?.poll()
+    fn poll(&mut self, waker_id: i32, resource_id: i32) -> Result<Vec<u8>> {
+        self.resources.get_mut(resource_id)?.poll(waker_id)
     }
 
-    fn poll_read(&mut self, resource_id: i32, data: &mut [u8]) -> Result<u32> {
-        self.resources.get_mut(resource_id)?.poll_read(data)
+    fn poll_read(&mut self, waker_id: i32, resource_id: i32, data: &mut [u8]) -> Result<u32> {
+        self.resources
+            .get_mut(resource_id)?
+            .poll_read(waker_id, data)
     }
 
-    fn poll_write(&mut self, resource_id: i32, data: &[u8]) -> Result<u32> {
-        self.resources.get_mut(resource_id)?.poll_write(data)
+    fn poll_write(&mut self, waker_id: i32, resource_id: i32, data: &[u8]) -> Result<u32> {
+        self.resources
+            .get_mut(resource_id)?
+            .poll_write(waker_id, data)
     }
 
-    fn poll_shutdown(&mut self, resource_id: i32) -> Result<()> {
-        self.resources.get_mut(resource_id)?.poll_shutdown()
+    fn poll_shutdown(&mut self, waker_id: i32, resource_id: i32) -> Result<()> {
+        self.resources.get_mut(resource_id)?.poll_shutdown(waker_id)
     }
 
-    fn poll_res(&mut self, resource_id: i32) -> Result<i32> {
-        let res = self.resources.get_mut(resource_id)?.poll_res()?;
+    fn poll_res(&mut self, waker_id: i32, resource_id: i32) -> Result<i32> {
+        let res = self.resources.get_mut(resource_id)?.poll_res(waker_id)?;
         self.resources.push(res)
     }
 
     fn mark_task_ready(&mut self, task_id: i32) -> Result<()> {
-        self.awake_tasks.push(task_id);
+        self.awake_tasks.push_task(task_id);
         Ok(())
     }
 
     fn next_ready_task(&mut self) -> Result<i32> {
-        self.awake_tasks.pop().ok_or(OcallError::NotFound)
+        self.awake_tasks.pop_task().ok_or(OcallError::NotFound)
     }
 
     fn create_timer(&mut self, timeout: i32) -> Result<i32> {
@@ -291,14 +300,14 @@ impl env::OcallFuncs for State {
         self.resources.push(Resource::TcpListener(listener))
     }
 
-    fn tcp_accept(&mut self, tcp_res_id: i32) -> Result<i32> {
+    fn tcp_accept(&mut self, waker_id: i32, tcp_res_id: i32) -> Result<i32> {
         let (stream, _remote_addr) = {
             let res = self.resources.get_mut(tcp_res_id)?;
             let listener = match res {
                 Resource::TcpListener(listener) => listener,
                 _ => return Err(OcallError::UnsupportedOperation),
             };
-            match get_task_cx(|ct| listener.poll_accept(ct)) {
+            match get_task_cx(waker_id, |ct| listener.poll_accept(ct)) {
                 Pending => return Err(OcallError::Pending),
                 Ready(result) => result.or(Err(OcallError::IoError))?,
             }
@@ -332,6 +341,16 @@ impl env::OcallFuncs for State {
 
     fn local_cache_remove(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         self.cache_ops.remove(&self.id[..], key)
+    }
+
+    fn awake_wakers(&mut self) -> Result<Vec<i32>> {
+        Ok(self
+            .awake_tasks
+            .awake_wakers
+            .lock()
+            .unwrap()
+            .drain(..)
+            .collect())
     }
 }
 

--- a/crates/pink/sidevm/host-runtime/src/env.rs
+++ b/crates/pink/sidevm/host-runtime/src/env.rs
@@ -67,29 +67,29 @@ pub fn create_env(id: VmId, store: &Store, cache_ops: DynCacheOps) -> (Env, Impo
 }
 
 pub(crate) struct TaskSet {
-    awaked_tasks: dashmap::DashSet<i32>,
+    awake_tasks: dashmap::DashSet<i32>,
     pub(crate) awake_wakers: Mutex<VecDeque<i32>>,
 }
 
 impl TaskSet {
     fn with_task0() -> Self {
-        let awaked_tasks = dashmap::DashSet::new();
-        awaked_tasks.insert(0);
+        let awake_tasks = dashmap::DashSet::new();
+        awake_tasks.insert(0);
         Self {
-            awaked_tasks,
+            awake_tasks,
             awake_wakers: Default::default(),
         }
     }
 
     pub(crate) fn push_task(&self, task_id: i32) {
-        self.awaked_tasks.insert(task_id);
+        self.awake_tasks.insert(task_id);
     }
 
     pub(crate) fn pop_task(&self) -> Option<i32> {
-        let item = self.awaked_tasks.iter().next().map(|task_id| *task_id);
+        let item = self.awake_tasks.iter().next().map(|task_id| *task_id);
         match item {
             Some(task_id) => {
-                self.awaked_tasks.remove(&task_id);
+                self.awake_tasks.remove(&task_id);
                 Some(task_id)
             }
             None => None,

--- a/crates/pink/sidevm/logger/Cargo.toml
+++ b/crates/pink/sidevm/logger/Cargo.toml
@@ -1,4 +1,7 @@
 [package]
+description = "A logger works in sidevm guest program"
+homepage = "https://github.com/Phala-Network/phala-blockchain"
+license = "Apache-2.0"
 edition = "2021"
 name = "pink-sidevm-logger"
 version = "0.1.0"

--- a/crates/pink/sidevm/macro/Cargo.toml
+++ b/crates/pink/sidevm/macro/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 description = "Macros for writing fat contract sidevm program"
+homepage = "https://github.com/Phala-Network/phala-blockchain"
+license = "Apache-2.0"
 edition = "2021"
 keywords = ["fat-contract", "pink", "ink", "sidevm"]
-license = "Apache-2.0"
 name = "pink-sidevm-macro"
 version = "0.1.0"
 

--- a/crates/pink/sidevm/sidevm/Cargo.toml
+++ b/crates/pink/sidevm/sidevm/Cargo.toml
@@ -1,12 +1,21 @@
 [package]
+description = "Framework to help developing phala sidevm program"
+license = "Apache-2.0"
+homepage = "https://github.com/Phala-Network/phala-blockchain"
 edition = "2021"
 name = "pink-sidevm"
-version = "0.1.0"
+version = "0.1.3"
 
 [dependencies]
-hyper = {version = "0.14.18", features = ["server"]}
-pink-sidevm-env = {version = "0.1.0", path = "../env"}
-pink-sidevm-logger = {version = "0.1.0", path = "../logger"}
-pink-sidevm-macro = {version = "0.1.0", path = "../macro"}
-tokio = {version = "1"}
+pink-sidevm-env = { version = "0.1.1", path = "../env" }
+pink-sidevm-logger = { version = "0.1.0", path = "../logger" }
+pink-sidevm-macro = { version = "0.1.0", path = "../macro" }
 log = "0.4.16"
+derive_more = "0.99"
+
+hyper = { version = "0.14.18", features = ["server"], optional = true }
+tokio = { version = "1", optional = true }
+futures = "0.3"
+
+[features]
+default = ["hyper", "tokio"]

--- a/crates/pink/sidevm/sidevm/src/channel.rs
+++ b/crates/pink/sidevm/sidevm/src/channel.rs
@@ -31,9 +31,10 @@ impl Receiver {
 impl Future for RxNext<'_> {
     type Output = Option<Vec<u8>>;
 
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         use crate::env::OcallError;
-        match ocall::poll(self.ch.res_id.0) {
+        let waker_id = crate::env::tasks::intern_waker(cx.waker().clone());
+        match ocall::poll(waker_id, self.ch.res_id.0) {
             Ok(msg) => Poll::Ready(Some(msg)),
             Err(OcallError::EndOfFile) => Poll::Ready(None), // tx dropped
             Err(OcallError::Pending) => Poll::Pending,

--- a/crates/pink/sidevm/sidevm/src/lib.rs
+++ b/crates/pink/sidevm/sidevm/src/lib.rs
@@ -10,6 +10,7 @@ pub use pink_sidevm_macro::main;
 pub use res_id::ResourceId;
 
 pub use env::spawn;
+pub use env::tasks as task;
 
 pub mod channel;
 pub mod time;

--- a/crates/pink/sidevm/sidevm/src/net.rs
+++ b/crates/pink/sidevm/sidevm/src/net.rs
@@ -5,9 +5,6 @@ use std::io::Error;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use hyper::server::accept::Accept;
-use tokio::io::{AsyncRead, AsyncWrite};
-
 use crate::env::{self, tasks, Result};
 use crate::{ocall, ResourceId};
 
@@ -47,8 +44,8 @@ impl Future for Acceptor<'_> {
 }
 
 impl TcpListener {
-    /// Listen on the specified address for incoming TCP connections.
-    pub async fn listen(addr: &str) -> Result<Self> {
+    /// Bind and listen on the specified address for incoming TCP connections.
+    pub async fn bind(addr: &str) -> Result<Self> {
         // Side notes: could be used to probe enabled interfaces and occupied ports. We may
         // consider to introduce some manifest file to further limit the capability in the future
         let todo = "prevent local interface probing and port occupation";
@@ -59,81 +56,6 @@ impl TcpListener {
     /// Accept a new incoming connection.
     pub async fn accept(&self) -> Result<TcpStream> {
         Acceptor { listener: self }.await
-    }
-}
-
-impl Accept for TcpListener {
-    type Conn = TcpStream;
-
-    type Error = env::OcallError;
-
-    fn poll_accept(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
-        let mut accept = Acceptor {
-            listener: self.get_mut(),
-        };
-        let x = Pin::new(&mut accept).poll(cx).map(Some);
-        log::info!("Poll accept = {:?}", x);
-        x
-    }
-}
-
-impl AsyncRead for TcpStream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        let result = {
-            let size = buf.remaining().min(512);
-            let buf = buf.initialize_unfilled_to(size);
-            let waker_id = tasks::intern_waker(cx.waker().clone());
-            ocall::poll_read(waker_id, self.res_id.0, buf)
-        };
-        use env::OcallError;
-        match result {
-            Ok(len) => {
-                let len = len as usize;
-                if len > buf.remaining() {
-                    Poll::Ready(Err(Error::from_raw_os_error(
-                        env::OcallError::InvalidEncoding as i32,
-                    )))
-                } else {
-                    buf.advance(len);
-                    Poll::Ready(Ok(()))
-                }
-            }
-            Err(OcallError::Pending) => Poll::Pending,
-            Err(err) => Poll::Ready(Err(Error::from_raw_os_error(err as i32))),
-        }
-    }
-}
-
-impl AsyncWrite for TcpStream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, Error>> {
-        match ocall::poll_write(tasks::intern_waker(cx.waker().clone()), self.res_id.0, buf) {
-            Ok(len) => Poll::Ready(Ok(len as _)),
-            Err(env::OcallError::Pending) => Poll::Pending,
-            Err(err) => Poll::Ready(Err(Error::from_raw_os_error(err as i32))),
-        }
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
-        match ocall::poll_shutdown(tasks::intern_waker(cx.waker().clone()), self.res_id.0) {
-            Ok(()) => Poll::Ready(Ok(())),
-            Err(env::OcallError::Pending) => Poll::Pending,
-            Err(err) => Poll::Ready(Err(Error::from_raw_os_error(err as i32))),
-        }
     }
 }
 
@@ -161,5 +83,130 @@ impl TcpStream {
         let todo = "prevent local network probing";
         let res_id = ResourceId(ocall::tcp_connect(addr.into())?);
         TcpConnector { res_id }.await
+    }
+}
+
+#[cfg(feature = "hyper")]
+mod impl_hyper {
+    use super::*;
+    use hyper::server::accept::Accept;
+
+    impl Accept for TcpListener {
+        type Conn = TcpStream;
+
+        type Error = env::OcallError;
+
+        fn poll_accept(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+            let mut accept = Acceptor {
+                listener: self.get_mut(),
+            };
+            let x = Pin::new(&mut accept).poll(cx).map(Some);
+            log::info!("Poll accept = {:?}", x);
+            x
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+mod impl_tokio {
+    use super::*;
+    use tokio::io::{AsyncRead, AsyncWrite};
+
+    impl AsyncRead for TcpStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            let result = {
+                let size = buf.remaining().min(512);
+                let buf = buf.initialize_unfilled_to(size);
+                let waker_id = tasks::intern_waker(cx.waker().clone());
+                ocall::poll_read(waker_id, self.res_id.0, buf)
+            };
+            use env::OcallError;
+            match result {
+                Ok(len) => {
+                    let len = len as usize;
+                    if len > buf.remaining() {
+                        Poll::Ready(Err(Error::from_raw_os_error(
+                            env::OcallError::InvalidEncoding as i32,
+                        )))
+                    } else {
+                        buf.advance(len);
+                        Poll::Ready(Ok(()))
+                    }
+                }
+                Err(OcallError::Pending) => Poll::Pending,
+                Err(err) => Poll::Ready(Err(Error::from_raw_os_error(err as i32))),
+            }
+        }
+    }
+
+    impl AsyncWrite for TcpStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, Error>> {
+            let waker_id = tasks::intern_waker(cx.waker().clone());
+            into_poll(ocall::poll_write(waker_id, self.res_id.0, buf).map(|len| len as usize))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+            let waker_id = tasks::intern_waker(cx.waker().clone());
+            into_poll(ocall::poll_shutdown(waker_id, self.res_id.0))
+        }
+    }
+}
+
+mod impl_futures_io {
+    use super::*;
+    use futures::io::{AsyncRead, AsyncWrite};
+
+    impl AsyncRead for TcpStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<std::io::Result<usize>> {
+            let waker_id = tasks::intern_waker(cx.waker().clone());
+            into_poll(ocall::poll_read(waker_id, self.res_id.0, buf).map(|len| len as usize))
+        }
+    }
+
+    impl AsyncWrite for TcpStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            let waker_id = tasks::intern_waker(cx.waker().clone());
+            into_poll(ocall::poll_write(waker_id, self.res_id.0, buf).map(|len| len as usize))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            let waker_id = tasks::intern_waker(cx.waker().clone());
+            into_poll(ocall::poll_shutdown(waker_id, self.res_id.0))
+        }
+    }
+}
+
+fn into_poll<T>(res: Result<T, env::OcallError>) -> Poll<std::io::Result<T>> {
+    match res {
+        Ok(v) => Poll::Ready(Ok(v)),
+        Err(env::OcallError::Pending) => Poll::Pending,
+        Err(err) => Poll::Ready(Err(std::io::Error::from_raw_os_error(err as i32))),
     }
 }

--- a/crates/pink/sidevm/sidevm/src/time.rs
+++ b/crates/pink/sidevm/sidevm/src/time.rs
@@ -29,9 +29,10 @@ pub fn sleep(duration: Duration) -> Sleep {
 impl Future for Sleep {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         use env::OcallError;
-        let rv = ocall::poll_read(self.id.0, &mut []);
+        let waker_id = env::tasks::intern_waker(cx.waker().clone());
+        let rv = ocall::poll_read(waker_id, self.id.0, &mut []);
         match rv {
             Ok(_) => Poll::Ready(()),
             Err(OcallError::Pending) => Poll::Pending,

--- a/crates/rustfmt-snippet/Cargo.toml
+++ b/crates/rustfmt-snippet/Cargo.toml
@@ -1,4 +1,7 @@
 [package]
+description = "Format given Rust code snippet with rustfmt"
+homepage = "https://github.com/Phala-Network/phala-blockchain"
+license = "Apache-2.0"
 name = "rustfmt-snippet"
 version = "0.1.0"
 edition = "2018"


### PR DESCRIPTION
This enables the `futures-channel` to work in sidevm. And enables some other stuff like `FuturesUnordered` from the crate `futures`.

An `async channel` is a hard requirement for inter-task communication. There are some implementations with different requirements in the ecosystem:
- tokio-channel: depends on the tokio runtime which can not be used in sidevm.
- futures-channel: uses the Waker from the poll Context.
- async-channel(from the async-std team): I haven't looked into it yet. But it must at least require access to the Waker.
