### PR TITLE
pink: Use log::LevelFilter instead of log::Level to set the log level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7967,7 +7967,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ink_env",
  "ink_lang",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "pink-sidevm-logger"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "log",
  "pink-sidevm-env",

--- a/crates/pink/examples/start_sidevm/sideprog/src/lib.rs
+++ b/crates/pink/examples/start_sidevm/sideprog/src/lib.rs
@@ -5,7 +5,7 @@ use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[sidevm::main]
 async fn main() {
-    sidevm::logger::Logger::with_max_level(log::Level::Trace).init();
+    sidevm::logger::Logger::with_max_level(log::LevelFilter::Trace).init();
     sidevm::ocall::enable_ocall_trace(true).unwrap();
 
     let address = "127.0.0.1:18080";

--- a/crates/pink/pink-extension/Cargo.toml
+++ b/crates/pink/pink-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pink-extension"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2018"
 description = "Phala's ink! for writing fat contracts"
 license = "Apache-2.0"

--- a/crates/pink/pink-extension/src/logger.rs
+++ b/crates/pink/pink-extension/src/logger.rs
@@ -1,7 +1,7 @@
 //! Logger for Pink contracts.
 
 use core::sync::atomic::{AtomicBool, Ordering};
-pub use log::{self, Level};
+pub use log::{self, LevelFilter as Level};
 use log::{Log, Metadata, Record};
 
 /// A logger working inside a Pink contract.
@@ -17,7 +17,7 @@ impl Logger {
 
     /// Install the logger as the global logger.
     pub fn init(&'static self) {
-        log::set_max_level(self.max_level.to_level_filter());
+        log::set_max_level(self.max_level);
         log::set_logger(self).unwrap();
     }
 }
@@ -29,6 +29,7 @@ impl Log for Logger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
+            use log::Level;
             let message = alloc::format!("{}", record.args());
             let level = match record.level() {
                 Level::Error => 1,

--- a/crates/pink/sidevm/examples/httpclient/src/lib.rs
+++ b/crates/pink/sidevm/examples/httpclient/src/lib.rs
@@ -6,7 +6,7 @@ use log::info;
 
 #[sidevm::main]
 async fn main() {
-    sidevm::logger::Logger::with_max_level(log::Level::Trace).init();
+    sidevm::logger::Logger::with_max_level(log::LevelFilter::Trace).init();
     sidevm::ocall::enable_ocall_trace(true).unwrap();
 
     let url = "https://example.com/";

--- a/crates/pink/sidevm/examples/httpserver/src/lib.rs
+++ b/crates/pink/sidevm/examples/httpserver/src/lib.rs
@@ -28,7 +28,7 @@ async fn handle(request: Request<Body>) -> Result<Response<Body>, Infallible> {
 
 #[sidevm::main]
 async fn main() {
-    sidevm::logger::Logger::with_max_level(log::Level::Trace).init();
+    sidevm::logger::Logger::with_max_level(log::LevelFilter::Trace).init();
     sidevm::ocall::enable_ocall_trace(true).unwrap();
 
     let make_svc = hyper::service::make_service_fn(|_conn| async {

--- a/crates/pink/sidevm/examples/recv_messages/src/lib.rs
+++ b/crates/pink/sidevm/examples/recv_messages/src/lib.rs
@@ -5,7 +5,7 @@ use sidevm::{logger::Logger, ocall};
 
 #[sidevm::main]
 async fn main() {
-    Logger::with_max_level(log::Level::Trace).init();
+    Logger::with_max_level(log::LevelFilter::Trace).init();
     ocall::enable_ocall_trace(true).unwrap();
 
     loop {

--- a/crates/pink/sidevm/examples/tcpclient/src/lib.rs
+++ b/crates/pink/sidevm/examples/tcpclient/src/lib.rs
@@ -5,7 +5,7 @@ use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[sidevm::main]
 async fn main() {
-    sidevm::logger::Logger::with_max_level(log::Level::Trace).init();
+    sidevm::logger::Logger::with_max_level(log::LevelFilter::Trace).init();
     sidevm::ocall::enable_ocall_trace(true).unwrap();
 
     let host = "example.com";

--- a/crates/pink/sidevm/examples/tcpserver/src/lib.rs
+++ b/crates/pink/sidevm/examples/tcpserver/src/lib.rs
@@ -5,7 +5,7 @@ use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[sidevm::main]
 async fn main() {
-    sidevm::logger::Logger::with_max_level(log::Level::Trace).init();
+    sidevm::logger::Logger::with_max_level(log::LevelFilter::Trace).init();
     sidevm::ocall::enable_ocall_trace(true).unwrap();
 
     let address = "127.0.0.1:9999";

--- a/crates/pink/sidevm/examples/timer/src/lib.rs
+++ b/crates/pink/sidevm/examples/timer/src/lib.rs
@@ -9,7 +9,7 @@ use sidevm::{logger::Logger, ocall};
 
 #[sidevm::main]
 async fn main() {
-    Logger::with_max_level(log::Level::Trace).init();
+    Logger::with_max_level(log::LevelFilter::Trace).init();
     ocall::enable_ocall_trace(true).unwrap();
     info!("creating channel...");
     let (tx, mut rx) = channel(100);

--- a/crates/pink/sidevm/logger/Cargo.toml
+++ b/crates/pink/sidevm/logger/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://github.com/Phala-Network/phala-blockchain"
 license = "Apache-2.0"
 edition = "2021"
 name = "pink-sidevm-logger"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 log = { version = "0.4.16", features = ["std"] }

--- a/crates/pink/sidevm/logger/src/lib.rs
+++ b/crates/pink/sidevm/logger/src/lib.rs
@@ -1,22 +1,22 @@
 //! Logger for sidevm programs.
 
-use log::{Level, Log, Metadata, Record};
+use log::{LevelFilter, Log, Metadata, Record};
 use pink_sidevm_env::ocall_funcs_guest as ocall;
 
 /// A logger working inside a Sidevm.
 pub struct Logger {
-    max_level: Level,
+    max_level: LevelFilter,
 }
 
 impl Logger {
     /// Create a new logger with the given maximum level.
-    pub fn with_max_level(max_level: Level) -> Self {
+    pub fn with_max_level(max_level: LevelFilter) -> Self {
         Self { max_level }
     }
 
     /// Install the logger as the global logger.
     pub fn init(self) {
-        log::set_max_level(self.max_level.to_level_filter());
+        log::set_max_level(self.max_level);
         log::set_boxed_logger(Box::new(self)).unwrap();
     }
 }


### PR DESCRIPTION
We misuse the log::Level in the previous implementation.
There is an `Off` in `LevelFilter` but not in `Level`.