### PR TITLE
pruntime: Revert query to single-threaded

### DIFF
--- a/crates/phactory/src/contracts/support.rs
+++ b/crates/phactory/src/contracts/support.rs
@@ -30,10 +30,10 @@ pub struct NativeContext<'a, 'b> {
     pub self_id: ContractId,
 }
 
-pub struct QueryContext {
+pub struct QueryContext<'a> {
     pub block_number: BlockNumber,
     pub now_ms: u64,
-    pub storage: ::pink::Storage,
+    pub storage: &'a mut ::pink::Storage,
     pub sidevm_handle: Option<SidevmHandle>,
 }
 

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -528,7 +528,11 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         };
 
         // Dispatch
-        let call = self.system()?.make_query(&head.id)?;
+        let call = self.system()?.make_query(
+            &head.id,
+            accid_origin.as_ref(),
+            &data[data.len() - rest..],
+        )?;
 
         Ok(move || {
             // Encode response


### PR DESCRIPTION
This avoids cloning the whole cluster KVDB in each query.