### PR TITLE
pink-logger: Don't use log::* API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7931,7 +7931,7 @@ dependencies = [
  "phala-serde-more",
  "phala-trie-storage",
  "phala-types",
- "pink-extension 0.1.16",
+ "pink-extension 0.1.17",
  "pink-extension-runtime 0.1.3",
  "reqwest",
  "reqwest-env-proxy 0.1.0",
@@ -7970,7 +7970,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "ink_env",
  "ink_lang",
@@ -8018,7 +8018,7 @@ version = "0.1.3"
 dependencies = [
  "getrandom 0.2.7",
  "log",
- "pink-extension 0.1.16",
+ "pink-extension 0.1.17",
  "reqwest",
  "reqwest-env-proxy 0.1.0",
  "ring 0.16.20",
@@ -8050,7 +8050,7 @@ dependencies = [
  "chrono",
  "hmac 0.12.1",
  "parity-scale-codec",
- "pink-extension 0.1.16",
+ "pink-extension 0.1.17",
  "pink-extension-runtime 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scale-info",
  "sha2 0.10.2",
@@ -8068,7 +8068,7 @@ dependencies = [
  "ink_primitives",
  "ink_storage",
  "parity-scale-codec",
- "pink-extension 0.1.16",
+ "pink-extension 0.1.17",
  "pink-extension-runtime 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scale-info",
 ]
@@ -10958,7 +10958,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sidevm"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "derive_more",
  "futures",

--- a/crates/pink/pink-extension/Cargo.toml
+++ b/crates/pink/pink-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pink-extension"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2018"
 description = "Phala's ink! for writing fat contracts"
 license = "Apache-2.0"

--- a/crates/pink/pink-extension/src/logger.rs
+++ b/crates/pink/pink-extension/src/logger.rs
@@ -1,35 +1,19 @@
 //! Logger for Pink contracts.
 
-use core::sync::atomic::{AtomicBool, Ordering};
-pub use log::{self, LevelFilter as Level};
+use core::fmt::Arguments;
+pub use log::Level;
 use log::{Log, Metadata, Record};
 
 /// A logger working inside a Pink contract.
-pub struct Logger {
-    max_level: Level,
-}
-
-impl Logger {
-    /// Create a new logger with the given maximum level.
-    pub const fn with_max_level(max_level: Level) -> Self {
-        Self { max_level }
-    }
-
-    /// Install the logger as the global logger.
-    pub fn init(&'static self) {
-        log::set_max_level(self.max_level);
-        log::set_logger(self).unwrap();
-    }
-}
+struct Logger;
 
 impl Log for Logger {
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() <= self.max_level
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
     }
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            use log::Level;
             let message = alloc::format!("{}", record.args());
             let level = match record.level() {
                 Level::Error => 1,
@@ -45,63 +29,43 @@ impl Log for Logger {
     fn flush(&self) {}
 }
 
-pub fn once(x: fn()) {
-    static INIT_LOCK: AtomicBool = AtomicBool::new(false);
-    if !INIT_LOCK.swap(true, Ordering::Relaxed) {
-        x();
-    }
+pub fn log(level: Level, args: Arguments<'_>) {
+    let record = Record::builder().level(level).args(args).build();
+    Logger.log(&record);
 }
 
-/// Register a logger as global logger for log.
-///
-/// We can not use `log::set_boxed_logger` or `log::set_logger` in ink due to it's
-/// non-contiguous execution model.
+/// Same as log::log!
 #[macro_export]
-macro_rules! register_logger {
-    ($logger: expr) => {
-        #[no_mangle]
-        fn pink_logger_try_init() {
-            $crate::logger::once(|| $logger.init());
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! try_init {
-    () => {
-        extern "Rust" {
-            fn pink_logger_try_init();
-        }
-        unsafe { pink_logger_try_init() };
-    };
+macro_rules! log {
+    ($level: expr, $($arg:tt)+) => {{ $crate::logger::log($level, ::core::format_args!($($arg)+)) }}
 }
 
 /// Same as log::error!
 #[macro_export(local_inner_macros)]
 macro_rules! error {
-    ($($arg:tt)+) => {{ try_init!(); $crate::logger::log::error!($($arg)+) }}
+    ($($arg:tt)+) => {{ log!($crate::logger::Level::Error, $($arg)+) }}
 }
 
 /// Same as log::warn!
 #[macro_export(local_inner_macros)]
 macro_rules! warn {
-    ($($arg:tt)+) => {{ try_init!(); $crate::logger::log::warn!($($arg)+) }}
+    ($($arg:tt)+) => {{ log!($crate::logger::Level::Warn, $($arg)+) }}
 }
 
 /// Same as log::info!
 #[macro_export(local_inner_macros)]
 macro_rules! info {
-    ($($arg:tt)+) => {{ try_init!(); $crate::logger::log::info!($($arg)+) }}
+    ($($arg:tt)+) => {{ log!($crate::logger::Level::Info, $($arg)+) }}
 }
 
 /// Same as log::debug!
 #[macro_export(local_inner_macros)]
 macro_rules! debug {
-    ($($arg:tt)+) => {{ try_init!(); $crate::logger::log::debug!($($arg)+) }}
+    ($($arg:tt)+) => {{ log!($crate::logger::Level::Debug, $($arg)+) }}
 }
 
 /// Same as log::trace!
 #[macro_export(local_inner_macros)]
 macro_rules! trace {
-    ($($arg:tt)+) => {{ try_init!(); $crate::logger::log::trace!($($arg)+) }}
+    ($($arg:tt)+) => {{ log!($crate::logger::Level::Trace, $($arg)+) }}
 }

--- a/crates/pink/src/contract.rs
+++ b/crates/pink/src/contract.rs
@@ -91,7 +91,7 @@ impl Contract {
                     pallet_contracts_primitives::Code::Existing(code_hash),
                     input_data,
                     salt.clone(),
-                    true,
+                    false,
                 );
                 log::info!("Contract instantiation result: {:?}", &result);
                 match result.result {
@@ -207,7 +207,7 @@ impl Contract {
             } else {
                 COMMAND_GAS_LIMIT
             };
-            Contracts::bare_call(origin, addr, 0, gas_limit, None, input_data, true)
+            Contracts::bare_call(origin, addr, 0, gas_limit, None, input_data, false)
         })
     }
 


### PR DESCRIPTION
This should fix the logging issues in the unit test.
Example changes: https://github.com/Phala-Network/fat-contract-examples/pull/3