### PR TITLE
Fix: build script should update submodules first

### DIFF
--- a/scripts/run/build.sh
+++ b/scripts/run/build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+git submodule update --init --recursive
 cargo build --release


### PR DESCRIPTION
Hello, I followed the build instruction from https://github.com/Phala-Network/phala-blockchain/tree/master/scripts/run to build the project for the first time and failed, the error message said some git submodules are empty, this PR fixes the problem.