### PR TITLE
Wrap contents signed by pRuntime

### DIFF
--- a/crates/phactory/src/bin_api_service.rs
+++ b/crates/phactory/src/bin_api_service.rs
@@ -1,3 +1,5 @@
+use phala_types::{wrap_content_to_sign, SignedContentType};
+
 use super::*;
 
 // For bin_api
@@ -96,8 +98,9 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         // Sign the output payload
         let str_payload = payload.to_string();
         let signature: Option<String> = self.system.as_ref().map(|state| {
-            let bytes = str_payload.as_bytes();
-            let sig = state.identity_key.sign(bytes).0;
+            let bytes =
+                wrap_content_to_sign(str_payload.as_bytes(), SignedContentType::RpcResponse);
+            let sig = state.identity_key.sign(&bytes).0;
             hex::encode(&sig)
         });
         let output_json = json!({

--- a/crates/phactory/src/system/gk.rs
+++ b/crates/phactory/src/system/gk.rs
@@ -18,7 +18,7 @@ use phala_types::{
         RandomNumberEvent, RotateMasterKeyEvent, SettleInfo, SystemEvent, WorkerEvent,
         WorkerEventWithKey,
     },
-    EcdhPublicKey, WorkerPublicKey,
+    wrap_content_to_sign, EcdhPublicKey, SignedContentType, WorkerPublicKey,
 };
 use serde::{Deserialize, Serialize};
 use sp_core::{hashing, sr25519, Pair};
@@ -363,6 +363,8 @@ where
             sig: vec![],
         };
         let data_to_sign = event.data_be_signed();
+        let data_to_sign =
+            wrap_content_to_sign(&data_to_sign, SignedContentType::MasterKeyRotation);
         event.sig = identity_key.sign(&data_to_sign).0.to_vec();
         self.egress
             .push_message(&KeyDistribution::<chain::BlockNumber>::MasterKeyRotation(

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -48,7 +48,8 @@ use phala_types::{
         KeyDistribution, MiningReportEvent, NewGatekeeperEvent, PRuntimeManagementEvent,
         RemoveGatekeeperEvent, RotateMasterKeyEvent, SystemEvent, WorkerEvent,
     },
-    EcdhPublicKey, HandoverChallenge, HandoverChallengePayload, WorkerPublicKey,
+    wrap_content_to_sign, EcdhPublicKey, HandoverChallenge, HandoverChallengePayload,
+    SignedContentType, WorkerPublicKey,
 };
 use serde::{Deserialize, Serialize};
 use side_tasks::geo_probe;
@@ -57,9 +58,9 @@ use sp_core::{hashing::blake2_256, sr25519, Pair, U256};
 use sp_io;
 
 use pink::runtime::PinkEvent;
+use std::cell::Cell;
 use std::convert::TryFrom;
 use std::future::Future;
-use std::cell::Cell;
 
 pub type TransactionResult = Result<pink::runtime::ExecSideEffects, TransactionError>;
 
@@ -571,7 +572,9 @@ impl<Platform: pal::Platform> System<Platform> {
             dev_mode,
             nonce: crate::generate_random_info(),
         };
-        let signature = self.identity_key.sign_data(&payload.encode());
+        let encoded = payload.encode();
+        let wrapped = wrap_content_to_sign(&encoded, SignedContentType::HandoverChallenge);
+        let signature = self.identity_key.sign_data(&wrapped);
         let challenge = HandoverChallenge { payload, signature };
         self.last_challenge = Some(challenge.clone());
         challenge
@@ -1446,6 +1449,7 @@ impl<Platform: pal::Platform> System<Platform> {
         let data = event.data_be_signed();
         let sig = sp_core::sr25519::Signature::try_from(event.sig.as_slice())
             .or(Err(TransactionError::BadSenderSignature))?;
+        let data = wrap_content_to_sign(&data, SignedContentType::MasterKeyRotation);
         if !sp_io::crypto::sr25519_verify(&sig, &data, &event.sender) {
             return Err(TransactionError::BadSenderSignature.into());
         }

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -572,9 +572,7 @@ impl<Platform: pal::Platform> System<Platform> {
             dev_mode,
             nonce: crate::generate_random_info(),
         };
-        let encoded = payload.encode();
-        let wrapped = wrap_content_to_sign(&encoded, SignedContentType::HandoverChallenge);
-        let signature = self.identity_key.sign_data(&wrapped);
+        let signature = self.identity_key.sign_data(&payload.encode());
         let challenge = HandoverChallenge { payload, signature };
         self.last_challenge = Some(challenge.clone());
         challenge

--- a/crates/phala-mq/src/types.rs
+++ b/crates/phala-mq/src/types.rs
@@ -50,6 +50,9 @@ pub enum MessageOrigin {
     #[display(fmt = "Cluster({})", "hex::encode(_0)")]
     #[serde(with = "more::scale_bytes")]
     Cluster(ContractClusterId),
+    /// Reserved, we use this prefix to indicate the signed content is not a mq message
+    #[codec(index = 255)]
+    Reserved,
 }
 
 impl Hash for MessageOrigin {

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -829,9 +829,8 @@ pub enum SignedContentType {
     MqMessage = 0,
     RpcResponse = 1,
     EndpointInfo = 2,
-    HandoverChallenge = 3,
-    MasterKeyRotation = 4,
-    MasterKeyStore = 5,
+    MasterKeyRotation = 3,
+    MasterKeyStore = 4,
 }
 
 pub fn wrap_content_to_sign(data: &[u8], sigtype: SignedContentType) -> Cow<[u8]> {

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -3,6 +3,7 @@ extern crate alloc;
 
 pub mod contract;
 
+use alloc::borrow::Cow;
 use alloc::str::FromStr;
 use alloc::string::ParseError;
 use alloc::vec::Vec;
@@ -820,5 +821,30 @@ pub enum PayoutReason {
 impl Default for PayoutReason {
     fn default() -> Self {
         PayoutReason::OnlineReward
+    }
+}
+
+#[repr(u8)]
+pub enum SignedContentType {
+    MqMessage = 0,
+    RpcResponse = 1,
+    EndpointInfo = 2,
+    HandoverChallenge = 3,
+    MasterKeyRotation = 4,
+    MasterKeyStore = 5,
+}
+
+pub fn wrap_content_to_sign(data: &[u8], sigtype: SignedContentType) -> Cow<[u8]> {
+    match sigtype {
+        // We don't wrap mq messages for backward compatibility.
+        SignedContentType::MqMessage => data.into(),
+        _ => {
+            let mut wrapped: Vec<u8> = Vec::new();
+            // MessageOrigin::Reserved.encode() == 0xff
+            wrapped.push(0xff);
+            wrapped.push(sigtype as u8);
+            wrapped.extend_from_slice(data);
+            wrapped.into()
+        }
     }
 }

--- a/crates/phaxt/src/dynamic.rs
+++ b/crates/phaxt/src/dynamic.rs
@@ -1,6 +1,3 @@
-use anyhow::Result;
-use subxt::{metadata::EncodeStaticType, Metadata};
-
 pub mod tx;
 
 pub fn storage_key(pallet: &str, entry: &str) -> Vec<u8> {


### PR DESCRIPTION
This PR wraps contents signed by pRuntime with a content-type flag to make the system more secure.
None of the changes should break the already release software. May break the testnet though.