### PR TITLE
Add verify state root for init_runtime

### DIFF
--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -379,12 +379,12 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         );
 
         if *runtime_state.chain_storage.root() != genesis.block_header.state_root {
-            warn!("Genesis chain storage state root: {:?}, Genesis block header state root: {:?}", 
+            error!("Genesis state root mismatch, required in header: {:?}, actual: {:?}", 
+                genesis.block_header.state_root,
                 runtime_state.chain_storage.root(), 
-                genesis.block_header.state_root
             );
             return Err(from_display(
-                "state root hash not equal",
+                "state root mismatch",
             ));
         }
 

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -348,7 +348,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         let next_headernum = genesis.block_header.number + 1;
         let mut light_client = LightValidation::new();
         let main_bridge = light_client
-            .initialize_bridge(genesis.block_header, genesis.authority_set, genesis.proof)
+            .initialize_bridge(genesis.block_header.clone(), genesis.authority_set, genesis.proof)
             .expect("Bridge initialize failed");
 
         let storage_synchronizer = if is_parachain {
@@ -377,6 +377,16 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             "Genesis state loaded: {:?}",
             runtime_state.chain_storage.root()
         );
+
+        if *runtime_state.chain_storage.root() != genesis.block_header.state_root {
+            warn!("Genesis chain storage state root: {:?}, Genesis block header state root: {:?}", 
+                runtime_state.chain_storage.root(), 
+                genesis.block_header.state_root
+            );
+            return Err(from_display(
+                "state root hash not equal",
+            ));
+        }
 
         let system = system::System::new(
             self.platform.clone(),


### PR DESCRIPTION
### Description

The root hash of Merkle Patricia Trie constructed by this KV vector needs to be checked against the state root in the header of the Genesis block.  `pherry` passes the KV vector of all the states of the Genesis block obtained by JSON-RPC `state_getPairs` to the `init_runtime` function of the `pRuntime` node.

### Test

Built success locally

### Token Pocket

Kusama Address： `EVYyMzs3Hg7NrVh3UQyvGKDmScc9XUV2yAQrY6DzTHVDCyL`   @kvinwang  @h4x3rotab  the address is it right? I am new to Polkadot/kusama eco. :)