### PR TITLE
Sidevm improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7730,6 +7730,7 @@ dependencies = [
 name = "pink-sidevm"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "hyper",
  "log",
  "pink-sidevm-env",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7728,7 +7728,7 @@ dependencies = [
 
 [[package]]
 name = "pink-sidevm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures",
  "hyper",
@@ -7741,10 +7741,11 @@ dependencies = [
 
 [[package]]
 name = "pink-sidevm-env"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cfg-if",
  "derive_more",
+ "futures",
  "log",
  "num_enum",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7728,8 +7728,9 @@ dependencies = [
 
 [[package]]
 name = "pink-sidevm"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
+ "derive_more",
  "futures",
  "hyper",
  "log",

--- a/crates/pink/examples/start_sidevm/sideprog/Cargo.toml
+++ b/crates/pink/examples/start_sidevm/sideprog/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4.16"
 once_cell = "1.10.0"
-pink-sidevm = {path = "../../../sidevm/sidevm"}
+pink-sidevm = {version = "0.1", path = "../../../sidevm/sidevm"}
 tokio = {version = "1", features = ["macros"]}
 futures = "0.3"

--- a/crates/pink/examples/start_sidevm/sideprog/Cargo.toml
+++ b/crates/pink/examples/start_sidevm/sideprog/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 log = "0.4.16"
 once_cell = "1.10.0"
 pink-sidevm = {path = "../../../sidevm/sidevm"}
-tokio = {version = "1", features = ["macros", "io-util"]}
+tokio = {version = "1", features = ["macros"]}
 futures = "0.3"

--- a/crates/pink/examples/start_sidevm/sideprog/src/lib.rs
+++ b/crates/pink/examples/start_sidevm/sideprog/src/lib.rs
@@ -1,7 +1,7 @@
 use log::info;
 use pink_sidevm as sidevm;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[sidevm::main]
 async fn main() {

--- a/crates/pink/examples/start_sidevm/sideprog/src/lib.rs
+++ b/crates/pink/examples/start_sidevm/sideprog/src/lib.rs
@@ -12,7 +12,7 @@ async fn main() {
 
     info!("Listening on {}", address);
 
-    let listener = sidevm::net::TcpListener::listen(address).await.unwrap();
+    let listener = sidevm::net::TcpListener::bind(address).await.unwrap();
 
     loop {
         info!("Waiting for incomming connection or message...");

--- a/crates/pink/sidevm/env/Cargo.toml
+++ b/crates/pink/sidevm/env/Cargo.toml
@@ -12,6 +12,7 @@ num_enum = "0.5.7"
 scale = {package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "std"]}
 tinyvec = {version = "1.5.1", features = ["alloc"]}
 log = "0.4.16"
+futures = "0.3"
 
 [features]
 host = []

--- a/crates/pink/sidevm/env/Cargo.toml
+++ b/crates/pink/sidevm/env/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
+description = "The low level protocol between sidevm guest and host"
+homepage = "https://github.com/Phala-Network/phala-blockchain"
+license = "Apache-2.0"
 edition = "2021"
 name = "pink-sidevm-env"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 pink-sidevm-macro = {path = "../macro", version = "0.1.0"}

--- a/crates/pink/sidevm/env/src/lib.rs
+++ b/crates/pink/sidevm/env/src/lib.rs
@@ -18,7 +18,7 @@ use tinyvec::TinyVec;
 pub use args_stack::RetEncode;
 pub use ocall_def::*;
 pub use pink_sidevm_macro::main;
-pub use tasks::{spawn, TaskHandle};
+pub use tasks::spawn;
 
 mod args_stack;
 mod ocall_def;

--- a/crates/pink/sidevm/examples/host/Cargo.toml
+++ b/crates/pink/sidevm/examples/host/Cargo.toml
@@ -7,9 +7,11 @@ name = "sidevm-host"
 version = "0.1.0"
 
 [dependencies]
-pink-sidevm-host-runtime = {path = "../../host-runtime"}
-tokio = {version = "1.17.0", features = ["full"]}
+pink-sidevm-host-runtime = { path = "../../host-runtime", features = [
+    "wasmer-compiler-cranelift",
+] }
+tokio = { version = "1.17.0", features = ["full"] }
 env_logger = "0.9.0"
 anyhow = "1.0.56"
-clap = {version = "3", features = ["derive"]}
+clap = { version = "3", features = ["derive"] }
 once_cell = "1"

--- a/crates/pink/sidevm/examples/host/src/main.rs
+++ b/crates/pink/sidevm/examples/host/src/main.rs
@@ -16,6 +16,9 @@ pub struct Args {
     /// The gas limit for each poll.
     #[clap(long, default_value_t = 1000_000_000_000_u128)]
     gas_per_breath: u128,
+    /// Don't instrument the program.
+    #[clap(long)]
+    no_instrument: bool,
     /// The WASM program to run
     program: String,
 }
@@ -70,9 +73,11 @@ async fn main() -> anyhow::Result<()> {
     });
 
     println!("Reading {}...", args.program);
-    let wasm_bytes = std::fs::read(&args.program)?;
-    println!("Instrumenting...");
-    let wasm_bytes = instrument::instrument(&wasm_bytes)?;
+    let mut wasm_bytes = std::fs::read(&args.program)?;
+    if !args.no_instrument {
+        println!("Instrumenting...");
+        wasm_bytes = instrument::instrument(&wasm_bytes)?;
+    }
     println!("VM running...");
     let (_sender, handle) = spawner
         .start(

--- a/crates/pink/sidevm/examples/httpserver/Cargo.toml
+++ b/crates/pink/sidevm/examples/httpserver/Cargo.toml
@@ -13,5 +13,4 @@ crate-type = ["cdylib"]
 log = "0.4.16"
 once_cell = "1.10.0"
 pink-sidevm = {path = "../../sidevm"}
-tokio = {version = "1", features = ["macros", "io-util"]}
 futures = "0.3"

--- a/crates/pink/sidevm/examples/httpserver/src/lib.rs
+++ b/crates/pink/sidevm/examples/httpserver/src/lib.rs
@@ -1,7 +1,7 @@
 use log::info;
 use pink_sidevm as sidevm;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[sidevm::main]
 async fn main() {

--- a/crates/pink/sidevm/examples/httpserver/src/lib.rs
+++ b/crates/pink/sidevm/examples/httpserver/src/lib.rs
@@ -12,7 +12,7 @@ async fn main() {
 
     info!("Listening on {}", address);
 
-    let listener = sidevm::net::TcpListener::listen(address).await.unwrap();
+    let listener = sidevm::net::TcpListener::bind(address).await.unwrap();
 
     loop {
         info!("Waiting for imcomming connection...");

--- a/crates/pink/sidevm/examples/tcpclient/Cargo.lock
+++ b/crates/pink/sidevm/examples/tcpclient/Cargo.lock
@@ -321,6 +321,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pink-sidevm"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "hyper",
  "log",
  "pink-sidevm-env",
@@ -422,7 +423,6 @@ dependencies = [
  "futures",
  "log",
  "pink-sidevm",
- "tokio",
 ]
 
 [[package]]
@@ -489,21 +489,7 @@ version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
- "bytes",
- "memchr",
  "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/crates/pink/sidevm/examples/tcpclient/Cargo.toml
+++ b/crates/pink/sidevm/examples/tcpclient/Cargo.toml
@@ -12,5 +12,4 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4.16"
 pink-sidevm = {path = "../../sidevm"}
-tokio = {version = "1", features = ["macros", "io-util"]}
 futures = "0.3"

--- a/crates/pink/sidevm/examples/tcpclient/src/lib.rs
+++ b/crates/pink/sidevm/examples/tcpclient/src/lib.rs
@@ -1,7 +1,7 @@
 use log::info;
 use pink_sidevm as sidevm;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[sidevm::main]
 async fn main() {

--- a/crates/pink/sidevm/host-runtime/Cargo.toml
+++ b/crates/pink/sidevm/host-runtime/Cargo.toml
@@ -15,6 +15,8 @@ thread_local = "1.1"
 tokio = {version = "1.17.0", features = ["full"]}
 wasmer = "2.2.1"
 wasmer-compiler-singlepass = "2.2.1"
+wasmer-compiler-cranelift = { version = "2.2.1", optional = true }
+wasmer-compiler-llvm = { version = "2.2.1", optional = true }
 wasmer-engine = "2.2.1"
 wasmer-engine-universal = "2.2.1"
 wasmer-tunables = {path = "../../../wasmer-tunables"}

--- a/crates/pink/sidevm/logger/Cargo.toml
+++ b/crates/pink/sidevm/logger/Cargo.toml
@@ -1,4 +1,7 @@
 [package]
+description = "A logger works in sidevm guest program"
+homepage = "https://github.com/Phala-Network/phala-blockchain"
+license = "Apache-2.0"
 edition = "2021"
 name = "pink-sidevm-logger"
 version = "0.1.0"

--- a/crates/pink/sidevm/macro/Cargo.toml
+++ b/crates/pink/sidevm/macro/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 description = "Macros for writing fat contract sidevm program"
+homepage = "https://github.com/Phala-Network/phala-blockchain"
+license = "Apache-2.0"
 edition = "2021"
 keywords = ["fat-contract", "pink", "ink", "sidevm"]
-license = "Apache-2.0"
 name = "pink-sidevm-macro"
 version = "0.1.0"
 

--- a/crates/pink/sidevm/sidevm/Cargo.toml
+++ b/crates/pink/sidevm/sidevm/Cargo.toml
@@ -4,9 +4,14 @@ name = "pink-sidevm"
 version = "0.1.0"
 
 [dependencies]
-hyper = {version = "0.14.18", features = ["server"]}
 pink-sidevm-env = {version = "0.1.0", path = "../env"}
 pink-sidevm-logger = {version = "0.1.0", path = "../logger"}
 pink-sidevm-macro = {version = "0.1.0", path = "../macro"}
-tokio = {version = "1"}
 log = "0.4.16"
+
+hyper = {version = "0.14.18", features = ["server"], optional = true}
+tokio = {version = "1", optional = true}
+futures = {version = "0.3", optional = true}
+
+[features]
+default = ["hyper", "tokio", "futures"]

--- a/crates/pink/sidevm/sidevm/Cargo.toml
+++ b/crates/pink/sidevm/sidevm/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
+description = "Framework to help developing phala sidevm program"
+license = "Apache-2.0"
+homepage = "https://github.com/Phala-Network/phala-blockchain"
 edition = "2021"
 name = "pink-sidevm"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
-pink-sidevm-env = {version = "0.1.0", path = "../env"}
+pink-sidevm-env = {version = "0.1.1", path = "../env"}
 pink-sidevm-logger = {version = "0.1.0", path = "../logger"}
 pink-sidevm-macro = {version = "0.1.0", path = "../macro"}
 log = "0.4.16"

--- a/crates/pink/sidevm/sidevm/Cargo.toml
+++ b/crates/pink/sidevm/sidevm/Cargo.toml
@@ -7,14 +7,15 @@ name = "pink-sidevm"
 version = "0.1.1"
 
 [dependencies]
-pink-sidevm-env = {version = "0.1.1", path = "../env"}
-pink-sidevm-logger = {version = "0.1.0", path = "../logger"}
-pink-sidevm-macro = {version = "0.1.0", path = "../macro"}
+pink-sidevm-env = { version = "0.1.1", path = "../env" }
+pink-sidevm-logger = { version = "0.1.0", path = "../logger" }
+pink-sidevm-macro = { version = "0.1.0", path = "../macro" }
 log = "0.4.16"
+derive_more = "0.99"
 
-hyper = {version = "0.14.18", features = ["server"], optional = true}
-tokio = {version = "1", optional = true}
-futures = {version = "0.3", optional = true}
+hyper = { version = "0.14.18", features = ["server"], optional = true }
+tokio = { version = "1", optional = true }
+futures = "0.3"
 
 [features]
-default = ["hyper", "tokio", "futures"]
+default = ["hyper", "tokio"]

--- a/crates/pink/sidevm/sidevm/Cargo.toml
+++ b/crates/pink/sidevm/sidevm/Cargo.toml
@@ -4,7 +4,7 @@ license = "Apache-2.0"
 homepage = "https://github.com/Phala-Network/phala-blockchain"
 edition = "2021"
 name = "pink-sidevm"
-version = "0.1.2"
+version = "0.1.3"
 
 [dependencies]
 pink-sidevm-env = { version = "0.1.1", path = "../env" }

--- a/crates/pink/sidevm/sidevm/Cargo.toml
+++ b/crates/pink/sidevm/sidevm/Cargo.toml
@@ -4,7 +4,7 @@ license = "Apache-2.0"
 homepage = "https://github.com/Phala-Network/phala-blockchain"
 edition = "2021"
 name = "pink-sidevm"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 pink-sidevm-env = { version = "0.1.1", path = "../env" }

--- a/crates/pink/sidevm/sidevm/src/lib.rs
+++ b/crates/pink/sidevm/sidevm/src/lib.rs
@@ -10,6 +10,7 @@ pub use pink_sidevm_macro::main;
 pub use res_id::ResourceId;
 
 pub use env::spawn;
+pub use env::tasks as task;
 
 pub mod channel;
 pub mod time;

--- a/crates/pink/sidevm/sidevm/src/net.rs
+++ b/crates/pink/sidevm/sidevm/src/net.rs
@@ -167,7 +167,6 @@ mod impl_tokio {
     }
 }
 
-#[cfg(feature = "futures")]
 mod impl_futures_io {
     use super::*;
     use futures::io::{AsyncRead, AsyncWrite};

--- a/crates/pink/sidevm/sidevm/src/net.rs
+++ b/crates/pink/sidevm/sidevm/src/net.rs
@@ -44,8 +44,8 @@ impl Future for Acceptor<'_> {
 }
 
 impl TcpListener {
-    /// Listen on the specified address for incoming TCP connections.
-    pub async fn listen(addr: &str) -> Result<Self> {
+    /// Bind and listen on the specified address for incoming TCP connections.
+    pub async fn bind(addr: &str) -> Result<Self> {
         // Side notes: could be used to probe enabled interfaces and occupied ports. We may
         // consider to introduce some manifest file to further limit the capability in the future
         let todo = "prevent local interface probing and port occupation";

--- a/crates/pink/sidevm/sidevm/src/net.rs
+++ b/crates/pink/sidevm/sidevm/src/net.rs
@@ -5,9 +5,6 @@ use std::io::Error;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use hyper::server::accept::Accept;
-use tokio::io::{AsyncRead, AsyncWrite};
-
 use crate::env::{self, tasks, Result};
 use crate::{ocall, ResourceId};
 
@@ -62,81 +59,6 @@ impl TcpListener {
     }
 }
 
-impl Accept for TcpListener {
-    type Conn = TcpStream;
-
-    type Error = env::OcallError;
-
-    fn poll_accept(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
-        let mut accept = Acceptor {
-            listener: self.get_mut(),
-        };
-        let x = Pin::new(&mut accept).poll(cx).map(Some);
-        log::info!("Poll accept = {:?}", x);
-        x
-    }
-}
-
-impl AsyncRead for TcpStream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        let result = {
-            let size = buf.remaining().min(512);
-            let buf = buf.initialize_unfilled_to(size);
-            let waker_id = tasks::intern_waker(cx.waker().clone());
-            ocall::poll_read(waker_id, self.res_id.0, buf)
-        };
-        use env::OcallError;
-        match result {
-            Ok(len) => {
-                let len = len as usize;
-                if len > buf.remaining() {
-                    Poll::Ready(Err(Error::from_raw_os_error(
-                        env::OcallError::InvalidEncoding as i32,
-                    )))
-                } else {
-                    buf.advance(len);
-                    Poll::Ready(Ok(()))
-                }
-            }
-            Err(OcallError::Pending) => Poll::Pending,
-            Err(err) => Poll::Ready(Err(Error::from_raw_os_error(err as i32))),
-        }
-    }
-}
-
-impl AsyncWrite for TcpStream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, Error>> {
-        match ocall::poll_write(tasks::intern_waker(cx.waker().clone()), self.res_id.0, buf) {
-            Ok(len) => Poll::Ready(Ok(len as _)),
-            Err(env::OcallError::Pending) => Poll::Pending,
-            Err(err) => Poll::Ready(Err(Error::from_raw_os_error(err as i32))),
-        }
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
-        match ocall::poll_shutdown(tasks::intern_waker(cx.waker().clone()), self.res_id.0) {
-            Ok(()) => Poll::Ready(Ok(())),
-            Err(env::OcallError::Pending) => Poll::Pending,
-            Err(err) => Poll::Ready(Err(Error::from_raw_os_error(err as i32))),
-        }
-    }
-}
-
 impl Future for TcpConnector {
     type Output = Result<TcpStream>;
 
@@ -161,5 +83,131 @@ impl TcpStream {
         let todo = "prevent local network probing";
         let res_id = ResourceId(ocall::tcp_connect(addr.into())?);
         TcpConnector { res_id }.await
+    }
+}
+
+#[cfg(feature = "hyper")]
+mod impl_hyper {
+    use super::*;
+    use hyper::server::accept::Accept;
+
+    impl Accept for TcpListener {
+        type Conn = TcpStream;
+
+        type Error = env::OcallError;
+
+        fn poll_accept(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+            let mut accept = Acceptor {
+                listener: self.get_mut(),
+            };
+            let x = Pin::new(&mut accept).poll(cx).map(Some);
+            log::info!("Poll accept = {:?}", x);
+            x
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+mod impl_tokio {
+    use super::*;
+    use tokio::io::{AsyncRead, AsyncWrite};
+
+    impl AsyncRead for TcpStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            let result = {
+                let size = buf.remaining().min(512);
+                let buf = buf.initialize_unfilled_to(size);
+                let waker_id = tasks::intern_waker(cx.waker().clone());
+                ocall::poll_read(waker_id, self.res_id.0, buf)
+            };
+            use env::OcallError;
+            match result {
+                Ok(len) => {
+                    let len = len as usize;
+                    if len > buf.remaining() {
+                        Poll::Ready(Err(Error::from_raw_os_error(
+                            env::OcallError::InvalidEncoding as i32,
+                        )))
+                    } else {
+                        buf.advance(len);
+                        Poll::Ready(Ok(()))
+                    }
+                }
+                Err(OcallError::Pending) => Poll::Pending,
+                Err(err) => Poll::Ready(Err(Error::from_raw_os_error(err as i32))),
+            }
+        }
+    }
+
+    impl AsyncWrite for TcpStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, Error>> {
+            let waker_id = tasks::intern_waker(cx.waker().clone());
+            into_poll(ocall::poll_write(waker_id, self.res_id.0, buf).map(|len| len as usize))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+            let waker_id = tasks::intern_waker(cx.waker().clone());
+            into_poll(ocall::poll_shutdown(waker_id, self.res_id.0))
+        }
+    }
+}
+
+#[cfg(feature = "futures")]
+mod impl_futures_io {
+    use super::*;
+    use futures::io::{AsyncRead, AsyncWrite};
+
+    impl AsyncRead for TcpStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<std::io::Result<usize>> {
+            let waker_id = tasks::intern_waker(cx.waker().clone());
+            into_poll(ocall::poll_read(waker_id, self.res_id.0, buf).map(|len| len as usize))
+        }
+    }
+
+    impl AsyncWrite for TcpStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            let waker_id = tasks::intern_waker(cx.waker().clone());
+            into_poll(ocall::poll_write(waker_id, self.res_id.0, buf).map(|len| len as usize))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            let waker_id = tasks::intern_waker(cx.waker().clone());
+            into_poll(ocall::poll_shutdown(waker_id, self.res_id.0))
+        }
+    }
+}
+
+fn into_poll<T>(res: Result<T, env::OcallError>) -> Poll<std::io::Result<T>> {
+    match res {
+        Ok(v) => Poll::Ready(Ok(v)),
+        Err(env::OcallError::Pending) => Poll::Pending,
+        Err(err) => Poll::Ready(Err(std::io::Error::from_raw_os_error(err as i32))),
     }
 }

--- a/crates/rustfmt-snippet/Cargo.toml
+++ b/crates/rustfmt-snippet/Cargo.toml
@@ -1,4 +1,7 @@
 [package]
+description = "Format given Rust code snippet with rustfmt"
+homepage = "https://github.com/Phala-Network/phala-blockchain"
+license = "Apache-2.0"
 name = "rustfmt-snippet"
 version = "0.1.0"
 edition = "2018"


### PR DESCRIPTION
This PR implements some improvements:
- Implement `futures::io::{AsyncRead, AsyncWrite}` as well as the ones in `tokio` for `sidevm::net::TcpStream`.
   The `futures::*` is preferred because the authors always design them with `runtime-agnostic` in mind.
- Support joining on the task handle.
   We can now write things like: 

    ```rust
    let handle = sidevm::spawn(async { ... });
    let _ = handle.await;
    ```

- Add util fn `sidevm::time::timeout(future)`.
- Support instrumenting for float instructions.
- Publish crates to `crates.io`.