### PR TITLE
pruntime: Support socks5 proxy for outgoing tcp connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3871,18 +3871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http_req"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6cd45a270dff33553602fd84beb02c89460ee32db638715f10d9060389fd6a"
-dependencies = [
- "rustls 0.19.1",
- "unicase",
- "webpki 0.21.4",
- "webpki-roots 0.21.1",
-]
-
-[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8042,7 +8030,6 @@ dependencies = [
  "frame-system 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24)",
  "hex",
  "hex-literal",
- "http_req",
  "impl-serde",
  "insta",
  "log",
@@ -8063,6 +8050,8 @@ dependencies = [
  "pink-extension",
  "pretty_assertions 0.7.2",
  "pwasm-utils",
+ "reqwest",
+ "reqwest-proxy",
  "scale-info",
  "serde",
  "serde_json",
@@ -8158,6 +8147,7 @@ dependencies = [
  "thiserror",
  "thread_local",
  "tokio",
+ "tokio-proxy",
  "tokio-rustls 0.23.4",
  "wasm-instrument",
  "wasmer",
@@ -9102,9 +9092,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
@@ -9115,6 +9105,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -9124,16 +9115,29 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.9",
+ "rustls 0.20.6",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.23.4",
+ "tokio-socks",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.22.3",
  "winreg 0.10.1",
+]
+
+[[package]]
+name = "reqwest-proxy"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
 ]
 
 [[package]]
@@ -13415,6 +13419,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-proxy"
+version = "0.1.0"
+source = "git+https://github.com/Phala-Network/tokio-proxy.git#e98d21a0ff7bf7a3bea413b2ee336b0d4da1e213"
+dependencies = [
+ "bytes 1.1.0",
+ "log",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13434,6 +13449,18 @@ dependencies = [
  "rustls 0.20.6",
  "tokio",
  "webpki 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -13745,7 +13772,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.3.23",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
 	"crates/pink/sidevm/sidevm",
 	"crates/phala-serde-more",
 	"crates/rustfmt-snippet",
+	"crates/reqwest-proxy",
 	"pallets/phala",
 	"pallets/phala/mq-runtime-api",
 	"scripts/toml-upgrade-version",

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -934,9 +934,9 @@ impl<Platform: pal::Platform> System<Platform> {
                             (BALANCES => balances::Balances::new()),
                             (ASSETS => assets::Assets::new()),
                             (BTC_LOTTERY => btc_lottery::BtcLottery::new(Some(contract_key.to_raw_vec()))),
-                            (GEOLOCATION => geolocation::Geolocation::new()),
-                            (GUESS_NUMBER => guess_number::GuessNumber::new()),
-                            (BTC_PRICE_BOT => btc_price_bot::BtcPriceBot::new())
+                            // (GEOLOCATION => geolocation::Geolocation::new()),
+                            (GUESS_NUMBER => guess_number::GuessNumber::new())
+                            // (BTC_PRICE_BOT => btc_price_bot::BtcPriceBot::new())
                         };
 
                         let message = ContractRegistryEvent::PubkeyAvailable {

--- a/crates/pink/Cargo.toml
+++ b/crates/pink/Cargo.toml
@@ -45,7 +45,8 @@ phala-trie-storage = { path = "../phala-trie-storage" }
 phala-types = { path = "../phala-types" }
 phala-crypto = { path = "../phala-crypto" }
 pink-extension = { path = "pink-extension" }
-http_req = { version = "0.8.1", default-features = false, features = ["rust-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "socks", "blocking"] }
+reqwest-proxy = { path = "../reqwest-proxy" }
 environmental = "1.1.3"
 once_cell = "1.10.0"
 

--- a/crates/pink/sidevm/host-runtime/Cargo.toml
+++ b/crates/pink/sidevm/host-runtime/Cargo.toml
@@ -32,3 +32,4 @@ tokio-rustls = "0.23"
 rustls-pemfile = "1"
 webpki-roots = "0.22"
 once_cell = "1"
+tokio-proxy = { git  = "https://github.com/Phala-Network/tokio-proxy.git" }

--- a/crates/pink/src/runtime/extension.rs
+++ b/crates/pink/src/runtime/extension.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
-use std::{convert::TryFrom, time::Duration};
+use std::str::FromStr;
+use std::time::Duration;
 
 use frame_support::log::error;
 use pallet_contracts::chain_extension::{
@@ -14,6 +15,9 @@ use pink_extension::{
     },
     dispatch_ext_call, PinkEvent,
 };
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::Method;
+use reqwest_proxy::EnvProxyBuilder;
 use scale::{Decode, Encode};
 use sp_core::{ByteArray, Pair};
 use sp_runtime::DispatchError;
@@ -126,51 +130,56 @@ struct CallInQuery {
 impl PinkExtBackend for CallInQuery {
     type Error = DispatchError;
     fn http_request(&self, request: HttpRequest) -> Result<HttpResponse, Self::Error> {
-        let uri = http_req::uri::Uri::try_from(request.url.as_str())
-            .or(Err(DispatchError::Other("Invalid URL")))?;
-
-        let mut req = http_req::request::Request::new(&uri);
-        for (key, value) in &request.headers {
-            req.header(key, value);
-        }
-
-        match request.method.as_str() {
-            "GET" => {
-                req.method(http_req::request::Method::GET);
-            }
-            "POST" => {
-                req.method(http_req::request::Method::POST)
-                    .body(request.body.as_slice());
-                req.header("Content-Length", &request.body.len());
-            }
-            _ => {
-                return Err(DispatchError::Other("Unsupported method"));
-            }
-        };
-
         // Hardcoded limitations for now
         const MAX_QUERY_TIME: u64 = 10; // seconds
         const MAX_BODY_SIZE: usize = 1024 * 256; // 256KB
 
         let elapsed = get_call_elapsed().ok_or(DispatchError::Other("Invalid exec env"))?;
         let timeout = Duration::from_secs(MAX_QUERY_TIME) - elapsed;
-        req.timeout(Some(timeout));
 
-        let mut body = Vec::new();
-        let mut writer = LimitedWriter::new(&mut body, MAX_BODY_SIZE);
+        let client = reqwest::blocking::Client::builder()
+            .timeout(timeout)
+            .env_proxy()
+            .build()
+            .or(Err(DispatchError::Other("Failed to create client")))?;
 
-        let response = req
-            .send(&mut writer)
+        let method: Method = FromStr::from_str(request.method.as_str())
+            .or(Err(DispatchError::Other("Invalid HTTP method")))?;
+        let mut headers = HeaderMap::new();
+        for (key, value) in &request.headers {
+            let key = HeaderName::from_str(key.as_str())
+                .or(Err(DispatchError::Other("Invalid HTTP header key")))?;
+            let value = HeaderValue::from_str(value)
+                .or(Err(DispatchError::Other("Invalid HTTP header value")))?;
+            headers.insert(key, value);
+        }
+
+        let mut response = client
+            .request(method, request.url.as_str())
+            .headers(headers)
+            .send()
             .or(Err(DispatchError::Other("Failed to send request")))?;
 
         let headers: Vec<_> = response
             .headers()
             .iter()
-            .map(|(k, v)| (k.to_string(), v.to_owned()))
+            .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or_default().into()))
             .collect();
+
+        let mut body = Vec::new();
+        let mut writer = LimitedWriter::new(&mut body, MAX_BODY_SIZE);
+
+        response
+            .copy_to(&mut writer)
+            .or(Err(DispatchError::Other("Failed to copy response body")))?;
+
         let response = HttpResponse {
-            status_code: response.status_code().into(),
-            reason_phrase: response.reason().into(),
+            status_code: response.status().as_u16(),
+            reason_phrase: response
+                .status()
+                .canonical_reason()
+                .unwrap_or_default()
+                .into(),
             body,
             headers,
         };

--- a/crates/reqwest-proxy/Cargo.toml
+++ b/crates/reqwest-proxy/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "reqwest-proxy"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+reqwest = { version = "0.11.11", default-features = false, features = [] }
+
+[features]
+default = ["blocking"]
+blocking = ["reqwest/blocking"]

--- a/crates/reqwest-proxy/src/lib.rs
+++ b/crates/reqwest-proxy/src/lib.rs
@@ -1,0 +1,31 @@
+use reqwest::Proxy;
+
+pub trait EnvProxyBuilder {
+    fn env_proxy(self) -> Self;
+}
+
+fn proxies_from_env() -> Option<(Proxy, Proxy)> {
+    let uri = std::env::var("all_proxy").ok()?;
+    let http_proxy = Proxy::http(&uri).ok()?;
+    let https_proxy = Proxy::https(&uri).ok()?;
+    Some((http_proxy, https_proxy))
+}
+
+impl EnvProxyBuilder for reqwest::ClientBuilder {
+    fn env_proxy(self) -> Self {
+        match proxies_from_env() {
+            Some((http_proxy, https_proxy)) => self.proxy(http_proxy).proxy(https_proxy),
+            None => self,
+        }
+    }
+}
+
+#[cfg(feature = "blocking")]
+impl EnvProxyBuilder for reqwest::blocking::ClientBuilder {
+    fn env_proxy(self) -> Self {
+        match proxies_from_env() {
+            Some((http_proxy, https_proxy)) => self.proxy(http_proxy).proxy(https_proxy),
+            None => self,
+        }
+    }
+}

--- a/crates/reqwest-proxy/src/lib.rs
+++ b/crates/reqwest-proxy/src/lib.rs
@@ -1,19 +1,26 @@
 use reqwest::Proxy;
 
 pub trait EnvProxyBuilder {
-    fn env_proxy(self) -> Self;
+    fn env_proxy(self, domain: &str) -> Self;
 }
 
-fn proxies_from_env() -> Option<(Proxy, Proxy)> {
-    let uri = std::env::var("all_proxy").ok()?;
+fn proxies_from_env(domain: &str) -> Option<(Proxy, Proxy)> {
+    let uri = if domain.ends_with(".i2p") {
+        std::env::var("i2p_proxy").ok()
+    } else {
+        None
+    };
+
+    let uri = uri.or_else(|| std::env::var("all_proxy").ok())?;
+
     let http_proxy = Proxy::http(&uri).ok()?;
     let https_proxy = Proxy::https(&uri).ok()?;
     Some((http_proxy, https_proxy))
 }
 
 impl EnvProxyBuilder for reqwest::ClientBuilder {
-    fn env_proxy(self) -> Self {
-        match proxies_from_env() {
+    fn env_proxy(self, domain: &str) -> Self {
+        match proxies_from_env(domain) {
             Some((http_proxy, https_proxy)) => self.proxy(http_proxy).proxy(https_proxy),
             None => self,
         }
@@ -22,8 +29,8 @@ impl EnvProxyBuilder for reqwest::ClientBuilder {
 
 #[cfg(feature = "blocking")]
 impl EnvProxyBuilder for reqwest::blocking::ClientBuilder {
-    fn env_proxy(self) -> Self {
-        match proxies_from_env() {
+    fn env_proxy(self, domain: &str) -> Self {
+        match proxies_from_env(domain) {
             Some((http_proxy, https_proxy)) => self.proxy(http_proxy).proxy(https_proxy),
             None => self,
         }

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -2552,18 +2552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http_req"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6cd45a270dff33553602fd84beb02c89460ee32db638715f10d9060389fd6a"
-dependencies = [
- "rustls 0.19.1",
- "unicase",
- "webpki 0.21.4",
- "webpki-roots 0.21.1",
-]
-
-[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,6 +2597,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.20.6",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2916,6 +2917,12 @@ checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -4962,7 +4969,6 @@ dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24)",
  "frame-system 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24)",
  "hex",
- "http_req",
  "impl-serde",
  "log",
  "once_cell",
@@ -4982,6 +4988,8 @@ dependencies = [
  "pink-extension",
  "pretty_assertions",
  "pwasm-utils",
+ "reqwest",
+ "reqwest-proxy",
  "scale-info",
  "serde",
  "serde_json",
@@ -5060,6 +5068,7 @@ dependencies = [
  "thiserror",
  "thread_local",
  "tokio",
+ "tokio-proxy",
  "tokio-rustls",
  "wasm-instrument",
  "wasmer",
@@ -5309,7 +5318,6 @@ dependencies = [
  "clap",
  "colored",
  "env_logger",
- "http_req",
  "lazy_static",
  "libc",
  "log",
@@ -5321,6 +5329,8 @@ dependencies = [
  "phactory-pal",
  "phala-allocator",
  "phala-rocket-middleware",
+ "reqwest",
+ "reqwest-proxy",
  "rocket",
  "rocket_cors",
  "serde",
@@ -5654,6 +5664,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+dependencies = [
+ "base64 0.13.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.20.6",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "tokio-socks",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.22.3",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest-proxy"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
 ]
 
 [[package]]
@@ -7895,6 +7952,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-proxy"
+version = "0.1.0"
+source = "git+https://github.com/Phala-Network/tokio-proxy.git#e98d21a0ff7bf7a3bea413b2ee336b0d4da1e213"
+dependencies = [
+ "bytes",
+ "log",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7903,6 +7971,18 @@ dependencies = [
  "rustls 0.20.6",
  "tokio",
  "webpki 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -8792,15 +8872,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
@@ -8901,6 +8972,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "woothee"

--- a/standalone/pruntime/Cargo.toml
+++ b/standalone/pruntime/Cargo.toml
@@ -10,7 +10,8 @@ panic = "abort"
 anyhow = "1.0"
 clap = {version = "3", features = ["derive"]}
 colored = "2"
-http_req = {version = "0.8.1", default-features = false, features = ["rust-tls"]}
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "socks", "blocking"] }
+reqwest-proxy = {path = "../../crates/reqwest-proxy"}
 libc = "0.2"
 log = "0.4.14"
 num_cpus = "1.13"

--- a/standalone/pruntime/gramine-build/pruntime.manifest.template
+++ b/standalone/pruntime/gramine-build/pruntime.manifest.template
@@ -16,6 +16,7 @@ LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
 M_ARENA_MAX = "1"
 ROCKET_WORKERS = "8"
 all_proxy = { passthrough = true }
+i2p_proxy = { passthrough = true }
 
 [[fs.mounts]]
 type = "chroot"

--- a/standalone/pruntime/gramine-build/pruntime.manifest.template
+++ b/standalone/pruntime/gramine-build/pruntime.manifest.template
@@ -15,6 +15,7 @@ insecure__allow_eventfd = true
 LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
 M_ARENA_MAX = "1"
 ROCKET_WORKERS = "8"
+all_proxy = { passthrough = true }
 
 [[fs.mounts]]
 type = "chroot"

--- a/standalone/pruntime/src/ra.rs
+++ b/standalone/pruntime/src/ra.rs
@@ -1,7 +1,8 @@
 use anyhow::{anyhow, Context as _, Result};
-use http_req::request::{Method, Request};
-use log::{error, warn};
-use std::{convert::TryFrom, fs, time::Duration};
+use log::{error, warn, info};
+use std::{fs, time::Duration};
+
+use reqwest_proxy::EnvProxyBuilder as _;
 
 pub const IAS_HOST: &str = env!("IAS_HOST");
 pub const IAS_REPORT_ENDPOINT: &str = env!("IAS_REPORT_ENDPOINT");
@@ -14,21 +15,21 @@ fn get_report_from_intel(quote: &[u8], ias_key: &str) -> Result<(String, String,
     let timeout = Some(Duration::from_secs(8));
 
     let url = format!("https://{}{}", IAS_HOST, IAS_REPORT_ENDPOINT);
-    let url = TryFrom::try_from(url.as_str()).context("Invalid IAS URI")?;
-    let res = Request::new(&url)
+    info!("Getting RA report from {}", url);
+    let mut res = reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .env_proxy()
+        .build()
+        .context("Failed to create http client, maybe invalid IAS URI")?
+        .post(url)
         .header("Connection", "Close")
         .header("Content-Type", "application/json")
-        .header("Content-Length", &encoded_json.len())
         .header("Ocp-Apim-Subscription-Key", ias_key)
-        .method(Method::POST)
-        .body(encoded_json.as_bytes())
-        .timeout(timeout)
-        .connect_timeout(timeout)
-        .read_timeout(timeout)
-        .send(&mut res_body_buffer)
-        .context("Http request to IAS failed")?;
+        .body(encoded_json)
+        .send()
+        .context("Failed to send http request")?;
 
-    let status_code = u16::from(res.status_code());
+    let status_code = u16::from(res.status().as_u16());
     if status_code != 200 {
         let msg = match status_code {
             401 => "Unauthorized Failed to authenticate or authorize request.",
@@ -47,7 +48,7 @@ fn get_report_from_intel(quote: &[u8], ias_key: &str) -> Result<(String, String,
         return Err(anyhow!(format!("Bad http status: {}", status_code)));
     }
 
-    let content_len = match res.content_len() {
+    let content_len = match res.content_length() {
         Some(len) => len,
         _ => {
             warn!("content_length not found");
@@ -59,17 +60,23 @@ fn get_report_from_intel(quote: &[u8], ias_key: &str) -> Result<(String, String,
         return Err(anyhow!("Empty HTTP response"));
     }
 
-    let attn_report = String::from_utf8(res_body_buffer).context("Failed to decode attestation report")?;
+    res.copy_to(&mut res_body_buffer)
+        .context("Failed to read response body from IAS")?;
+
+    let attn_report =
+        String::from_utf8(res_body_buffer).context("Failed to decode attestation report")?;
     let sig = res
         .headers()
         .get("X-IASReport-Signature")
         .context("No header X-IASReport-Signature")?
-        .to_string();
+        .to_str()
+        .context("Failed to decode X-IASReport-Signature")?;
     let cert = res
         .headers()
         .get("X-IASReport-Signing-Certificate")
         .context("No header X-IASReport-Signing-Certificate")?
-        .to_string();
+        .to_str()
+        .context("Failed to decode X-IASReport-Signing-Certificate")?;
 
     // Remove %0A from cert, and only obtain the signing cert
     let cert = cert.replace("%0A", "");
@@ -78,7 +85,7 @@ fn get_report_from_intel(quote: &[u8], ias_key: &str) -> Result<(String, String,
     let sig_cert = v[2].to_string();
 
     // len_num == 0
-    Ok((attn_report, sig, sig_cert))
+    Ok((attn_report, sig.into(), sig_cert))
 }
 
 pub fn create_quote_vec(data: &[u8]) -> Result<Vec<u8>> {

--- a/standalone/pruntime/src/ra.rs
+++ b/standalone/pruntime/src/ra.rs
@@ -14,11 +14,11 @@ fn get_report_from_intel(quote: &[u8], ias_key: &str) -> Result<(String, String,
     let mut res_body_buffer = Vec::new(); //container for body of a response
     let timeout = Some(Duration::from_secs(8));
 
-    let url = format!("https://{}{}", IAS_HOST, IAS_REPORT_ENDPOINT);
+    let url: reqwest::Url = format!("https://{}{}", IAS_HOST, IAS_REPORT_ENDPOINT).parse()?;
     info!("Getting RA report from {}", url);
     let mut res = reqwest::blocking::Client::builder()
         .timeout(timeout)
-        .env_proxy()
+        .env_proxy(url.domain().unwrap_or_default())
         .build()
         .context("Failed to create http client, maybe invalid IAS URI")?
         .post(url)


### PR DESCRIPTION
After doing some research, I find it not easy to transparently proxy the pruntime outgoing connections. The techniques like the [proxychains](https://github.com/rofl0r/proxychains-ng) do not work with gramine-sgx. It is also easy to make mistakes if we use iptables to redirect outgoing TCP connections.
So the easier way would be the pruntime with built-in sock5 proxy support.

This PR adds built-in socks5 proxy support. A proxy server is configured via the `all_proxy` env var. `socks5://` and `socks5h://` are supported. The later also sending DNS queries via the proxy server.
example:
```
all_proxy=socks5h://localhost:1080 ./pruntime
```
We can also set `i2p_proxy` for domains ending with `.i2p`:
```
i2p_proxy=socks5h://localhost:4447 all_proxy=socks5h://localhost:1080 ./pruntime
```

The native contract `BTC_PRICE_BOT` and `GEOLOCATION` are disabled because they are using an http client without proxy supported.