### PR TITLE
Send the nonce of Command(InkMessage) to log handler

### DIFF
--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -6,12 +6,16 @@ use phala_mq::{ContractClusterId, ContractId, MessageOrigin};
 use pink::runtime::{BoxedEventCallbacks, ExecSideEffects};
 use runtime::{AccountId, BlockNumber, Hash};
 use sidevm::service::{Command as SidevmCommand, CommandSender, SystemMessage};
+use sp_runtime::{traits::ConstU32, BoundedVec};
 
 use super::contract_address_to_id;
 
 #[derive(Debug, Encode, Decode)]
 pub enum Command {
-    InkMessage { nonce: Vec<u8>, message: Vec<u8> },
+    InkMessage {
+        nonce: BoundedVec<u8, ConstU32<32>>,
+        message: Vec<u8>,
+    },
 }
 
 #[derive(Debug, Encode, Decode)]
@@ -190,7 +194,7 @@ impl contracts::NativeContract for Pink {
                             origin: origin.clone().into(),
                             contract: self.instance.address.clone().into(),
                             block_number: context.block.block_number,
-                            nonce,
+                            nonce: nonce.into_inner(),
                             output: result.result.encode(),
                         },
                     )) {

--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -162,7 +162,7 @@ impl contracts::NativeContract for Pink {
         context: &mut contracts::NativeContext,
     ) -> TransactionResult {
         match cmd {
-            Command::InkMessage { nonce: _, message } => {
+            Command::InkMessage { nonce, message } => {
                 let origin: runtime::AccountId = match origin {
                     MessageOrigin::AccountId(origin) => origin.0.into(),
                     _ => return Err(TransactionError::BadOrigin),
@@ -190,6 +190,7 @@ impl contracts::NativeContract for Pink {
                             origin: origin.clone().into(),
                             contract: self.instance.address.clone().into(),
                             block_number: context.block.block_number,
+                            nonce,
                             output: result.result.encode(),
                         },
                     )) {

--- a/crates/pink/sidevm/env/src/messages.rs
+++ b/crates/pink/sidevm/env/src/messages.rs
@@ -31,6 +31,7 @@ pub enum SystemMessage {
         block_number: u32,
         origin: AccountId,
         contract: AccountId,
+        nonce: Vec<u8>,
         output: Vec<u8>,
     },
 }


### PR DESCRIPTION
Sorry, I forgot this. That's exactly the purpose of the nonce. It may be used to connect the message output to it's original TX.