### PR TITLE
[Backport] pruntime: Also pick messages from OutboundMessagesV2

### DIFF
--- a/.github/actions/install_toolchain/action.yml
+++ b/.github/actions/install_toolchain/action.yml
@@ -9,5 +9,5 @@ runs:
       shell: bash
     - run: chmod +x ./sgx_linux_sdk.bin && echo -e 'no\n/opt/intel' | sudo ./sgx_linux_sdk.bin
       shell: bash
-    - run: sudo pip install rust_demangler meson ninja
+    - run: sudo pip install rust_demangler meson==0.62 ninja
       shell: bash

--- a/crates/phactory/src/storage.rs
+++ b/crates/phactory/src/storage.rs
@@ -71,7 +71,15 @@ mod storage_ext {
             self.get_decoded(storage_prefix("ParachainInfo", "ParachainId"))
         }
         fn mq_messages(&self) -> Result<Vec<Message>, Error> {
-            self.get_decoded_or_default(storage_prefix("PhalaMq", "OutboundMessages"))
+            for key in ["OutboundMessagesV2", "OutboundMessages"] {
+                let messages: Vec<Message> =
+                    self.get_decoded_or_default(storage_prefix("PhalaMq", key))?;
+                if !messages.is_empty() {
+                    info!("Got {} messages from {}", messages.len(), key);
+                    return Ok(messages);
+                }
+            }
+            Ok(vec![])
         }
         fn timestamp_now(&self) -> Option<chain::Moment> {
             self.get_decoded(storage_prefix("Timestamp", "Now"))


### PR DESCRIPTION
We'd better release a teaclave-based pruntime with this patch before the chain launches #828.
