### PR TITLE
pherry: Turn down the default block batch size to 4

### DIFF
--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -128,7 +128,7 @@ struct Args {
     fetch_blocks: u32,
 
     #[clap(
-        default_value = "10",
+        default_value = "4",
         long = "sync-blocks",
         help = "The batch size to sync blocks to pRuntime."
     )]


### PR DESCRIPTION
Too large batch could let the RPC to the node to fail with:
```
The background task been terminated because:
  Networking or low-level protocol error:
    WebSocket connection error:
      message too large: len >= 11443848, maximum = 10485760; restart required
```