### PR TITLE
pruntime: Some fixes and optimiztions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3916,6 +3916,7 @@ dependencies = [
  "bitmaps",
  "rand_core 0.6.3",
  "rand_xoshiro",
+ "serde",
  "sized-chunks",
  "typenum",
  "version_check",
@@ -7736,6 +7737,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
+ "trie-db",
 ]
 
 [[package]]

--- a/crates/phactory/api/src/ecall_args.rs
+++ b/crates/phactory/api/src/ecall_args.rs
@@ -7,6 +7,9 @@ pub struct InitArgs {
     /// The GK master key sealing path.
     pub sealing_path: String,
 
+    /// The PRuntime persistent data storing path
+    pub storage_path: String,
+
     /// The log filter string to pass to env_logger.
     pub log_filter: String,
 

--- a/crates/phactory/pal/src/lib.rs
+++ b/crates/phactory/pal/src/lib.rs
@@ -36,15 +36,6 @@ pub trait Machine {
     fn cpu_feature_level(&self) -> u32;
 }
 
-pub trait ProtectedFileSystem {
-    type IoError: ErrorType;
-    type ReadFile: std::io::Read;
-    type WriteFile: std::io::Write;
-
-    fn open_protected_file(&self, path: impl AsRef<Path>, key: &[u8]) -> Result<Option<Self::ReadFile>, Self::IoError>;
-    fn create_protected_file(&self, path: impl AsRef<Path>, key: &[u8]) -> Result<Self::WriteFile, Self::IoError>;
-}
-
 pub struct AppVersion {
     pub major: u32,
     pub minor: u32,
@@ -55,5 +46,5 @@ pub trait AppInfo {
     fn app_version() -> AppVersion;
 }
 
-pub trait Platform: Sealing + RA + Machine + MemoryStats + ProtectedFileSystem + AppInfo + Clone {}
-impl<T: Sealing + RA + Machine + MemoryStats + ProtectedFileSystem + AppInfo + Clone> Platform for T {}
+pub trait Platform: Sealing + RA + Machine + MemoryStats + AppInfo + Clone {}
+impl<T: Sealing + RA + Machine + MemoryStats + AppInfo + Clone> Platform for T {}

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -273,6 +273,7 @@ impl<Platform: pal::Platform> Phactory<Platform> {
         self.args = args;
         if let Some(system) = &mut self.system {
             system.sealing_path = self.args.sealing_path.clone();
+            system.storage_path = self.args.storage_path.clone();
             system.geoip_city_db = self.args.geoip_city_db.clone();
         }
     }
@@ -378,7 +379,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         info!("Checkpoint saved to {}", checkpoint_file);
         self.last_checkpoint = Instant::now();
         remove_outdated_checkpoints(
-            &self.args.sealing_path,
+            &self.args.storage_path,
             self.args.max_checkpoint_files,
             current_block,
         )?;

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -20,7 +20,7 @@ use serde::{
 };
 
 use crate::light_validation::LightValidation;
-use std::path::PathBuf;
+use std::{fs::File, io::ErrorKind, path::PathBuf};
 use std::{io::Write, marker::PhantomData};
 use std::{path::Path, str};
 
@@ -51,13 +51,13 @@ use phala_types::WorkerRegistrationInfo;
 use std::time::Instant;
 use types::Error;
 
+pub use chain::BlockNumber;
 pub use contracts::pink;
 pub use prpc_service::dispatch_prpc_request;
 pub use side_task::SideTaskManager;
 pub use storage::{Storage, StorageExt};
 pub use system::gk;
 pub use types::BlockInfo;
-pub use chain::BlockNumber;
 
 pub mod benchmark;
 
@@ -364,25 +364,17 @@ impl<P: pal::Platform> Phactory<P> {
 
 impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> {
     pub fn take_checkpoint(&mut self, current_block: chain::BlockNumber) -> anyhow::Result<()> {
-        let key = if let Some(key) = self.system.as_ref().map(|r| &r.identity_key) {
-            key.dump_secret_key().to_vec()
-        } else {
-            return Err(anyhow!("Take checkpoint failed, runtime is not ready"));
-        };
-
+        let key = self
+            .system
+            .as_ref()
+            .context("Take checkpoint failed, runtime is not ready")?
+            .identity_key
+            .dump_secret_key();
         info!("Taking checkpoint...");
-        let checkpoint_file = checkpoint_filename_for(current_block, &self.args.sealing_path);
-        {
-            // Do serialization
-            let file = self
-                .platform
-                .create_protected_file(&checkpoint_file, &key)
-                .map_err(|err| anyhow!("{:?}", err))
-                .context("Failed to create protected file")?;
-
-            serde_cbor::ser::to_writer(file, &PhactoryDumper(self))
-                .context("Failed to write checkpoint")?;
-        }
+        let checkpoint_file = checkpoint_filename_for(current_block, &self.args.storage_path);
+        let file = File::create(&checkpoint_file).context("Failed to create checkpoint file")?;
+        self.take_checkpoint_to_writer(&key, file)
+            .context("Take checkpoint to writer failed")?;
         info!("Checkpoint saved to {}", checkpoint_file);
         self.last_checkpoint = Instant::now();
         remove_outdated_checkpoints(
@@ -395,13 +387,9 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
 
     pub fn take_checkpoint_to_writer<W: std::io::Write>(
         &mut self,
+        key: &[u8],
         writer: W,
     ) -> anyhow::Result<()> {
-        let key = if let Some(key) = self.system.as_ref().map(|r| &r.identity_key) {
-            key.dump_secret_key().to_vec()
-        } else {
-            return Err(anyhow!("Take checkpoint failed, runtime is not ready"));
-        };
         let key128 = derive_key_for_checkpoint(&key);
         let nonce = rand::thread_rng().gen();
         let mut enc_writer = aead::stream::new_aes128gcm_writer(key128, nonce, writer);
@@ -416,6 +404,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
     pub fn restore_from_checkpoint(
         platform: &Platform,
         sealing_path: &str,
+        storage_path: &str,
         remove_corrupted_checkpoint: bool,
     ) -> anyhow::Result<Option<Self>> {
         let runtime_data = match Self::load_runtime_data(platform, sealing_path) {
@@ -423,15 +412,15 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             other => other.context("Failed to load persistent data")?,
         };
         let files =
-            glob_checkpoint_files_sorted(sealing_path).context("Glob checkpoint files failed")?;
+            glob_checkpoint_files_sorted(storage_path).context("Glob checkpoint files failed")?;
         if files.is_empty() {
             return Ok(None);
         }
         let (_block, ckpt_filename) = &files[0];
 
-        let file = match platform.open_protected_file(&ckpt_filename, &runtime_data.sk) {
-            Ok(Some(file)) => file,
-            Ok(None) => {
+        let file = match File::open(&ckpt_filename) {
+            Ok(file) => file,
+            Err(err) if matches!(err.kind(), ErrorKind::NotFound) => {
                 // This should never happen unless it was removed just after the glob.
                 anyhow::bail!("Checkpoint file {:?} is not found", ckpt_filename);
             }
@@ -453,8 +442,11 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             }
         };
 
-        let loader: PhactoryLoader<_> = match serde_cbor::de::from_reader(file) {
-            Ok(loader) => loader,
+        match Self::restore_from_checkpoint_reader(&runtime_data.sk, file) {
+            Ok(state) => {
+                info!("Succeeded to load checkpoint file {:?}", ckpt_filename);
+                Ok(Some(state))
+            }
             Err(_err /*Don't leak it into the log*/) => {
                 error!("Failed to load checkpoint file {:?}", ckpt_filename);
                 if remove_corrupted_checkpoint {
@@ -464,18 +456,14 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
                 }
                 anyhow::bail!("Failed to load checkpoint file {:?}", ckpt_filename);
             }
-        };
-        info!("Succeeded to load checkpoint file {:?}", ckpt_filename);
-        return Ok(Some(loader.0));
+        }
     }
 
     pub fn restore_from_checkpoint_reader<R: std::io::Read>(
-        platform: &Platform,
-        sealing_path: &str,
+        key: &[u8],
         reader: R,
     ) -> anyhow::Result<Self> {
-        let runtime_data = Self::load_runtime_data(platform, sealing_path)?;
-        let key128 = derive_key_for_checkpoint(&runtime_data.sk);
+        let key128 = derive_key_for_checkpoint(key);
         let dec_reader = aead::stream::new_aes128gcm_reader(key128, reader);
         let loader: PhactoryLoader<_> =
             serde_cbor::de::from_reader(dec_reader).context("Failed to decode state")?;

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -380,6 +380,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         let system = system::System::new(
             self.platform.clone(),
             self.args.sealing_path.clone(),
+            self.args.storage_path.clone(),
             false,
             self.args.geoip_city_db.clone(),
             identity_key,

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -396,6 +396,7 @@ pub struct System<Platform> {
     platform: Platform,
     // Configuration
     pub(crate) sealing_path: String,
+    pub(crate) storage_path: String,
     enable_geoprobing: bool,
     pub(crate) geoip_city_db: String,
     // Messageing
@@ -444,6 +445,7 @@ impl<Platform: pal::Platform> System<Platform> {
     pub fn new(
         platform: Platform,
         sealing_path: String,
+        storage_path: String,
         enable_geoprobing: bool,
         geoip_city_db: String,
         identity_key: sr25519::Pair,
@@ -463,6 +465,7 @@ impl<Platform: pal::Platform> System<Platform> {
         System {
             platform,
             sealing_path,
+            storage_path,
             enable_geoprobing,
             geoip_city_db,
             egress: send_mq.channel(sender, identity_key.clone().0.into()),
@@ -685,7 +688,7 @@ impl<Platform: pal::Platform> System<Platform> {
             self.master_key = Some(master_key);
 
             if need_restart {
-                crate::maybe_remove_checkpoints(&self.sealing_path);
+                crate::maybe_remove_checkpoints(&self.storage_path);
                 panic!("Received master key, please restart pRuntime and pherry");
             }
         } else if let Some(my_master_key) = &self.master_key {

--- a/crates/phala-trie-storage/Cargo.toml
+++ b/crates/phala-trie-storage/Cargo.toml
@@ -10,19 +10,20 @@ repository = "https://github.com/Phala-Network/phala-blockchain"
 [dependencies]
 parity-scale-codec = { version = "3.0", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", default-features = false, features = ["full_crypto"] }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", default-features = false }
-sp-io   = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", features = ["full_crypto"] }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+sp-io   = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
 sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 hash-db = "0.15.2"
+trie-db = "0.23.1"
 im = { version = "15", features = ["serde"] }
 parity-util-mem = "0.11.0"
 
 [dev-dependencies]
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", default-features = false }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", default-features = false, features = ["full_crypto"] }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", features = ["full_crypto"] }
 hash256-std-hasher = { version = "0.15", default-features = false }
 hex = "0.4"
 serde_json = "1.0"

--- a/crates/phala-trie-storage/Cargo.toml
+++ b/crates/phala-trie-storage/Cargo.toml
@@ -17,7 +17,7 @@ sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 hash-db = "0.15.2"
-im = "15"
+im = { version = "15", features = ["serde"] }
 parity-util-mem = "0.11.0"
 
 [dev-dependencies]

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -20,9 +20,6 @@ use sp_trie::{trie_types::TrieDBMutV0 as TrieDBMut, TrieMut};
 
 pub use memdb::GenericMemoryDB as MemoryDB;
 
-
-use sp_trie::HashDBT as _;
-
 /// Storage key.
 pub type StorageKey = Vec<u8>;
 
@@ -102,19 +99,9 @@ where
     H::Out: Codec,
 {
     let root = trie.root();
-    let kvs: Vec<_> = trie
+    let mdb = trie
         .backend_storage()
-        .clone()
-        .drain()
-        .into_iter()
-        .map(|it| it.1)
-        .collect();
-    let mut mdb = MemoryDB::default();
-    for value in kvs {
-        for _ in 0..value.1 {
-            mdb.insert((&[], None), &value.0);
-        }
-    }
+        .clone();
     TrieBackend::new(mdb, *root)
 }
 

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -174,12 +174,7 @@ where
         let _ = core::mem::replace(&mut self.0, TrieBackend::new(storage, root));
     }
 
-    pub fn purge(&mut self) {
-        let root = *self.0.root();
-        let mut storage = core::mem::take(self).0.into_storage();
-        storage.purge();
-        let _ = core::mem::replace(&mut self.0, TrieBackend::new(storage, root));
-    }
+    pub fn purge(&mut self) {}
 
     /// Return the state root hash
     pub fn root(&self) -> &H::Out {

--- a/crates/phala-trie-storage/src/memdb.rs
+++ b/crates/phala-trie-storage/src/memdb.rs
@@ -184,6 +184,14 @@ where
         }
     }
 
+    /// Create a new `MemoryDB` from a given inner hash map.
+    pub fn from_inner(data: HashMap<KF::Key, (T, i32)>) -> Self {
+        MemoryDB {
+            data,
+            ..Default::default()
+        }
+    }
+
     /// Create a new instance of `Self`.
     pub fn new(data: &[u8]) -> Self {
         Self::from_null_node(data, data.into())

--- a/crates/phala-trie-storage/src/memdb.rs
+++ b/crates/phala-trie-storage/src/memdb.rs
@@ -6,7 +6,8 @@ use im::{hashmap::Entry, HashMap};
 use parity_util_mem::{malloc_size, MallocSizeOf, MallocSizeOfOps};
 use std::{borrow::Borrow, cmp::Eq, hash, marker::PhantomData, mem};
 
-use sp_state_machine::{backend::Consolidate, DBValue, DefaultError, TrieBackendStorage};
+use sp_state_machine::{backend::Consolidate, DefaultError, TrieBackendStorage};
+use trie_db::DBValue;
 
 pub trait MaybeDebug: std::fmt::Debug {}
 impl<T: std::fmt::Debug> MaybeDebug for T {}
@@ -700,10 +701,7 @@ mod tests {
 
         main.consolidate(other);
 
-        assert_eq!(
-            main.raw(&remove_key, EMPTY_PREFIX).unwrap(),
-            (&"doggo".as_bytes().to_vec(), 0)
-        );
+        assert_eq!(main.raw(&remove_key, EMPTY_PREFIX), None);
         assert_eq!(
             main.raw(&insert_key, EMPTY_PREFIX).unwrap(),
             (&"arf".as_bytes().to_vec(), 2)

--- a/crates/pink/sidevm/host-runtime/src/service.rs
+++ b/crates/pink/sidevm/host-runtime/src/service.rs
@@ -94,6 +94,10 @@ impl ServiceRun {
                 }
             }
         }
+
+        // To avoid: panicked at 'Cannot drop a runtime in a context where blocking is not allowed.'
+        let handle = self.runtime.handle().clone();
+        handle.spawn_blocking(move || drop(self));
     }
 }
 

--- a/e2e/src/fullstack.js
+++ b/e2e/src/fullstack.js
@@ -203,7 +203,7 @@ describe('A full stack', function () {
             );
             const dataDir = "data";
             assert.isTrue(
-                fs.existsSync(`${tmpPath}/pruntime1/${dataDir}/master_key.seal`),
+                fs.existsSync(`${tmpPath}/pruntime1/${dataDir}/protected_files/master_key.seal`),
                 'master key not received'
             );
         });

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -2553,6 +2553,7 @@ dependencies = [
  "bitmaps",
  "rand_core 0.6.3",
  "rand_xoshiro",
+ "serde",
  "sized-chunks",
  "typenum",
  "version_check",

--- a/standalone/pruntime/gramine-build/Makefile
+++ b/standalone/pruntime/gramine-build/Makefile
@@ -24,7 +24,9 @@ CARGO_ARGS += -vv
 endif
 
 PREFIX ?= ../bin
-PRUNTIME_SEAL_DIR ?= data
+PRUNTIME_DATA_DIR ?= data
+PRUNTIME_SEAL_DIR ?= ${PRUNTIME_DATA_DIR}/protected_files
+PRUNTIME_STORAGE_DIR ?= ${PRUNTIME_DATA_DIR}/storage_files
 
 .PHONY: all
 all: ${BIN_NAME} ${BIN_NAME}.manifest
@@ -46,6 +48,7 @@ ${BIN_NAME}.manifest: ${BIN_NAME}.manifest.template
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Dra_client_spid=${IAS_SPID} \
 		-Dseal_dir=${PRUNTIME_SEAL_DIR} \
+		-Dstorage_dir=${PRUNTIME_STORAGE_DIR} \
 		$< $@
 
 ${BIN_NAME}.manifest.sgx: ${BIN_NAME}.manifest ${BIN_FILE}

--- a/standalone/pruntime/gramine-build/pruntime.manifest.template
+++ b/standalone/pruntime/gramine-build/pruntime.manifest.template
@@ -30,8 +30,13 @@ uri = "file:/lib/x86_64-linux-gnu"
 
 [[fs.mounts]]
 type = "chroot"
-path = "/protected_files"
+path = "/data/protected_files"
 uri = "file:{{ seal_dir }}"
+
+[[fs.mounts]]
+type = "chroot"
+path = "/data/storage_files"
+uri = "file:{{ storage_dir }}"
 
 [[fs.mounts]]
 type = "chroot"
@@ -59,9 +64,10 @@ allowed_files = [
   "file:/etc/hosts",
   "file:/etc/resolv.conf",
   "file:Rocket.toml",
+  "file:{{ storage_dir }}/",
 ]
 
 protected_mrenclave_files = [
-    "file:{{ seal_dir }}"
+    "file:{{ seal_dir }}/"
 ]
 

--- a/standalone/pruntime/gramine-build/pruntime.manifest.template
+++ b/standalone/pruntime/gramine-build/pruntime.manifest.template
@@ -13,7 +13,7 @@ insecure__allow_eventfd = true
 
 [loader.env]
 LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
-M_ARENA_MAX = "1"
+MALLOC_ARENA_MAX = "1"
 ROCKET_WORKERS = "8"
 all_proxy = { passthrough = true }
 i2p_proxy = { passthrough = true }

--- a/standalone/pruntime/src/pal_gramine.rs
+++ b/standalone/pruntime/src/pal_gramine.rs
@@ -3,7 +3,6 @@ use std::alloc::System;
 
 use phactory_pal::{AppInfo, AppVersion, Machine, MemoryStats, MemoryUsage, Sealing, RA};
 use phala_allocator::StatSizeAllocator;
-use std::fs::File;
 use std::io::ErrorKind;
 use std::str::FromStr as _;
 

--- a/standalone/pruntime/src/pal_gramine.rs
+++ b/standalone/pruntime/src/pal_gramine.rs
@@ -1,9 +1,7 @@
 use log::info;
 use std::alloc::System;
 
-use phactory_pal::{
-    AppInfo, AppVersion, Machine, MemoryStats, MemoryUsage, ProtectedFileSystem, Sealing, RA,
-};
+use phactory_pal::{AppInfo, AppVersion, Machine, MemoryStats, MemoryUsage, Sealing, RA};
 use phala_allocator::StatSizeAllocator;
 use std::fs::File;
 use std::io::ErrorKind;
@@ -35,38 +33,6 @@ impl Sealing for GraminePlatform {
             Err(err) if matches!(err.kind(), ErrorKind::NotFound) => Ok(None),
             other => other.map(Some),
         }
-    }
-}
-
-impl ProtectedFileSystem for GraminePlatform {
-    type IoError = std::io::Error;
-
-    type ReadFile = File;
-
-    type WriteFile = File;
-
-    fn open_protected_file(
-        &self,
-        path: impl AsRef<std::path::Path>,
-        _key: &[u8],
-    ) -> Result<Option<Self::ReadFile>, Self::IoError> {
-        let todo = "Kevin: Use the key to encrypt the file";
-        // We currently use the mrenclave protected fs to store the data, so no need to encrypt twice.
-        // Gramine has a plan to support set key for individual files. We can turn back to use the key
-        // once gramine finish the feature.
-
-        match std::fs::File::open(path) {
-            Err(err) if matches!(err.kind(), ErrorKind::NotFound) => Ok(None),
-            other => other.map(Some),
-        }
-    }
-
-    fn create_protected_file(
-        &self,
-        path: impl AsRef<std::path::Path>,
-        _key: &[u8],
-    ) -> Result<Self::WriteFile, Self::IoError> {
-        std::fs::File::create(path)
     }
 }
 

--- a/standalone/pruntime/src/runtime.rs
+++ b/standalone/pruntime/src/runtime.rs
@@ -25,6 +25,7 @@ pub fn ecall_init(args: phactory_api::ecall_args::InitArgs) -> Result<()> {
         match Phactory::restore_from_checkpoint(
             &GraminePlatform,
             &args.sealing_path,
+            &args.storage_path,
             args.remove_corrupted_checkpoint,
         ) {
             Ok(Some(mut factory)) => {


### PR DESCRIPTION
Main changes in this PR:
- [Encrypt state checkpoint with custom AEAD instead of gramine protected files](https://github.com/Phala-Network/phala-blockchain/pull/838/commits/18ed9c29a5732f8f6a6b60f0afa38db0d2b6de51)
   This enables resync-free pruntime upgrading in the future
- [Remove the slow GC in MemoryDB](https://github.com/Phala-Network/phala-blockchain/pull/838/commits/3d1777fd0f5a2498f96c18cc3c40b5275cda4932)
   Instead, we remove the value immediately once its ref count goes zero. This makes it possible to sync the pruntime from scratch in `4` hours.
- [Zero overhead MemoryDB ser/de](https://github.com/Phala-Network/phala-blockchain/pull/838/commits/29dec9e722b4d4571fe6d3adb46f4886e46e186f)
   In the previous implementation, we collect the key/value pairs into a Vec<(k,v)> before the serialization because the third-party MemoryDB does NOT export enough pub API to get the inner hashmap and to create an instance from the inner hashmap.
- Some other minor fixes.