### PR TITLE
pherry: fix panics while using cache

### DIFF
--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -7,7 +7,7 @@ use phaxt::{
 };
 use std::io::{Read, Write};
 
-use log::info;
+use log::{error, info, warn};
 
 pub use phactory_api::blocks::{AuthoritySetChange, BlockHeaderWithChanges, GenesisBlockInfo};
 
@@ -361,8 +361,27 @@ impl Client {
     }
 
     async fn request<T: Decode>(&self, url: &str) -> Result<T> {
-        let body = reqwest::get(url).await?.bytes().await?;
-        Ok(T::decode(&mut &body[..])?)
+        let response = reqwest::get(url).await.map_err(|err| {
+            warn!("Failed to fetch data from cache: {err}");
+            err
+        })?;
+        let status = response.status();
+        info!("Requested cache from {url} ({})", status.as_u16());
+        if !status.is_success() {
+            return Err(anyhow!(
+                "Failed to fetch data from cache with status={}",
+                status.as_u16()
+            ));
+        }
+        let body = response.bytes().await.map_err(|err| {
+            error!("Failed to read cache response: {err}");
+            err
+        })?;
+        let decoded = T::decode(&mut &body[..]).map_err(|err| {
+            error!("Failed to decode cache response: {err}");
+            err
+        })?;
+        Ok(decoded)
     }
 
     pub async fn get_headers(&self, block_number: BlockNumber) -> Result<Vec<BlockInfo>> {

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -368,10 +368,10 @@ impl Client {
         let status = response.status();
         info!("Requested cache from {url} ({})", status.as_u16());
         if !status.is_success() {
-            return Err(anyhow!(
+            anyhow::bail!(
                 "Failed to fetch data from cache with status={}",
                 status.as_u16()
-            ));
+            );
         }
         let body = response.bytes().await.map_err(|err| {
             error!("Failed to read cache response: {err}");

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -679,6 +679,7 @@ async fn maybe_sync_waiting_parablocks(
     info: &PhactoryInfo,
     batch_window: BlockNumber,
 ) -> Result<()> {
+    info!("Syncing waiting parablocks...");
     let mut fin_header = None;
     if let Some(cache) = &cache_client {
         let mut cached_headers = cache


### PR DESCRIPTION
This fixes the bug reported by Wang Zhe @skysummerice : 
```
[2022-08-27T15:09:25.966576Z INFO  pherry] pRuntime get_info response: PhactoryInfo {
        initialized: true,
        registered: false,
        genesis_block_hash: Some(
            "ff93a4a903207ad45af110a3e15f8b66c903a0045f886c528c23fe7064532b08",
        ),
        public_key: Some(
            "78aaed50c54bc3912214991ad9b230ad3bc47c88e6504a81b65a4925372ba27f",
        ),
        ecdh_public_key: Some(
            "78aaed50c54bc3912214991ad9b230ad3bc47c88e6504a81b65a4925372ba27f",
        ),
        headernum: 8325312,
        para_headernum: 1,
        blocknum: 1,
        state_root: "fd2e3e07ed2d610c6c0c6c3cd6858fff733fe53c03bd75d46f25e7c69dec490b",
        dev_mode: false,
        pending_messages: 0,
        score: 0,
        gatekeeper: Some(
            GatekeeperStatus {
                role: None,
                master_public_key: "",
            },
        ),
        version: "0.2.4",
        git_revision: "848b954d581c2fa60b1024cc7f3a1322b4ca027f",
        running_side_tasks: 0,
        memory_usage: Some(
            MemoryUsage {
                rust_used: 595582,
                rust_peak_used: 2113034,
                total_peak_used: 42037248,
            },
        ),
        number_of_clusters: 0,
        number_of_contracts: 0,
        waiting_for_paraheaders: false,
    }
[2022-08-27T15:09:25.973844Z INFO  pherry] bridge() exited with error: Rpc error: RPC call failed: ErrorObject { code: ServerError(-32000), message: "Client error: UnknownBlock: State already discarded for BlockId::Hash(0xff93a4a903207ad45af110a3e15f8b66c903a0045f886c528c23fe7064532b08)", data: None }
    
    Caused by:
        0: RPC call failed: ErrorObject { code: ServerError(-32000), message: "Client error: UnknownBlock: State already discarded for BlockId::Hash(0xff93a4a903207ad45af110a3e15f8b66c903a0045f886c528c23fe7064532b08)", data: None }
        1: RPC call failed: ErrorObject { code: ServerError(-32000), message: "Client error: UnknownBlock: State already discarded for BlockId::Hash(0xff93a4a903207ad45af110a3e15f8b66c903a0045f886c528c23fe7064532b08)", data: None }
```

@jasl Please update the docker image `jasl123/phala-pherry` with this patch.