### PR TITLE
Keep mq dispatching order

### DIFF
--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -572,12 +572,23 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             .mq_messages()
             .map_err(|_| from_display("Can not get mq messages from storage"))?;
 
+        state.recv_mq.reset_local_index();
+
         let now_ms = state
             .chain_storage
             .timestamp_now()
             .ok_or_else(|| from_display("No timestamp found in block"))?;
 
-        state.recv_mq.reset_local_index();
+        let mut block = BlockInfo {
+            block_number,
+            now_ms,
+            storage: &state.chain_storage,
+            send_mq: &state.send_mq,
+            recv_mq: &mut state.recv_mq,
+            side_task_man: &mut self.side_task_man,
+        };
+
+        system.will_process_block(&mut block);
 
         for message in messages {
             use phala_types::messaging::SystemEvent;
@@ -607,23 +618,15 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
                     message.sender, message.destination
                 );
             }
-            state.recv_mq.dispatch(message);
-
-            let mut block = BlockInfo {
-                block_number,
-                now_ms,
-                storage: &state.chain_storage,
-                send_mq: &state.send_mq,
-                recv_mq: &mut state.recv_mq,
-                side_task_man: &mut self.side_task_man,
-            };
+            block.recv_mq.dispatch(message);
 
             system.process_messages(&mut block);
+        }
+        system.did_process_block(&mut block);
 
-            let n_unhandled = state.recv_mq.clear();
-            if n_unhandled > 0 {
-                warn!("There are {} unhandled messages dropped", n_unhandled);
-            }
+        let n_unhandled = block.recv_mq.clear();
+        if n_unhandled > 0 {
+            warn!("There are {} unhandled messages dropped", n_unhandled);
         }
 
         let block_time = now_ms / 1000;

--- a/crates/phactory/src/system/gk.rs
+++ b/crates/phactory/src/system/gk.rs
@@ -196,8 +196,10 @@ where
     }
 
     pub fn master_pubkey_uploaded(&mut self, master_pubkey: sr25519::Public) {
-        assert!(
-            self.master_key.public() == master_pubkey,
+        #[cfg(not(feature = "shadow-gk"))]
+        assert_eq!(
+            self.master_key.public(),
+            master_pubkey,
             "local and on-chain master key mismatch"
         );
         self.master_pubkey_on_chain = true;

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -344,7 +344,7 @@ pub mod messaging {
     }
 
     bind_topic!(MiningInfoUpdateEvent<BlockNumber>, b"^phala/mining/update");
-    #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo)]
+    #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, Default)]
     pub struct MiningInfoUpdateEvent<BlockNumber> {
         /// The block emiting this message.
         pub block_number: BlockNumber,


### PR DESCRIPTION
Previously, the dispatching order for `phala-mq` was only kept within a `phala_mq::select!` block.
This PR keeps the order globally. 

There might be some performance impacts because the memory accessing would be frequently jumping from one contract to another which is not cache friendly and would cause more EPC page faults.