### PR TITLE
pruntime: Use im::HashMap as trie storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,6 +2607,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethbloom"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3857,12 +3893,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.3",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
 ]
 
 [[package]]
@@ -4367,6 +4426,17 @@ name = "keccak"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+
+[[package]]
+name = "keccak-hasher"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711adba9940a039f4374fc5724c0a5eaca84a2d558cce62256bfe26f0dbef05e"
+dependencies = [
+ "hash-db",
+ "hash256-std-hasher",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "kv-log-macro"
@@ -6824,8 +6894,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c32561d248d352148124f036cac253a644685a21dc9fea383eb4907d7bd35a8f"
 dependencies = [
  "cfg-if",
+ "ethereum-types",
  "hashbrown 0.12.1",
  "impl-trait-for-tuples",
+ "lru",
  "parity-util-mem-derive",
  "parking_lot 0.12.1",
  "primitive-types",
@@ -7472,10 +7544,14 @@ dependencies = [
 name = "phala-trie-storage"
 version = "0.1.0"
 dependencies = [
+ "hash-db",
  "hash256-std-hasher",
  "hex",
+ "im",
  "impl-serde",
+ "keccak-hasher",
  "parity-scale-codec",
+ "parity-util-mem",
  "scale-info",
  "serde",
  "serde_json",
@@ -7694,6 +7770,7 @@ dependencies = [
  "sp-sandbox",
  "sp-state-machine",
  "sp-std 4.0.0",
+ "sp-trie",
  "wasmi-validation 0.3.0",
  "wat",
 ]
@@ -7957,6 +8034,7 @@ checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -8446,6 +8524,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8778,6 +8865,16 @@ name = "rlibc"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
+
+[[package]]
+name = "rlp"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
+dependencies = [
+ "bytes 1.1.0",
+ "rustc-hex",
+]
 
 [[package]]
 name = "rmp"
@@ -10619,6 +10716,16 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "slab"

--- a/crates/phala-trie-storage/Cargo.toml
+++ b/crates/phala-trie-storage/Cargo.toml
@@ -27,6 +27,7 @@ hash256-std-hasher = { version = "0.15", default-features = false }
 hex = "0.4"
 serde_json = "1.0"
 impl-serde = "0.3"
+keccak-hasher = "0.15.3"
 
 [features]
 default = ["serde"]

--- a/crates/phala-trie-storage/Cargo.toml
+++ b/crates/phala-trie-storage/Cargo.toml
@@ -16,6 +16,9 @@ sp-io   = { path = "../../substrate/primitives/io", default-features = false, fe
 sp-state-machine = { path = "../../substrate/primitives/state-machine", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
+hash-db = "0.15.2"
+im = "15"
+parity-util-mem = "0.11.0"
 
 [dev-dependencies]
 sp-runtime = { path = "../../substrate/primitives/runtime", default-features = false }

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -1,9 +1,10 @@
-#![no_std]
-
 extern crate alloc;
 
 #[cfg(feature = "serde")]
 pub mod ser;
+
+mod memdb;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -15,7 +16,10 @@ use parity_scale_codec::Codec;
 use sp_core::storage::ChildInfo;
 use sp_core::Hasher;
 use sp_state_machine::{Backend, TrieBackend};
-use sp_trie::{trie_types::TrieDBMutV0 as TrieDBMut, MemoryDB, TrieMut};
+use sp_trie::{trie_types::TrieDBMutV0 as TrieDBMut, TrieMut};
+
+pub use memdb::GenericMemoryDB as MemoryDB;
+
 
 use sp_trie::HashDBT as _;
 
@@ -31,7 +35,8 @@ pub type StorageCollection = Vec<(StorageKey, Option<StorageValue>)>;
 /// In memory arrays of storage values for multiple child tries.
 pub type ChildStorageCollection = Vec<(StorageKey, StorageCollection)>;
 
-pub struct TrieStorage<H: Hasher>(TrieBackend<MemoryDB<H>, H>);
+pub type InMemoryBackend<H> = TrieBackend<MemoryDB<H>, H>;
+pub struct TrieStorage<H: Hasher>(InMemoryBackend<H>);
 
 impl<H: Hasher> Default for TrieStorage<H>
 where

--- a/crates/phala-trie-storage/src/memdb.rs
+++ b/crates/phala-trie-storage/src/memdb.rs
@@ -265,26 +265,6 @@ where
     }
 
     /// Clear all data from the database.
-    ///
-    /// # Examples
-    /// ```rust
-    /// extern crate hash_db;
-    /// extern crate keccak_hasher;
-    /// extern crate memory_db;
-    ///
-    /// use hash_db::{Hasher, HashDB, EMPTY_PREFIX};
-    /// use keccak_hasher::KeccakHasher;
-    /// use memory_db::{MemoryDB, HashKey};
-    ///
-    /// fn main() {
-    ///   let mut m = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
-    ///   let hello_bytes = "Hello world!".as_bytes();
-    ///   let hash = m.insert(EMPTY_PREFIX, hello_bytes);
-    ///   assert!(m.contains(&hash, EMPTY_PREFIX));
-    ///   m.clear();
-    ///   assert!(!m.contains(&hash, EMPTY_PREFIX));
-    /// }
-    /// ```
     pub fn clear(&mut self) {
         self.malloc_tracker.on_clear();
         self.data.clear();
@@ -798,7 +778,7 @@ mod tests {
         }
         assert_eq!(
             malloc_size(&db),
-            crate::size_of_hash_map(&db.data)
+            super::size_of_hash_map(&db.data)
                 + malloc_size(&db.null_node_data)
                 + malloc_size(&db.hashed_null_node)
         );

--- a/crates/phala-trie-storage/src/memdb.rs
+++ b/crates/phala-trie-storage/src/memdb.rs
@@ -1,0 +1,806 @@
+//! Reference-counted memory-based `HashDB` implementation.
+use hash_db::{
+    AsHashDB, AsPlainDB, HashDB, HashDBRef, Hasher as KeyHasher, PlainDB, PlainDBRef, Prefix,
+};
+use im::{hashmap::Entry, HashMap};
+use parity_util_mem::{malloc_size, MallocSizeOf, MallocSizeOfOps};
+use std::{borrow::Borrow, cmp::Eq, hash, marker::PhantomData, mem};
+
+use sp_state_machine::{backend::Consolidate, DBValue, DefaultError, TrieBackendStorage};
+
+pub trait MaybeDebug: std::fmt::Debug {}
+impl<T: std::fmt::Debug> MaybeDebug for T {}
+
+pub type DefaultMemTracker<T> = MemCounter<T>;
+
+pub struct MemoryDB<H, KF, T, M = DefaultMemTracker<T>>
+where
+    H: KeyHasher,
+    KF: KeyFunction<H>,
+    M: MemTracker<T>,
+{
+    data: HashMap<KF::Key, (T, i32)>,
+    malloc_tracker: M,
+    hashed_null_node: H::Out,
+    null_node_data: T,
+    _kf: PhantomData<KF>,
+}
+
+impl<H, KF, T, M> Clone for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    KF: KeyFunction<H>,
+    T: Clone,
+    M: MemTracker<T> + Copy,
+{
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            hashed_null_node: self.hashed_null_node,
+            null_node_data: self.null_node_data.clone(),
+            malloc_tracker: self.malloc_tracker,
+            _kf: Default::default(),
+        }
+    }
+}
+
+impl<H, KF, T, M> PartialEq<MemoryDB<H, KF, T, M>> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    KF: KeyFunction<H>,
+    <KF as KeyFunction<H>>::Key: Eq + MaybeDebug,
+    T: Eq + MaybeDebug,
+    M: MemTracker<T> + PartialEq,
+{
+    fn eq(&self, other: &MemoryDB<H, KF, T, M>) -> bool {
+        for a in self.data.iter() {
+            match other.data.get(&a.0) {
+                Some(v) if v != a.1 => return false,
+                None => return false,
+                _ => (),
+            }
+        }
+        true
+    }
+}
+
+impl<H, KF, T, M> Eq for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    KF: KeyFunction<H>,
+    <KF as KeyFunction<H>>::Key: Eq + MaybeDebug,
+    T: Eq + MaybeDebug,
+    M: MemTracker<T> + Eq,
+{
+}
+
+pub trait KeyFunction<H: KeyHasher> {
+    type Key: Send + Sync + Clone + hash::Hash + Eq;
+
+    fn key(hash: &H::Out, prefix: Prefix) -> Self::Key;
+}
+
+/// Key function that only uses the hash
+pub struct HashKey<H>(PhantomData<H>);
+
+impl<H> Clone for HashKey<H> {
+    fn clone(&self) -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<H> core::fmt::Debug for HashKey<H> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::write!(f, "HashKey")
+    }
+}
+
+impl<H: KeyHasher> KeyFunction<H> for HashKey<H> {
+    type Key = H::Out;
+
+    fn key(hash: &H::Out, prefix: Prefix) -> H::Out {
+        hash_key::<H>(hash, prefix)
+    }
+}
+
+/// Make database key from hash only.
+pub fn hash_key<H: KeyHasher>(key: &H::Out, _prefix: Prefix) -> H::Out {
+    *key
+}
+
+/// Key function that concatenates prefix and hash.
+pub struct PrefixedKey<H>(PhantomData<H>);
+
+impl<H> Clone for PrefixedKey<H> {
+    fn clone(&self) -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<H> core::fmt::Debug for PrefixedKey<H> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::write!(f, "PrefixedKey")
+    }
+}
+
+impl<H: KeyHasher> KeyFunction<H> for PrefixedKey<H> {
+    type Key = Vec<u8>;
+
+    fn key(hash: &H::Out, prefix: Prefix) -> Vec<u8> {
+        prefixed_key::<H>(hash, prefix)
+    }
+}
+
+/// Derive a database key from hash value of the node (key) and  the node prefix.
+pub fn prefixed_key<H: KeyHasher>(key: &H::Out, prefix: Prefix) -> Vec<u8> {
+    let mut prefixed_key = Vec::with_capacity(key.as_ref().len() + prefix.0.len() + 1);
+    prefixed_key.extend_from_slice(prefix.0);
+    if let Some(last) = prefix.1 {
+        prefixed_key.push(last);
+    }
+    prefixed_key.extend_from_slice(key.as_ref());
+    prefixed_key
+}
+
+/// Key function that concatenates prefix and hash.
+/// This is doing useless computation and should only be
+/// used for legacy purpose.
+/// It shall be remove in the future.
+#[derive(Clone, Debug)]
+#[deprecated(since = "0.22.0")]
+pub struct LegacyPrefixedKey<H: KeyHasher>(PhantomData<H>);
+
+#[allow(deprecated)]
+impl<H: KeyHasher> KeyFunction<H> for LegacyPrefixedKey<H> {
+    type Key = Vec<u8>;
+
+    fn key(hash: &H::Out, prefix: Prefix) -> Vec<u8> {
+        legacy_prefixed_key::<H>(hash, prefix)
+    }
+}
+
+/// Legacy method for db using previous version of prefix encoding.
+/// Only for trie radix 16 trie.
+#[deprecated(since = "0.22.0")]
+pub fn legacy_prefixed_key<H: KeyHasher>(key: &H::Out, prefix: Prefix) -> Vec<u8> {
+    let mut prefixed_key = Vec::with_capacity(key.as_ref().len() + prefix.0.len() + 1);
+    if let Some(last) = prefix.1 {
+        let mut prev = 0x01u8;
+        for i in prefix.0.iter() {
+            prefixed_key.push((prev << 4) + (*i >> 4));
+            prev = *i;
+        }
+        prefixed_key.push((prev << 4) + (last >> 4));
+    } else {
+        prefixed_key.push(0);
+        prefixed_key.extend_from_slice(prefix.0);
+    }
+    prefixed_key.extend_from_slice(key.as_ref());
+    prefixed_key
+}
+
+impl<H, KF, T, M> Default for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: for<'a> From<&'a [u8]> + Clone,
+    KF: KeyFunction<H>,
+    M: MemTracker<T> + Default,
+{
+    fn default() -> Self {
+        Self::from_null_node(&[0u8][..], [0u8][..].into())
+    }
+}
+
+/// Create a new `MemoryDB` from a given null key/data
+impl<H, KF, T, M> MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + Clone,
+    KF: KeyFunction<H>,
+    M: MemTracker<T>,
+{
+    /// Remove an element and delete it from storage if reference count reaches zero.
+    /// If the value was purged, return the old value.
+    pub fn remove_and_purge(&mut self, key: &<H as KeyHasher>::Out, prefix: Prefix) -> Option<T> {
+        if key == &self.hashed_null_node {
+            return None;
+        }
+        let key = KF::key(key, prefix);
+        match self.data.entry(key) {
+            Entry::Occupied(mut entry) => {
+                if entry.get().1 == 1 {
+                    let (value, _) = entry.remove();
+                    self.malloc_tracker.on_remove(&value);
+                    Some(value)
+                } else {
+                    entry.get_mut().1 -= 1;
+                    None
+                }
+            }
+            Entry::Vacant(entry) => {
+                let value = T::default();
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, -1));
+                None
+            }
+        }
+    }
+
+    /// Shrinks the capacity of the map as much as possible. It will drop
+    /// down as much as possible while maintaining the internal rules
+    /// and possibly leaving some space in accordance with the resize policy.
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {}
+}
+
+impl<H, KF, T, M> MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: for<'a> From<&'a [u8]> + Clone,
+    KF: KeyFunction<H>,
+    M: MemTracker<T> + Default,
+{
+    /// Create a new `MemoryDB` from a given null key/data
+    pub fn from_null_node(null_key: &[u8], null_node_data: T) -> Self {
+        MemoryDB {
+            data: HashMap::default(),
+            hashed_null_node: H::hash(null_key),
+            null_node_data,
+            malloc_tracker: M::default(),
+            _kf: Default::default(),
+        }
+    }
+
+    /// Create a new instance of `Self`.
+    pub fn new(data: &[u8]) -> Self {
+        Self::from_null_node(data, data.into())
+    }
+
+    /// Create a new default instance of `Self` and returns `Self` and the root hash.
+    pub fn default_with_root() -> (Self, H::Out) {
+        let db = Self::default();
+        let root = db.hashed_null_node;
+
+        (db, root)
+    }
+
+    /// Clear all data from the database.
+    ///
+    /// # Examples
+    /// ```rust
+    /// extern crate hash_db;
+    /// extern crate keccak_hasher;
+    /// extern crate memory_db;
+    ///
+    /// use hash_db::{Hasher, HashDB, EMPTY_PREFIX};
+    /// use keccak_hasher::KeccakHasher;
+    /// use memory_db::{MemoryDB, HashKey};
+    ///
+    /// fn main() {
+    ///   let mut m = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+    ///   let hello_bytes = "Hello world!".as_bytes();
+    ///   let hash = m.insert(EMPTY_PREFIX, hello_bytes);
+    ///   assert!(m.contains(&hash, EMPTY_PREFIX));
+    ///   m.clear();
+    ///   assert!(!m.contains(&hash, EMPTY_PREFIX));
+    /// }
+    /// ```
+    pub fn clear(&mut self) {
+        self.malloc_tracker.on_clear();
+        self.data.clear();
+    }
+
+    /// Purge all zero-referenced data from the database.
+    pub fn purge(&mut self) {
+        let malloc_tracker = &mut self.malloc_tracker;
+        self.data.retain(|_, (v, rc)| {
+            let keep = *rc != 0;
+            if !keep {
+                malloc_tracker.on_remove(v);
+            }
+            keep
+        });
+    }
+
+    /// Return the internal key-value HashMap, clearing the current state.
+    pub fn drain(&mut self) -> HashMap<KF::Key, (T, i32)> {
+        self.malloc_tracker.on_clear();
+        mem::take(&mut self.data)
+    }
+
+    /// Grab the raw information associated with a key. Returns None if the key
+    /// doesn't exist.
+    ///
+    /// Even when Some is returned, the data is only guaranteed to be useful
+    /// when the refs > 0.
+    pub fn raw(&self, key: &<H as KeyHasher>::Out, prefix: Prefix) -> Option<(&T, i32)> {
+        if key == &self.hashed_null_node {
+            return Some((&self.null_node_data, 1));
+        }
+        self.data
+            .get(&KF::key(key, prefix))
+            .map(|(value, count)| (value, *count))
+    }
+
+    /// Consolidate all the entries of `other` into `self`.
+    pub fn consolidate(&mut self, mut other: Self) {
+        for (key, (value, rc)) in other.drain() {
+            match self.data.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    if entry.get().1 < 0 {
+                        self.malloc_tracker.on_insert(&value);
+                        self.malloc_tracker.on_remove(&entry.get().0);
+                        entry.get_mut().0 = value;
+                    }
+
+                    entry.get_mut().1 += rc;
+                }
+                Entry::Vacant(entry) => {
+                    self.malloc_tracker.on_insert(&value);
+                    entry.insert((value, rc));
+                }
+            }
+        }
+    }
+
+    /// Get the keys in the database together with number of underlying references.
+    pub fn keys(&self) -> HashMap<KF::Key, i32> {
+        self.data
+            .iter()
+            .filter_map(|(k, v)| {
+                if v.1 != 0 {
+                    Some((k.clone(), v.1))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+impl<H, KF, T, M> MallocSizeOf for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    H::Out: MallocSizeOf,
+    T: MallocSizeOf,
+    KF: KeyFunction<H>,
+    KF::Key: MallocSizeOf,
+    M: MemTracker<T>,
+{
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        shallow_size_of_hashmap(&self.data, ops)
+            + self.malloc_tracker.get_size()
+            + self.null_node_data.size_of(ops)
+            + self.hashed_null_node.size_of(ops)
+    }
+}
+
+impl<H, KF, T, M> PlainDB<H::Out, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: Send + Sync + KeyFunction<H>,
+    KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out) -> Option<T> {
+        match self.data.get(key.as_ref()) {
+            Some(&(ref d, rc)) if rc > 0 => Some(d.clone()),
+            _ => None,
+        }
+    }
+
+    fn contains(&self, key: &H::Out) -> bool {
+        match self.data.get(key.as_ref()) {
+            Some(&(_, x)) if x > 0 => true,
+            _ => false,
+        }
+    }
+
+    fn emplace(&mut self, key: H::Out, value: T) {
+        match self.data.entry(key.as_ref().into()) {
+            Entry::Occupied(mut entry) => {
+                let &mut (ref mut old_value, ref mut rc) = entry.get_mut();
+                if *rc <= 0 {
+                    self.malloc_tracker.on_insert(&value);
+                    self.malloc_tracker.on_remove(old_value);
+                    *old_value = value;
+                }
+                *rc += 1;
+            }
+            Entry::Vacant(entry) => {
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, 1));
+            }
+        }
+    }
+
+    fn remove(&mut self, key: &H::Out) {
+        match self.data.entry(key.as_ref().into()) {
+            Entry::Occupied(mut entry) => {
+                let &mut (_, ref mut rc) = entry.get_mut();
+                *rc -= 1;
+            }
+            Entry::Vacant(entry) => {
+                let value = T::default();
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, -1));
+            }
+        }
+    }
+}
+
+impl<H, KF, T, M> PlainDBRef<H::Out, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: Send + Sync + KeyFunction<H>,
+    KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out) -> Option<T> {
+        PlainDB::get(self, key)
+    }
+    fn contains(&self, key: &H::Out) -> bool {
+        PlainDB::contains(self, key)
+    }
+}
+
+impl<H, KF, T, M> HashDB<H, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
+        if key == &self.hashed_null_node {
+            return Some(self.null_node_data.clone());
+        }
+
+        let key = KF::key(key, prefix);
+        match self.data.get(&key) {
+            Some(&(ref d, rc)) if rc > 0 => Some(d.clone()),
+            _ => None,
+        }
+    }
+
+    fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
+        if key == &self.hashed_null_node {
+            return true;
+        }
+
+        let key = KF::key(key, prefix);
+        match self.data.get(&key) {
+            Some(&(_, x)) if x > 0 => true,
+            _ => false,
+        }
+    }
+
+    fn emplace(&mut self, key: H::Out, prefix: Prefix, value: T) {
+        if value == self.null_node_data {
+            return;
+        }
+
+        let key = KF::key(&key, prefix);
+        match self.data.entry(key) {
+            Entry::Occupied(mut entry) => {
+                let &mut (ref mut old_value, ref mut rc) = entry.get_mut();
+                if *rc <= 0 {
+                    self.malloc_tracker.on_insert(&value);
+                    self.malloc_tracker.on_remove(old_value);
+                    *old_value = value;
+                }
+                *rc += 1;
+            }
+            Entry::Vacant(entry) => {
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, 1));
+            }
+        }
+    }
+
+    fn insert(&mut self, prefix: Prefix, value: &[u8]) -> H::Out {
+        if T::from(value) == self.null_node_data {
+            return self.hashed_null_node;
+        }
+
+        let key = H::hash(value);
+        HashDB::emplace(self, key, prefix, value.into());
+        key
+    }
+
+    fn remove(&mut self, key: &H::Out, prefix: Prefix) {
+        if key == &self.hashed_null_node {
+            return;
+        }
+
+        let key = KF::key(key, prefix);
+        match self.data.entry(key) {
+            Entry::Occupied(mut entry) => {
+                let &mut (_, ref mut rc) = entry.get_mut();
+                *rc -= 1;
+            }
+            Entry::Vacant(entry) => {
+                let value = T::default();
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, -1));
+            }
+        }
+    }
+}
+
+impl<H, KF, T, M> HashDBRef<H, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
+        HashDB::get(self, key, prefix)
+    }
+    fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
+        HashDB::contains(self, key, prefix)
+    }
+}
+
+impl<H, KF, T, M> AsPlainDB<H::Out, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn as_plain_db(&self) -> &dyn PlainDB<H::Out, T> {
+        self
+    }
+    fn as_plain_db_mut(&mut self) -> &mut dyn PlainDB<H::Out, T> {
+        self
+    }
+}
+
+impl<H, KF, T, M> AsHashDB<H, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn as_hash_db(&self) -> &dyn HashDB<H, T> {
+        self
+    }
+    fn as_hash_db_mut(&mut self) -> &mut dyn HashDB<H, T> {
+        self
+    }
+}
+
+/// Used to implement incremental evaluation of `MallocSizeOf` for a collection.
+pub trait MemTracker<T> {
+    /// Update `malloc_size_of` when a value is removed.
+    fn on_remove(&mut self, _value: &T) {}
+    /// Update `malloc_size_of` when a value is inserted.
+    fn on_insert(&mut self, _value: &T) {}
+    /// Reset `malloc_size_of` to zero.
+    fn on_clear(&mut self) {}
+    /// Get the allocated size of the values.
+    fn get_size(&self) -> usize {
+        0
+    }
+}
+
+/// `MemTracker` implementation for types
+/// which implement `MallocSizeOf`.
+#[derive(Eq, PartialEq)]
+pub struct MemCounter<T> {
+    malloc_size_of_values: usize,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> MemCounter<T> {
+    // Create a new instance of MemCounter<T>.
+    pub fn new() -> Self {
+        Self {
+            malloc_size_of_values: 0,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Default for MemCounter<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Clone for MemCounter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            malloc_size_of_values: self.malloc_size_of_values,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Copy for MemCounter<T> {}
+
+impl<T: MallocSizeOf> MemTracker<T> for MemCounter<T> {
+    fn on_remove(&mut self, value: &T) {
+        self.malloc_size_of_values -= malloc_size(value);
+    }
+    fn on_insert(&mut self, value: &T) {
+        self.malloc_size_of_values += malloc_size(value);
+    }
+    fn on_clear(&mut self) {
+        self.malloc_size_of_values = 0;
+    }
+    fn get_size(&self) -> usize {
+        self.malloc_size_of_values
+    }
+}
+
+/// No-op `MemTracker` implementation for when we want to
+/// construct a `MemoryDB` instance that does not track memory usage.
+#[derive(PartialEq, Eq)]
+pub struct NoopTracker<T>(PhantomData<T>);
+
+impl<T> Default for NoopTracker<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> Clone for NoopTracker<T> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl<T> Copy for NoopTracker<T> {}
+
+impl<T> MemTracker<T> for NoopTracker<T> {}
+
+fn shallow_size_of_hashmap<K, V, S>(map: &HashMap<K, V, S>, ops: &mut MallocSizeOfOps) -> usize {
+    // See the implementation for std::collections::HashSet for details.
+    if ops.has_malloc_enclosing_size_of() {
+        map.values()
+            .next()
+            .map_or(0, |v| unsafe { ops.malloc_enclosing_size_of(v) })
+    } else {
+        map.len() * (mem::size_of::<V>() + mem::size_of::<K>() + mem::size_of::<usize>())
+    }
+}
+
+#[cfg(test)]
+fn size_of_hash_map<K, V, S>(map: &HashMap<K, V, S>) -> usize
+where
+    K: MallocSizeOf,
+    V: MallocSizeOf,
+{
+    let ops = &mut parity_util_mem::allocators::new_malloc_size_ops();
+    let mut n = shallow_size_of_hashmap(map, ops);
+    if let (Some(k), Some(v)) = (K::constant_size(), V::constant_size()) {
+        n += map.len() * (k + v)
+    } else {
+        n = map
+            .iter()
+            .fold(n, |acc, (k, v)| acc + k.size_of(ops) + v.size_of(ops))
+    }
+    n
+}
+
+pub type GenericMemoryDB<H> = MemoryDB<H, HashKey<H>, DBValue, NoopTracker<DBValue>>;
+
+impl<H: KeyHasher> Consolidate for GenericMemoryDB<H> {
+    fn consolidate(&mut self, other: Self) {
+        MemoryDB::consolidate(self, other)
+    }
+}
+
+impl<H: KeyHasher> TrieBackendStorage<H> for GenericMemoryDB<H> {
+    type Overlay = Self;
+
+    fn get(
+        &self,
+        key: &<H as KeyHasher>::Out,
+        prefix: Prefix,
+    ) -> Result<Option<DBValue>, DefaultError> {
+        Ok(hash_db::HashDB::get(self, key, prefix))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HashDB, HashKey, KeyHasher, MemoryDB};
+    use hash_db::EMPTY_PREFIX;
+    use keccak_hasher::KeccakHasher;
+    use parity_util_mem::malloc_size;
+
+    #[test]
+    fn memorydb_remove_and_purge() {
+        let hello_bytes = b"Hello world!";
+        let hello_key = KeccakHasher::hash(hello_bytes);
+
+        let mut m = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        m.remove(&hello_key, EMPTY_PREFIX);
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, -1);
+        m.purge();
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, -1);
+        m.insert(EMPTY_PREFIX, hello_bytes);
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, 0);
+        m.purge();
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX), None);
+
+        let mut m = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        assert!(m.remove_and_purge(&hello_key, EMPTY_PREFIX).is_none());
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, -1);
+        m.insert(EMPTY_PREFIX, hello_bytes);
+        m.insert(EMPTY_PREFIX, hello_bytes);
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, 1);
+        assert_eq!(
+            &*m.remove_and_purge(&hello_key, EMPTY_PREFIX).unwrap(),
+            hello_bytes
+        );
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX), None);
+        assert!(m.remove_and_purge(&hello_key, EMPTY_PREFIX).is_none());
+    }
+
+    #[test]
+    fn consolidate() {
+        let mut main = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        let mut other = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        let remove_key = other.insert(EMPTY_PREFIX, b"doggo");
+        main.remove(&remove_key, EMPTY_PREFIX);
+
+        let insert_key = other.insert(EMPTY_PREFIX, b"arf");
+        main.emplace(insert_key, EMPTY_PREFIX, "arf".as_bytes().to_vec());
+
+        let negative_remove_key = other.insert(EMPTY_PREFIX, b"negative");
+        other.remove(&negative_remove_key, EMPTY_PREFIX); // ref cnt: 0
+        other.remove(&negative_remove_key, EMPTY_PREFIX); // ref cnt: -1
+        main.remove(&negative_remove_key, EMPTY_PREFIX); // ref cnt: -1
+
+        main.consolidate(other);
+
+        assert_eq!(
+            main.raw(&remove_key, EMPTY_PREFIX).unwrap(),
+            (&"doggo".as_bytes().to_vec(), 0)
+        );
+        assert_eq!(
+            main.raw(&insert_key, EMPTY_PREFIX).unwrap(),
+            (&"arf".as_bytes().to_vec(), 2)
+        );
+        assert_eq!(
+            main.raw(&negative_remove_key, EMPTY_PREFIX).unwrap(),
+            (&"negative".as_bytes().to_vec(), -2),
+        );
+    }
+
+    #[test]
+    fn default_works() {
+        let mut db = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        let hashed_null_node = KeccakHasher::hash(&[0u8][..]);
+        assert_eq!(db.insert(EMPTY_PREFIX, &[0u8][..]), hashed_null_node);
+
+        let (db2, root) = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default_with_root();
+        assert!(db2.contains(&root, EMPTY_PREFIX));
+        assert!(db.contains(&root, EMPTY_PREFIX));
+    }
+
+    #[test]
+    fn malloc_size_of() {
+        let mut db = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        for i in 0u32..1024 {
+            let bytes = i.to_be_bytes();
+            let prefix = (bytes.as_ref(), None);
+            db.insert(prefix, &bytes);
+        }
+        assert_eq!(
+            malloc_size(&db),
+            crate::size_of_hash_map(&db.data)
+                + malloc_size(&db.null_node_data)
+                + malloc_size(&db.hashed_null_node)
+        );
+    }
+}

--- a/crates/pink/Cargo.toml
+++ b/crates/pink/Cargo.toml
@@ -23,6 +23,7 @@ sp-std = { path = "../../substrate/primitives/std" }
 sp-sandbox = { path = "../../substrate/primitives/sandbox" }
 sp-state-machine = { path = "../../substrate/primitives/state-machine" }
 sp-externalities = { path = "../../substrate/primitives/externalities" }
+sp-trie = { path = "../../substrate/primitives/trie" }
 
 scale = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.0", default-features = false, features = ["derive", "serde", "decode"] }

--- a/crates/pink/src/contract.rs
+++ b/crates/pink/src/contract.rs
@@ -14,6 +14,12 @@ type ContractExecResult = pallet_contracts_primitives::ContractExecResult<crate:
 
 pub type Storage = storage::Storage<storage::InMemoryBackend>;
 
+impl Default for Storage {
+    fn default() -> Self {
+        Self::new(storage::new_in_memory_backend())
+    }
+}
+
 #[derive(Debug)]
 pub struct ExecError {
     pub source: DispatchError,
@@ -32,10 +38,7 @@ pub struct Contract {
 }
 
 impl Contract {
-    pub fn new_storage() -> Storage {
-        Storage::new(Default::default())
-    }
-
+    /// Create a new contract instance from existing address.
     pub fn from_address(address: AccountId) -> Self {
         Contract {
             address,

--- a/crates/pink/tests/test_pink_contract.rs
+++ b/crates/pink/tests/test_pink_contract.rs
@@ -1,6 +1,6 @@
 use frame_support::assert_ok;
 use hex_literal::hex;
-use pink::Contract;
+use pink::{Contract, Storage};
 use pink_extension::PinkEvent;
 use sp_runtime::AccountId32;
 
@@ -8,7 +8,7 @@ pub const ALICE: AccountId32 = AccountId32::new([1u8; 32]);
 
 #[test]
 fn test_ink_flip() {
-    let mut storage = Contract::new_storage();
+    let mut storage = Storage::default();
     let code_hash = storage
         .upload_code(
             ALICE.clone(),
@@ -96,7 +96,7 @@ fn test_load_contract_file() {
 
 #[test]
 fn test_ink_cross_contract_instanciate() {
-    let mut storage = Contract::new_storage();
+    let mut storage = Storage::default();
     let code_hash = storage
         .upload_code(
             ALICE.clone(),
@@ -154,7 +154,7 @@ fn test_ink_cross_contract_instanciate() {
 
 #[test]
 fn test_mq_egress() {
-    let mut storage = Contract::new_storage();
+    let mut storage = Storage::default();
     let code_hash = storage
         .upload_code(
             ALICE.clone(),
@@ -205,7 +205,7 @@ fn test_mq_egress() {
 
 #[test]
 fn test_on_block_end() {
-    let mut storage = Contract::new_storage();
+    let mut storage = Storage::default();
     let code_hash = storage
         .upload_code(
             ALICE.clone(),
@@ -243,7 +243,7 @@ fn test_on_block_end() {
 }
 
 fn test_with_wasm(wasm: &[u8], constructor: [u8; 4], message: [u8; 4]) {
-    let mut storage = Contract::new_storage();
+    let mut storage = Storage::default();
     storage.set_key_seed([1u8; 64]);
     let code_hash = storage.upload_code(ALICE.clone(), wasm.to_vec()).unwrap();
 

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -511,6 +511,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1581,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
+name = "ethbloom"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,12 +2533,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.3",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
 ]
 
 [[package]]
@@ -2969,6 +3028,15 @@ checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
 dependencies = [
  "quote 1.0.18",
  "syn 1.0.95",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8015d95cb7b2ddd3c0d32ca38283ceb1eea09b4713ee380bceb942d85a244228"
+dependencies = [
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -4050,11 +4118,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c32561d248d352148124f036cac253a644685a21dc9fea383eb4907d7bd35a8f"
 dependencies = [
  "cfg-if",
+ "ethereum-types",
  "hashbrown 0.12.1",
  "impl-trait-for-tuples",
+ "lru",
  "parity-util-mem-derive",
  "parking_lot 0.12.1",
  "primitive-types",
+ "smallvec",
  "winapi",
 ]
 
@@ -4539,7 +4610,10 @@ dependencies = [
 name = "phala-trie-storage"
 version = "0.1.0"
 dependencies = [
+ "hash-db",
+ "im",
  "parity-scale-codec",
+ "parity-util-mem",
  "scale-info",
  "serde",
  "sp-core",
@@ -4674,6 +4748,7 @@ dependencies = [
  "sp-sandbox",
  "sp-state-machine",
  "sp-std",
+ "sp-trie",
  "wasmi-validation 0.3.0",
  "wat",
 ]
@@ -4819,6 +4894,7 @@ checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -5188,6 +5264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5390,6 +5475,16 @@ name = "rlibc"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
+
+[[package]]
+name = "rlp"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
 
 [[package]]
 name = "rocket"
@@ -5972,6 +6067,16 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "slab"
@@ -7009,6 +7114,15 @@ dependencies = [
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]


### PR DESCRIPTION
The enables lightweight snapshots for cluster storage.