### PR TITLE
Upgrade Subxt to v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7082,9 +7082,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.1.5"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9182e4a71cae089267ab03e67c99368db7cd877baf50f931e5d6d4b71e195ac0"
+checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
 dependencies = [
  "arrayvec 0.7.2",
  "bitvec",
@@ -10490,22 +10490,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "scale-decode"
+name = "scale-bits"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70dece385bc3e5918109830d9509806b5d4525fdf594e3463078c529122979e"
+checksum = "8dd7aca73785181cc41f0bbe017263e682b585ca660540ba569133901d013ecf"
 dependencies = [
- "bitvec",
  "parity-scale-codec",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d823d4be477fc33321f93d08fb6c2698273d044f01362dc27573a750deb7c233"
+dependencies = [
+ "parity-scale-codec",
+ "scale-bits",
  "scale-info",
  "thiserror",
 ]
 
 [[package]]
 name = "scale-info"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c46be926081c9f4dd5dd9b6f1d3e3229f2360bc6502dd8836f84a93b7c75e99a"
+checksum = "333af15b02563b8182cd863f925bd31ef8fa86a0e095d30c091956057d436153"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10517,9 +10528,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e334bb10a245e28e5fd755cabcafd96cfcd167c99ae63a46924ca8d8703a3c"
+checksum = "53f56acbd0743d29ffa08f911ab5397def774ad01bab3786804cf6ee057fb5e1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.40",
@@ -10529,14 +10540,14 @@ dependencies = [
 
 [[package]]
 name = "scale-value"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae8b296b3ebcb3425661e9b612ccc34cb1064483a61dc379c65e6b1463498f1"
+checksum = "16a5e7810815bd295da73e4216d1dfbced3c7c7c7054d70fa5f6e4c58123fff4"
 dependencies = [
- "bitvec",
  "either",
  "frame-metadata",
  "parity-scale-codec",
+ "scale-bits",
  "scale-decode",
  "scale-info",
  "serde",
@@ -11452,7 +11463,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
 dependencies = [
  "base58",
  "bitflags",
@@ -11498,7 +11509,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
 dependencies = [
  "blake2",
  "byteorder",
@@ -11532,7 +11543,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
 dependencies = [
  "proc-macro2 1.0.40",
  "quote 1.0.20",
@@ -11542,7 +11553,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11714,7 +11725,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
 dependencies = [
  "bytes 1.1.0",
  "impl-trait-for-tuples",
@@ -11732,7 +11743,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -11805,12 +11816,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11852,7 +11863,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -11940,7 +11951,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -12404,7 +12415,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subxt"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "bitvec",
  "derivative",
@@ -12429,7 +12440,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "darling 0.14.1",
  "frame-metadata",
@@ -12445,7 +12456,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "darling 0.14.1",
  "proc-macro-error",
@@ -12455,7 +12466,7 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",

--- a/crates/phaxt/src/rpc.rs
+++ b/crates/phaxt/src/rpc.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
 use phala_node_rpc_ext_types::GetStorageChangesResponse;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::to_value as to_json_value;
 use subxt::{
     ext::sp_core::storage::{StorageData, StorageKey},
-    rpc::{rpc_params, RpcClientT, RpcClient},
+    rpc::{rpc_params, RpcClient},
     Config, Error, OnlineClient,
 };
 
@@ -18,14 +16,14 @@ impl<C: Config> ExtraRpcExt for OnlineClient<C> {
     type Config = C;
     fn extra_rpc(&self) -> ExtraRpcClient<Self::Config> {
         ExtraRpcClient {
-            client: &self.rpc().client,
+            client: &self.rpc(),
             _config: Default::default(),
         }
     }
 }
 
 pub struct ExtraRpcClient<'a, Config> {
-    client: &'a Arc<RpcClient>,
+    client: &'a RpcClient,
     _config: std::marker::PhantomData<Config>,
 }
 

--- a/crates/phaxt/src/rpc.rs
+++ b/crates/phaxt/src/rpc.rs
@@ -5,7 +5,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::to_value as to_json_value;
 use subxt::{
     ext::sp_core::storage::{StorageData, StorageKey},
-    rpc::{rpc_params, ClientT, RpcClient},
+    rpc::{rpc_params, RpcClientT, RpcClient},
     Config, Error, OnlineClient,
 };
 

--- a/standalone/pherry/src/chain_client.rs
+++ b/standalone/pherry/src/chain_client.rs
@@ -11,7 +11,7 @@ use phala_trie_storage::ser::StorageChanges;
 use phala_types::messaging::MessageOrigin;
 use phaxt::{rpc::ExtraRpcExt as _, subxt, RpcClient};
 use serde_json::to_value;
-use subxt::rpc::{rpc_params, ClientT};
+use subxt::rpc::rpc_params;
 
 pub use sp_core::{twox_128, twox_64};
 
@@ -85,7 +85,6 @@ pub async fn mq_next_sequence(
     let sender_hex = hex::encode(sender_scl);
     let seq: u64 = api
         .rpc()
-        .client
         .request("pha_getMqNextSequence", rpc_params![to_value(sender_hex)?])
         .await?;
     Ok(seq)

--- a/standalone/pherry/src/msg_sync.rs
+++ b/standalone/pherry/src/msg_sync.rs
@@ -82,9 +82,9 @@ pub async fn maybe_sync_mq_egress(
                             }
                             Ok(Err(err)) => {
                                 error!("Error submitting message {}: {:?}", msg_info, err);
-                                use phaxt::subxt::{rpc::RpcError, Error as SubxtError};
+                                use phaxt::subxt::{error::RpcError, Error as SubxtError};
                                 let report = match err {
-                                    SubxtError::Rpc(RpcError::Custom(err)) => {
+                                    SubxtError::Rpc(RpcError(err)) => {
                                         if err.contains("bad signature") {
                                             Error::BadSignature
                                         } else {


### PR DESCRIPTION
It seems latest Subxt no longer expose the `client`

```
error[E0616]: field `client` of struct `subxt::rpc::Rpc` is private
  --> crates/phaxt/src/rpc.rs:21:33
   |
21 |             client: &self.rpc().client,
   |                                 ^^^^^^ private field

   Compiling pallet-child-bounties v4.0.0-dev (https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358)
error[E0308]: mismatched types
  --> crates/phaxt/src/rpc.rs:21:21
   |
21 |             client: &self.rpc().client,
   |                     ^^^^^^^^^^^^^^^^^^ expected struct `Arc`, found struct `subxt::rpc::RpcClient`
   |
   = note: expected reference `&Arc<subxt::rpc::RpcClient>`
              found reference `&subxt::rpc::RpcClient`

Some errors have detailed explanations: E0308, E0432, E0616.
For more information about an error, try `rustc --explain E0308`.
error: could not compile `phaxt` due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
```

@kvinwang can you help?