### PR TITLE
Sign public rpc response

### DIFF
--- a/crates/phactory/src/bin_api_service.rs
+++ b/crates/phactory/src/bin_api_service.rs
@@ -8,29 +8,41 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         serde_json::to_string_pretty(&self.get_info()).unwrap_or_default()
     }
 
+    pub fn sign_http_response(&self, body: &[u8]) -> Option<String> {
+        self.system.as_ref().map(|state| {
+            let bytes = wrap_content_to_sign(body, SignedContentType::RpcResponse);
+            let sig = state.identity_key.sign(&bytes).0;
+            hex::encode(&sig)
+        })
+    }
+
     fn get_info_json(&self) -> Result<Value, Value> {
         Ok(json!(self.get_info()))
     }
 
     fn bin_sync_header(&mut self, input: blocks::SyncHeaderReq) -> Result<Value, Value> {
-        let resp =
-            self.sync_header(input.headers, input.authority_set_change).map_err(display)?;
+        let resp = self
+            .sync_header(input.headers, input.authority_set_change)
+            .map_err(display)?;
         Ok(json!({ "synced_to": resp.synced_to }))
     }
 
     fn bin_sync_para_header(&mut self, input: SyncParachainHeaderReq) -> Result<Value, Value> {
-        let resp = self.sync_para_header(input.headers, input.proof).map_err(display)?;
+        let resp = self
+            .sync_para_header(input.headers, input.proof)
+            .map_err(display)?;
         Ok(json!({ "synced_to": resp.synced_to }))
     }
 
     fn bin_sync_combined_headers(&mut self, input: SyncCombinedHeadersReq) -> Result<Value, Value> {
-        let resp = self.sync_combined_headers(
-            input.relaychain_headers,
-            input.authority_set_change,
-            input.parachain_headers,
-            input.proof,
-        )
-        .map_err(display)?;
+        let resp = self
+            .sync_combined_headers(
+                input.relaychain_headers,
+                input.authority_set_change,
+                input.parachain_headers,
+                input.proof,
+            )
+            .map_err(display)?;
         Ok(json!({
             "relaychain_synced_to": resp.relaychain_synced_to,
             "parachain_synced_to": resp.parachain_synced_to,
@@ -68,12 +80,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
 
         // Sign the output payload
         let str_payload = payload.to_string();
-        let signature: Option<String> = self.system.as_ref().map(|state| {
-            let bytes =
-                wrap_content_to_sign(str_payload.as_bytes(), SignedContentType::RpcResponse);
-            let sig = state.identity_key.sign(&bytes).0;
-            hex::encode(&sig)
-        });
+        let signature = self.sign_http_response(str_payload.as_bytes());
         let output_json = json!({
             "status": status,
             "payload": str_payload,

--- a/crates/phala-rocket-middleware/src/lib.rs
+++ b/crates/phala-rocket-middleware/src/lib.rs
@@ -1,3 +1,5 @@
 pub use time_meter::TimeMeter;
+pub use response_signer::ResponseSigner;
 
 mod time_meter;
+mod response_signer;

--- a/crates/phala-rocket-middleware/src/response_signer.rs
+++ b/crates/phala-rocket-middleware/src/response_signer.rs
@@ -1,0 +1,52 @@
+use std::io::Cursor;
+
+use rocket::fairing::{Fairing, Info, Kind};
+use rocket::{Request, Response};
+
+/// A signer to sign the response with given signing fn.
+pub struct ResponseSigner<SignFn> {
+    max_signing_body_size: usize,
+    sign_fn: SignFn,
+}
+
+impl<SignFn> ResponseSigner<SignFn> {
+    pub fn new(max_signing_body_size: usize, sign_fn: SignFn) -> Self {
+        Self {
+            max_signing_body_size,
+            sign_fn,
+        }
+    }
+}
+
+#[rocket::async_trait]
+impl<SignFn> Fairing for ResponseSigner<SignFn>
+where
+    SignFn: Fn(&[u8]) -> Option<String> + Send + Sync + 'static,
+{
+    fn info(&self) -> Info {
+        Info {
+            name: "ResponseSigner",
+            kind: Kind::Response,
+        }
+    }
+
+    async fn on_response<'r>(&self, _request: &'r Request<'_>, response: &mut Response<'r>) {
+        // TODO.kevin: use `let else` instead when the next rustc released
+        let body_size = response.body().preset_size();
+        let body = match body_size {
+            Some(body_size) if body_size <= self.max_signing_body_size => {
+                let mut body = response.body_mut().take();
+                if let Ok(body) = body.to_bytes().await {
+                    body
+                } else {
+                    return;
+                }
+            }
+            _ => return,
+        };
+        if let Some(signature) = (self.sign_fn)(&body) {
+            response.set_raw_header("X-Phactory-Signature", signature);
+        }
+        response.set_sized_body(body.len(), Cursor::new(body));
+    }
+}

--- a/pallets/phala/src/registry.rs
+++ b/pallets/phala/src/registry.rs
@@ -498,7 +498,7 @@ pub mod pallet {
 				.or(Err(Error::<T>::MalformedSignature))?;
 			let encoded_data = endpoint_payload.encode();
 			let data_to_sign =
-				wrap_content_to_sign(&encoded_data, SignedContentType::MasterKeyRotation);
+				wrap_content_to_sign(&encoded_data, SignedContentType::EndpointInfo);
 
 			ensure!(
 				sp_io::crypto::sr25519_verify(&sig, &data_to_sign, &endpoint_payload.pubkey),

--- a/standalone/pherry/src/endpoint.rs
+++ b/standalone/pherry/src/endpoint.rs
@@ -4,7 +4,6 @@ use crate::{
     Args,
 };
 use anyhow::{anyhow, Result};
-use codec::Decode;
 use log::{error, info};
 
 async fn update_worker_endpoint(
@@ -15,10 +14,8 @@ async fn update_worker_endpoint(
     args: &Args,
 ) -> Result<bool> {
     chain_client::update_signer_nonce(para_api, signer).await?;
-    let signed_endpoint = Decode::decode(&mut &encoded_endpoint_payload[..])
-        .map_err(|_| anyhow!("Decode signed endpoint failed"))?;
     let params = crate::mk_params(para_api, args.longevity, args.tip).await?;
-    let tx = phaxt::dynamic::tx::update_worker_endpoint(signed_endpoint, signature);
+    let tx = phaxt::dynamic::tx::update_worker_endpoint(encoded_endpoint_payload, signature);
     let ret = para_api
         .tx()
         .sign_and_submit_then_watch(&tx, signer, params)

--- a/standalone/pruntime/src/runtime.rs
+++ b/standalone/pruntime/src/runtime.rs
@@ -18,6 +18,10 @@ pub fn ecall_getinfo() -> String {
     APPLICATION.lock_phactory().getinfo()
 }
 
+pub fn ecall_sign_http_response(data: &[u8]) -> Option<String> {
+    APPLICATION.lock_phactory().sign_http_response(data)
+}
+
 pub fn ecall_init(args: phactory_api::ecall_args::InitArgs) -> Result<()> {
     static INITIALIZED: AtomicU32 = AtomicU32::new(0);
     if INITIALIZED.fetch_add(1, Ordering::SeqCst) != 0 {


### PR DESCRIPTION
Example response:
```
< HTTP/1.1 200 OK
< content-type: text/plain; charset=utf-8
< server: Rocket
< permissions-policy: interest-cohort=()
< x-frame-options: SAMEORIGIN
< x-content-type-options: nosniff
< x-phactory-signature: 08ce5ca7696d8ce9723aff1b2114de54489f86e1af153298a544a34c237dba50e7c1a8c766b6086c04ad7c7a5e5b4264547e42e4e48d6b2df9b9826e0388fe86
< content-length: 1274
< date: Fri, 23 Sep 2022 07:11:20 GMT
<
```