### PR TITLE
pink: Disable sr25519 signing in tx

### DIFF
--- a/crates/pink/pink-extension-runtime/src/lib.rs
+++ b/crates/pink/pink-extension-runtime/src/lib.rs
@@ -206,7 +206,7 @@ impl<T: PinkRuntimeEnv, E: From<&'static str>> PinkExtBackend for DefaultPinkExt
         Ok(buf)
     }
 
-    fn is_running_in_command(&self) -> Result<bool, Self::Error> {
+    fn is_in_transaction(&self) -> Result<bool, Self::Error> {
         Ok(false)
     }
 

--- a/crates/pink/pink-extension-runtime/src/mock_ext.rs
+++ b/crates/pink/pink-extension-runtime/src/mock_ext.rs
@@ -22,6 +22,8 @@ impl super::PinkRuntimeEnv for MockExtension {
 }
 
 impl ext::PinkExtBackend for MockExtension {
+    type Error = String;
+
     fn http_request(&self, request: ext::HttpRequest) -> Result<ext::HttpResponse, Self::Error> {
         super::DefaultPinkExtension::new(self).http_request(request)
     }
@@ -85,11 +87,9 @@ impl ext::PinkExtBackend for MockExtension {
         super::DefaultPinkExtension::new(self).getrandom(length)
     }
 
-    fn is_running_in_command(&self) -> Result<bool, Self::Error> {
+    fn is_in_transaction(&self) -> Result<bool, Self::Error> {
         Ok(IS_COMMAND_MODE.with(|mode| mode.get()))
     }
-
-    type Error = String;
 
     fn ecdsa_sign_prehashed(
         &self,

--- a/crates/pink/pink-extension/src/chain_extension.rs
+++ b/crates/pink/pink-extension/src/chain_extension.rs
@@ -92,7 +92,7 @@ pub trait PinkExt {
 
     /// Check if it is running in a Command context.
     #[ink(extension = 12, handle_status = false, returns_result = false)]
-    fn is_running_in_command() -> bool;
+    fn is_in_transaction() -> bool;
 
     #[ink(extension = 13, handle_status = false, returns_result = false)]
     fn ecdsa_sign_prehashed(key: &[u8], message_hash: Hash) -> EcdsaSignature;

--- a/crates/pink/src/runtime/extension.rs
+++ b/crates/pink/src/runtime/extension.rs
@@ -285,6 +285,9 @@ impl PinkExtBackend for CallInCommand {
         key: Cow<[u8]>,
         message: Cow<[u8]>,
     ) -> Result<Vec<u8>, Self::Error> {
+        if matches!(sigtype, SigType::Sr25519) {
+            return Err("signing with sr25519 is not allowed in command".into());
+        }
         self.as_in_query.sign(sigtype, key, message)
     }
 

--- a/crates/pink/src/runtime/extension.rs
+++ b/crates/pink/src/runtime/extension.rs
@@ -242,7 +242,7 @@ impl PinkExtBackend for CallInQuery {
         DefaultPinkExtension::new(self).getrandom(length)
     }
 
-    fn is_running_in_command(&self) -> Result<bool, Self::Error> {
+    fn is_in_transaction(&self) -> Result<bool, Self::Error> {
         Ok(false)
     }
 
@@ -357,7 +357,7 @@ impl PinkExtBackend for CallInCommand {
         Err("getrandom is not allowed in command".into())
     }
 
-    fn is_running_in_command(&self) -> Result<bool, Self::Error> {
+    fn is_in_transaction(&self) -> Result<bool, Self::Error> {
         Ok(true)
     }
 


### PR DESCRIPTION
And rename the command to transaction.

Chan extension function availability:

| Function  | query | transaction |
| ------------- | ------------- |------------- |
| http_request  | ✅  | ❌ |
| sign(ecdsa/ed25519) |✅  |✅|
| sign(sr25519) | ✅  | ❌ |
| verify |✅  |✅|
| derive_sr25519_key |✅  |✅|
| get_public_key |✅  |✅|
| cache_set |✅  |✅|
| cache_set_expire |✅  |✅|
| cache_get |✅  |❌|
| cache_remove |✅  |✅|
| log |✅  |✅|
| getrandom |✅  |❌|
| is_running_in_command |✅  |✅|
| ecdsa_sign_prehashed |✅  |✅|
| ecdsa_verify_prehashed |✅  |✅|


