### PR TITLE
gramine-build: Use relative path for files mounted into enclave

### DIFF
--- a/crates/pink/pink-extension-runtime/Cargo.toml
+++ b/crates/pink/pink-extension-runtime/Cargo.toml
@@ -12,6 +12,6 @@ pink-extension = { version = "0.1", path = "../pink-extension" }
 reqwest-env-proxy = { version = "0.1", path = "../../reqwest-env-proxy" }
 sp-core = { version = "6" }
 sp-runtime-interface = { version = "6", features = ["disable_target_static_assertions"] }
-reqwest = "0.11"
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "socks", "blocking"] }
 log = "0.4"
 ring = "0.16"

--- a/dockerfile.d/01_apt_gramine.sh
+++ b/dockerfile.d/01_apt_gramine.sh
@@ -1,7 +1,7 @@
 set -e
 apt update
 apt upgrade -y
-apt install -y apt-utils apt-transport-https software-properties-common readline-common curl vim wget gnupg gnupg2 gnupg-agent ca-certificates unzip lsb-release debhelper gettext cmake reprepro autoconf automake bison build-essential curl dpkg-dev expect flex gcc gdb git git-core gnupg kmod libboost-system-dev libboost-thread-dev libcurl4-openssl-dev libiptcdata0-dev libjsoncpp-dev liblog4cpp5-dev libprotobuf-dev libssl-dev libtool libxml2-dev uuid-dev ocaml ocamlbuild pkg-config protobuf-compiler python texinfo llvm clang libclang-dev nginx python3-pip libprotobuf-c1
+apt install -y apt-utils apt-transport-https software-properties-common readline-common curl vim wget gnupg gnupg2 gnupg-agent ca-certificates unzip lsb-release debhelper gettext cmake reprepro autoconf automake bison build-essential curl dpkg-dev expect flex gcc gdb git git-core gnupg kmod libboost-system-dev libboost-thread-dev libcurl4-openssl-dev libiptcdata0-dev libjsoncpp-dev liblog4cpp5-dev libprotobuf-dev libssl-dev libtool libxml2-dev uuid-dev ocaml ocamlbuild pkg-config protobuf-compiler python texinfo llvm clang libclang-dev nginx python3-pip libprotobuf-c1 rsync
 curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
 echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ stable main' | tee /etc/apt/sources.list.d/gramine.list
 apt update

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -889,22 +889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,21 +1711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,19 +2467,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3263,24 +3219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "node-primitives"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
@@ -3463,51 +3401,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.98",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_pipe"
@@ -5046,12 +4939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
-
-[[package]]
 name = "polling"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5644,13 +5531,11 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.6",
@@ -5659,7 +5544,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-socks",
  "tower-service",
@@ -6030,16 +5914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
-dependencies = [
- "lazy_static",
- "windows-sys",
-]
-
-[[package]]
 name = "schnorrkel"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6160,29 +6034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -7690,16 +7541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-proxy"
 version = "0.1.0"
 source = "git+https://github.com/Phala-Network/tokio-proxy#e98d21a0ff7bf7a3bea413b2ee336b0d4da1e213"
@@ -8141,12 +7982,6 @@ dependencies = [
  "ctor",
  "version_check",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version"

--- a/standalone/pruntime/gramine-build/.gitignore
+++ b/standalone/pruntime/gramine-build/.gitignore
@@ -7,3 +7,4 @@
 /pruntime.token
 /bin
 /data
+/cruntime

--- a/standalone/pruntime/gramine-build/Makefile
+++ b/standalone/pruntime/gramine-build/Makefile
@@ -75,7 +75,7 @@ ${BIN_NAME}.manifest.sgx: ${BIN_NAME}.manifest ${BIN_NAME} ${LIBOS}
 
 ${LIBOS}:
 	mkdir -p ${RUNTIME_DIR}
-	cp -rfLT ${GRAMINE_RUNTIME_DIR} ${RUNTIME_DIR}/lib
+	rsync -r --no-links ${GRAMINE_RUNTIME_DIR}/ ${RUNTIME_DIR}/lib
 ifeq ($(USE_MUSL),0)
 	cp -rfL ${HOST_LIBC_DIR}/libgcc_s.so.1 ${RUNTIME_DIR}/lib/
 endif

--- a/standalone/pruntime/gramine-build/Makefile
+++ b/standalone/pruntime/gramine-build/Makefile
@@ -14,6 +14,14 @@ BIN_NAME = pruntime
 DATA_DIRS = data/protected_files \
             data/storage_files
 
+GRAMINE_DIR ?= $(shell ./gramine-dir libs)
+GRAMINE_LIBOS ?= $(shell ./gramine-dir libos)
+GRAMINE_RUNTIME_DIR ?= $(shell ./gramine-dir runtime)
+
+CRUNTIME = cruntime
+LIBOS_BASENAME ?= $(shell basename ${GRAMINE_LIBOS})
+LIBOS ?= ${CRUNTIME}/${LIBOS_BASENAME}
+
 ifeq ($(USE_MUSL),1)
 BIN_FILE = ../target/x86_64-unknown-linux-musl/release/${BIN_NAME}
 CARGO_ARGS = --target x86_64-unknown-linux-musl
@@ -51,15 +59,27 @@ ${BIN_NAME}.manifest: ${BIN_NAME}.manifest.template
 		-Dra_client_spid=${IAS_SPID} \
 		-Dseal_dir=${PRUNTIME_SEAL_DIR} \
 		-Dstorage_dir=${PRUNTIME_STORAGE_DIR} \
+		-Dlibdir=${CRUNTIME}/lib/ \
+		-Dlibos=${LIBOS} \
 		$< $@
 
-${BIN_NAME}.manifest.sgx: ${BIN_NAME}.manifest ${BIN_NAME}
+${BIN_NAME}.manifest.sgx: ${BIN_NAME}.manifest ${BIN_NAME} ${LIBOS}
 	@test -s $(SGX_SIGNER_KEY) || \
 	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	gramine-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
+
+${LIBOS}:
+	mkdir -p ${CRUNTIME}
+	cp -rfLT ${GRAMINE_RUNTIME_DIR} ${CRUNTIME}/lib
+	mkdir -p ${CRUNTIME}/lib/x86_64-linux-gnu/
+	for f in "libssl.so.1.1" "libcrypto.so.1.1" "libgcc_s.so.1"; do \
+		cp -rfL /lib/x86_64-linux-gnu/$$f ${CRUNTIME}/lib/x86_64-linux-gnu/; \
+	done
+	cp -rfL ${GRAMINE_DIR}/sgx ${CRUNTIME}/
+	cp -rfL ${GRAMINE_LIBOS} ${CRUNTIME}/
 
 ${BIN_NAME}.sig: ${BIN_NAME}.manifest.sgx
 
@@ -81,6 +101,7 @@ clean:
 	$(RM) *.token *.sig *.manifest.sgx *.manifest ${BIN_NAME}.o ${BIN_NAME} OUTPUT
 	$(RM) -rf ../target
 	$(RM) -rf data
+	$(RM) -rf ${CRUNTIME}
 
 .PHONY: distclean
 distclean: clean
@@ -93,6 +114,8 @@ dist: all
 ifeq ($(SGX),1)
 	cp ${BIN_NAME}.manifest.sgx ${PREFIX}/
 	cp ${BIN_NAME}.sig ${PREFIX}/
+	cp -rfL ${CRUNTIME} ${PREFIX}/
+	cp gramine-sgx ${PREFIX}/
 endif
 	cp ${BIN_NAME}.manifest ${PREFIX}/
 
@@ -100,7 +123,7 @@ endif
 run: all token
 	make dirs
 ifeq ($(SGX),1)
-	gramine-sgx pruntime
+	./gramine-sgx pruntime
 else
 	gramine-direct pruntime
 endif

--- a/standalone/pruntime/gramine-build/Makefile
+++ b/standalone/pruntime/gramine-build/Makefile
@@ -25,9 +25,11 @@ LIBOS ?= ${RUNTIME_DIR}/${LIBOS_BASENAME}
 ifeq ($(USE_MUSL),1)
 BIN_FILE = ../target/x86_64-unknown-linux-musl/release/${BIN_NAME}
 CARGO_ARGS = --target x86_64-unknown-linux-musl
+HOST_LIBC_DIR = /lib/x86_64-linux-musl
 else
 BIN_FILE = ../target/release/${BIN_NAME}
 CARGO_ARGS =
+HOST_LIBC_DIR = /lib/x86_64-linux-gnu
 endif
 
 ifeq ($(V),1)
@@ -74,10 +76,9 @@ ${BIN_NAME}.manifest.sgx: ${BIN_NAME}.manifest ${BIN_NAME} ${LIBOS}
 ${LIBOS}:
 	mkdir -p ${RUNTIME_DIR}
 	cp -rfLT ${GRAMINE_RUNTIME_DIR} ${RUNTIME_DIR}/lib
-	mkdir -p ${RUNTIME_DIR}/lib/x86_64-linux-gnu/
-	for f in "libssl.so.1.1" "libcrypto.so.1.1" "libgcc_s.so.1"; do \
-		cp -rfL /lib/x86_64-linux-gnu/$$f ${RUNTIME_DIR}/lib/x86_64-linux-gnu/; \
-	done
+ifeq ($(USE_MUSL),0)
+	cp -rfL ${HOST_LIBC_DIR}/libgcc_s.so.1 ${RUNTIME_DIR}/lib/
+endif
 	cp -rfL ${GRAMINE_DIR}/sgx ${RUNTIME_DIR}/
 	cp -rfL ${GRAMINE_LIBOS} ${RUNTIME_DIR}/
 

--- a/standalone/pruntime/gramine-build/Makefile
+++ b/standalone/pruntime/gramine-build/Makefile
@@ -18,9 +18,9 @@ GRAMINE_DIR ?= $(shell ./gramine-dir libs)
 GRAMINE_LIBOS ?= $(shell ./gramine-dir libos)
 GRAMINE_RUNTIME_DIR ?= $(shell ./gramine-dir runtime)
 
-CRUNTIME = cruntime
+RUNTIME_DIR = cruntime
 LIBOS_BASENAME ?= $(shell basename ${GRAMINE_LIBOS})
-LIBOS ?= ${CRUNTIME}/${LIBOS_BASENAME}
+LIBOS ?= ${RUNTIME_DIR}/${LIBOS_BASENAME}
 
 ifeq ($(USE_MUSL),1)
 BIN_FILE = ../target/x86_64-unknown-linux-musl/release/${BIN_NAME}
@@ -59,7 +59,7 @@ ${BIN_NAME}.manifest: ${BIN_NAME}.manifest.template
 		-Dra_client_spid=${IAS_SPID} \
 		-Dseal_dir=${PRUNTIME_SEAL_DIR} \
 		-Dstorage_dir=${PRUNTIME_STORAGE_DIR} \
-		-Dlibdir=${CRUNTIME}/lib/ \
+		-Dlibdir=${RUNTIME_DIR}/lib/ \
 		-Dlibos=${LIBOS} \
 		$< $@
 
@@ -72,14 +72,14 @@ ${BIN_NAME}.manifest.sgx: ${BIN_NAME}.manifest ${BIN_NAME} ${LIBOS}
 		--output $@
 
 ${LIBOS}:
-	mkdir -p ${CRUNTIME}
-	cp -rfLT ${GRAMINE_RUNTIME_DIR} ${CRUNTIME}/lib
-	mkdir -p ${CRUNTIME}/lib/x86_64-linux-gnu/
+	mkdir -p ${RUNTIME_DIR}
+	cp -rfLT ${GRAMINE_RUNTIME_DIR} ${RUNTIME_DIR}/lib
+	mkdir -p ${RUNTIME_DIR}/lib/x86_64-linux-gnu/
 	for f in "libssl.so.1.1" "libcrypto.so.1.1" "libgcc_s.so.1"; do \
-		cp -rfL /lib/x86_64-linux-gnu/$$f ${CRUNTIME}/lib/x86_64-linux-gnu/; \
+		cp -rfL /lib/x86_64-linux-gnu/$$f ${RUNTIME_DIR}/lib/x86_64-linux-gnu/; \
 	done
-	cp -rfL ${GRAMINE_DIR}/sgx ${CRUNTIME}/
-	cp -rfL ${GRAMINE_LIBOS} ${CRUNTIME}/
+	cp -rfL ${GRAMINE_DIR}/sgx ${RUNTIME_DIR}/
+	cp -rfL ${GRAMINE_LIBOS} ${RUNTIME_DIR}/
 
 ${BIN_NAME}.sig: ${BIN_NAME}.manifest.sgx
 
@@ -101,7 +101,7 @@ clean:
 	$(RM) *.token *.sig *.manifest.sgx *.manifest ${BIN_NAME}.o ${BIN_NAME} OUTPUT
 	$(RM) -rf ../target
 	$(RM) -rf data
-	$(RM) -rf ${CRUNTIME}
+	$(RM) -rf ${RUNTIME_DIR}
 
 .PHONY: distclean
 distclean: clean
@@ -114,7 +114,7 @@ dist: all
 ifeq ($(SGX),1)
 	cp ${BIN_NAME}.manifest.sgx ${PREFIX}/
 	cp ${BIN_NAME}.sig ${PREFIX}/
-	cp -rfL ${CRUNTIME} ${PREFIX}/
+	cp -rfL ${RUNTIME_DIR} ${PREFIX}/
 	cp gramine-sgx ${PREFIX}/
 endif
 	cp ${BIN_NAME}.manifest ${PREFIX}/

--- a/standalone/pruntime/gramine-build/gramine-dir
+++ b/standalone/pruntime/gramine-build/gramine-dir
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+from argparse import ArgumentParser
+
+from graminelibos.gen_jinja_env import make_env
+
+
+parser = ArgumentParser()
+parser.add_argument("dirtype", default="libs", help="libs, runtime, libos or sgx")
+
+
+def get_libs_dir(dirtype):
+    tmpl_vars = make_env().globals["gramine"]
+    if dirtype == "libs":
+        return tmpl_vars["pkglibdir"]
+    elif dirtype == "runtime":
+        return tmpl_vars["runtimedir"]()
+    elif dirtype == "libos":
+        return tmpl_vars["libos"]
+    elif dirtype == "sgx":
+        return get_libs_dir("libs") / "sgx"
+    else:
+        return None
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    path = get_libs_dir(args.dirtype)
+    if path is None:
+        print("Invalid dirtype")
+        parser.print_help()
+        exit(1)
+    print(path)

--- a/standalone/pruntime/gramine-build/gramine-sgx
+++ b/standalone/pruntime/gramine-build/gramine-sgx
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+GRAMINE_DIR="$PWD/cruntime"
+PAL_CMD="$GRAMINE_DIR/sgx/loader"
+LIBPAL_PATH="$GRAMINE_DIR/sgx/libpal.so"
+
+APPLICATION=
+
+
+while [ "$1" != "" ];
+do
+	if [ "$APPLICATION" == "" ]; then
+		APPLICATION=$1
+		shift
+		continue
+	fi
+	break
+done
+
+if [ "$APPLICATION" == "" ]; then
+	echo "Usage: $0 [<application>] <args>..."
+	exit 2
+fi
+
+if [ ! -e "$APPLICATION.manifest.sgx" ]; then
+    echo "Invalid application path specified ($APPLICATION.manifest.sgx does not exist)." >&2
+    echo "The path should point to application configuration files, so that they can be" >&2
+    echo "found after appending corresponding extensions." >&2
+    exit 2
+fi
+
+if [ ! -f "$PAL_CMD" ]; then
+	echo "$PAL_CMD not found"
+	exit 1
+fi
+
+CMD=("$PAL_CMD" "$LIBPAL_PATH" init "$APPLICATION" "$@")
+eval "${CMD[@]}"

--- a/standalone/pruntime/gramine-build/pruntime.manifest.template
+++ b/standalone/pruntime/gramine-build/pruntime.manifest.template
@@ -2,8 +2,7 @@
 entrypoint = "pruntime"
 
 [loader]
-preload = "file:{{ gramine.libos }}" # for compatibility with v1.0
-entrypoint = "file:{{ gramine.libos }}"
+entrypoint = "file:{{ libos }}"
 log_level = "{{ log_level }}"
 argv0_override = "pruntime"
 insecure__use_cmdline_argv = true
@@ -22,12 +21,7 @@ i2p_proxy = { passthrough = true }
 [[fs.mounts]]
 type = "chroot"
 path = "/lib"
-uri = "file:{{ gramine.runtimedir() }}"
-
-[[fs.mounts]]
-type = "chroot"
-path = "/lib/x86_64-linux-gnu"
-uri = "file:/lib/x86_64-linux-gnu"
+uri = "file:{{ libdir }}"
 
 [[fs.mounts]]
 type = "chroot"
@@ -55,10 +49,9 @@ ra_client_linkable = true
 ra_client_spid = "{{ ra_client_spid }}"
 
 trusted_files = [
-  "file:{{ gramine.libos }}",
+  "file:{{ libos }}",
   "file:pruntime",
-  "file:{{ gramine.runtimedir() }}/",
-  "file:/lib/x86_64-linux-gnu/",
+  "file:{{ libdir }}",
 ]
 
 allowed_files = [


### PR DESCRIPTION
This makes it easier to run multiple versions of pruntime in a single container.
Self explained steps:
```
cd standalone/pruntime/gramine-build
make run
```
Or
```
cd standalone/pruntime/gramine-build
make dist
cd ../bin
# make token if it is needed
# cp ../gramine-build/pruntime.token .
./gramine-sgx pruntime
```