### PR TITLE
Support to kick old pruntime

### DIFF
--- a/crates/phactory/pal/src/lib.rs
+++ b/crates/phactory/pal/src/lib.rs
@@ -45,5 +45,15 @@ pub trait ProtectedFileSystem {
     fn create_protected_file(&self, path: impl AsRef<Path>, key: &[u8]) -> Result<Self::WriteFile, Self::IoError>;
 }
 
-pub trait Platform: Sealing + RA + Machine + MemoryStats + ProtectedFileSystem + Clone {}
-impl<T: Sealing + RA + Machine + MemoryStats + ProtectedFileSystem + Clone> Platform for T {}
+pub struct AppVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+pub trait AppInfo {
+    fn app_version() -> AppVersion;
+}
+
+pub trait Platform: Sealing + RA + Machine + MemoryStats + ProtectedFileSystem + AppInfo + Clone {}
+impl<T: Sealing + RA + Machine + MemoryStats + ProtectedFileSystem + AppInfo + Clone> Platform for T {}

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -352,7 +352,7 @@ impl<Platform: pal::Platform> Phactory<Platform> {
     }
 }
 
-impl<P> Phactory<P> {
+impl<P: pal::Platform> Phactory<P> {
     // Restored from checkpoint
     pub fn on_restored(&mut self) -> Result<()> {
         if let Some(system) = &mut self.system {
@@ -554,7 +554,7 @@ impl<Platform: Serialize + DeserializeOwned> Serialize for PhactoryDumper<'_, Pl
     }
 }
 struct PhactoryLoader<Platform>(Phactory<Platform>);
-impl<'de, Platform: Serialize + DeserializeOwned> Deserialize<'de> for PhactoryLoader<Platform> {
+impl<'de, Platform: Serialize + DeserializeOwned + pal::Platform> Deserialize<'de> for PhactoryLoader<Platform> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let mut factory = Phactory::load_state(deserializer)?;
         factory

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -34,9 +34,10 @@ use phala_serde_more as more;
 use phala_types::{
     contract::{self, messaging::ContractOperation, CodeIndex},
     messaging::{
-        AeadIV, BatchDispatchClusterKeyEvent, ClusterKeyDistribution, DispatchMasterKeyEvent,
-        GatekeeperChange, GatekeeperLaunch, HeartbeatChallenge, KeyDistribution, MiningReportEvent,
-        NewGatekeeperEvent, SystemEvent, WorkerClusterReport, WorkerContractReport, WorkerEvent,
+        AeadIV, BatchDispatchClusterKeyEvent, ClusterKeyDistribution, Condition,
+        DispatchMasterKeyEvent, GatekeeperChange, GatekeeperLaunch, HeartbeatChallenge,
+        KeyDistribution, MiningReportEvent, NewGatekeeperEvent, PRuntimeManagementEvent,
+        SystemEvent, WorkerClusterReport, WorkerContractReport, WorkerEvent,
     },
     EcdhPublicKey, WorkerPublicKey,
 };
@@ -400,6 +401,7 @@ pub struct System<Platform> {
     // Messageing
     egress: SignedMessageChannel,
     system_events: TypedReceiver<SystemEvent>,
+    pruntime_management_events: TypedReceiver<PRuntimeManagementEvent>,
     gatekeeper_launch_events: TypedReceiver<GatekeeperLaunch>,
     gatekeeper_change_events: TypedReceiver<GatekeeperChange>,
     key_distribution_events: TypedReceiver<KeyDistribution>,
@@ -424,6 +426,7 @@ pub struct System<Platform> {
     // Cached for query
     block_number: BlockNumber,
     now_ms: u64,
+    retired_versions: Vec<Condition>,
 }
 
 fn create_sidevm_service() -> Spawner {
@@ -449,6 +452,9 @@ impl<Platform: pal::Platform> System<Platform> {
         recv_mq: &mut MessageDispatcher,
         contracts: ContractsKeeper,
     ) -> Self {
+        // Trigger panic early if platform is not properly implemented.
+        let _ = Platform::app_version();
+
         let identity_key = WorkerIdentityKey(identity_key);
         let pubkey = identity_key.public();
         let sender = MessageOrigin::Worker(pubkey);
@@ -461,6 +467,7 @@ impl<Platform: pal::Platform> System<Platform> {
             geoip_city_db,
             egress: send_mq.channel(sender, identity_key.clone().0.into()),
             system_events: recv_mq.subscribe_bound(),
+            pruntime_management_events: recv_mq.subscribe_bound(),
             gatekeeper_launch_events: recv_mq.subscribe_bound(),
             gatekeeper_change_events: recv_mq.subscribe_bound(),
             key_distribution_events: recv_mq.subscribe_bound(),
@@ -476,6 +483,7 @@ impl<Platform: pal::Platform> System<Platform> {
             block_number: 0,
             now_ms: 0,
             sidevm_spawner: create_sidevm_service(),
+            retired_versions: vec![],
         }
     }
 
@@ -515,9 +523,15 @@ impl<Platform: pal::Platform> System<Platform> {
         let ok = phala_mq::select_ignore_errors! {
             (event, origin) = self.system_events => {
                 if !origin.is_pallet() {
-                    anyhow::bail!("Invalid SystemEvent sender: {:?}", origin);
+                    anyhow::bail!("Invalid SystemEvent sender: {}", origin);
                 }
                 self.process_system_event(block, &event);
+            },
+            (event, origin) = self.pruntime_management_events => {
+                if !origin.is_pallet() {
+                    anyhow::bail!("Invalid pRuntime management event sender: {}", origin);
+                }
+                self.process_pruntime_management_event(event);
             },
             (event, origin) = self.gatekeeper_launch_events => {
                 self.process_gatekeeper_launch_event(block, origin, event);
@@ -630,6 +644,34 @@ impl<Platform: pal::Platform> System<Platform> {
     fn process_system_event(&mut self, block: &BlockInfo, event: &SystemEvent) {
         self.worker_state
             .process_event(block, event, &mut WorkerSMDelegate(&self.egress), true);
+    }
+
+    fn process_pruntime_management_event(&mut self, event: PRuntimeManagementEvent) {
+        match event {
+            PRuntimeManagementEvent::RetirePRuntime(condition) => {
+                self.retired_versions.push(condition.clone());
+                self.check_retirement();
+            }
+        }
+    }
+
+    fn check_retirement(&mut self) {
+        let cur_ver = Platform::app_version();
+        for condition in self.retired_versions.iter() {
+            let should_retire = match *condition {
+                Condition::VersionLessThan(major, minor, patch) => {
+                    (cur_ver.major, cur_ver.minor, cur_ver.patch) < (major, minor, patch)
+                }
+                Condition::VersionIs(major, minor, patch) => {
+                    (cur_ver.major, cur_ver.minor, cur_ver.patch) == (major, minor, patch)
+                }
+            };
+
+            if should_retire {
+                error!("This pRuntime is outdated. Please update to the latest version.");
+                std::process::abort();
+            }
+        }
     }
 
     fn set_master_key(&mut self, master_key: sr25519::Pair, need_restart: bool) {
@@ -1112,9 +1154,10 @@ impl<Platform: pal::Platform> System<Platform> {
     }
 }
 
-impl<P> System<P> {
+impl<P: pal::Platform> System<P> {
     pub fn on_restored(&mut self) -> Result<()> {
         self.contracts.try_restart_sidevms(&self.sidevm_spawner);
+        self.check_retirement();
         Ok(())
     }
 }

--- a/crates/phala-mq/src/types.rs
+++ b/crates/phala-mq/src/types.rs
@@ -20,8 +20,9 @@ use serde::{Deserialize, Serialize};
 /// The origin of a Phala message
 // TODO: should we use XCM MultiLocation directly?
 // [Reference](https://github.com/paritytech/xcm-format#multilocation-universal-destination-identifiers)
-#[derive(Encode, Decode, TypeInfo, Debug, Clone, Eq, PartialOrd, Ord, Display)]
-#[derive(Serialize, Deserialize)]
+#[derive(
+    Encode, Decode, TypeInfo, Debug, Clone, Eq, PartialOrd, Ord, Display, Serialize, Deserialize,
+)]
 pub enum MessageOrigin {
     /// Runtime pallets (identified by pallet name)
     #[display(fmt = "Pallet(\"{}\")", "String::from_utf8_lossy(_0)")]
@@ -80,6 +81,14 @@ impl MessageOrigin {
     /// Returns if the origin is from a Pallet
     pub fn is_pallet(&self) -> bool {
         matches!(self, Self::Pallet(_))
+    }
+
+    /// Returns if we can trust the origin to not send us non-well-formed messages
+    pub fn always_well_formed(&self) -> bool {
+        matches!(
+            self,
+            Self::Pallet(_) | Self::Worker(_) | Self::Gatekeeper
+        )
     }
 
     /// Returns if the origin is from a Gatekeeper

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -293,6 +293,21 @@ pub mod messaging {
         }
     }
 
+    bind_topic!(PRuntimeManagementEvent, b"phala/pruntime/management");
+    #[derive(Encode, Decode, Debug, TypeInfo)]
+    pub enum PRuntimeManagementEvent {
+        RetirePRuntime(Condition),
+    }
+
+    #[cfg_attr(feature = "enable_serde", derive(Serialize, Deserialize))]
+    #[derive(Encode, Decode, Debug, TypeInfo, Clone)]
+    pub enum Condition {
+        /// pRuntimes of version less than given version will be retired.
+        VersionLessThan(u32, u32, u32),
+        /// pRuntimes of version equal to given version will be retired.
+        VersionIs(u32, u32, u32),
+    }
+
     #[derive(Encode, Decode, Debug, Default, Clone, PartialEq, Eq, TypeInfo)]
     pub struct HeartbeatChallenge {
         pub seed: U256,

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -5311,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "pruntime"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -5336,6 +5336,7 @@ dependencies = [
  "serde",
  "serde_json",
  "urlencoding",
+ "version",
 ]
 
 [[package]]
@@ -8393,6 +8394,12 @@ dependencies = [
  "ctor",
  "version_check",
 ]
+
+[[package]]
+name = "version"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a449064fee414fcc201356a3e6c1510f6c8829ed28bb06b91c54ebe208ce065"
 
 [[package]]
 name = "version_check"

--- a/standalone/pruntime/Cargo.toml
+++ b/standalone/pruntime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "pruntime"
-version = "0.1.0"
+version = "2.0.0"
 
 [profile.release]
 panic = "abort"
@@ -16,6 +16,7 @@ libc = "0.2"
 log = "0.4.14"
 num_cpus = "1.13"
 os_pipe = "1.0.0"
+version = "3.0.0"
 
 rocket = { version = "0.5.0-rc.1", features = ["json"] }
 rocket_cors = "0.6.0-alpha1"

--- a/standalone/pruntime/src/pal_gramine.rs
+++ b/standalone/pruntime/src/pal_gramine.rs
@@ -1,10 +1,13 @@
 use log::info;
 use std::alloc::System;
 
-use phactory_pal::{Machine, MemoryStats, MemoryUsage, ProtectedFileSystem, Sealing, RA};
+use phactory_pal::{
+    AppInfo, AppVersion, Machine, MemoryStats, MemoryUsage, ProtectedFileSystem, Sealing, RA,
+};
 use phala_allocator::StatSizeAllocator;
 use std::fs::File;
 use std::io::ErrorKind;
+use std::str::FromStr as _;
 
 use crate::ra;
 
@@ -119,6 +122,17 @@ impl MemoryStats for GraminePlatform {
             total_peak_used: 0,
             rust_used: stats.current_used,
             rust_peak_used: stats.peak_used,
+        }
+    }
+}
+
+impl AppInfo for GraminePlatform {
+    fn app_version() -> AppVersion {
+        let ver = version::Version::from_str(version::version!()).unwrap();
+        AppVersion {
+            major: ver.major,
+            minor: ver.minor,
+            patch: ver.patch,
         }
     }
 }


### PR DESCRIPTION
Main changes in this PR:

- Add the MQ event PRuntimeManagementEvent, which is used to retire pRuntimes explicitly.
- Abort when pruntime failed to decode a message from a trusted origin.