### PR TITLE
Use Rust nightly-2022-09-08, newer can not compile ink contract for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-10
+          toolchain: nightly-2022-09-08
           override: true
           target: wasm32-unknown-unknown
       - uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-10
+          toolchain: nightly-2022-09-08
           override: true
           target: wasm32-unknown-unknown
       - uses: actions/checkout@v3
@@ -67,7 +67,7 @@ jobs:
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-10
+          toolchain: nightly-2022-09-08
           override: true
           target: wasm32-unknown-unknown
       - uses: actions/checkout@v3
@@ -92,7 +92,7 @@ jobs:
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-10
+          toolchain: nightly-2022-09-08
           override: true
           target: wasm32-unknown-unknown
       - uses: actions/checkout@v3
@@ -138,7 +138,7 @@ jobs:
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-09-10
+          toolchain: nightly-2022-09-08
           override: true
           target: wasm32-unknown-unknown
           components: rustfmt

--- a/gramine.Dockerfile
+++ b/gramine.Dockerfile
@@ -15,7 +15,7 @@ ARG CODENAME='focal'
 ADD ./dockerfile.d/04_psw.sh /root
 RUN bash /root/04_psw.sh
 
-ARG RUST_TOOLCHAIN='nightly-2022-09-10'
+ARG RUST_TOOLCHAIN='nightly-2022-09-08'
 ADD ./dockerfile.d/05_rust.sh /root
 RUN bash /root/05_rust.sh
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-09-10"
+channel = "nightly-2022-09-08"
 components = ["rustfmt"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
In the future, it probably worth to add a `cargo contract create` test