### PR TITLE
sidevm: Use wasmer 3.0-beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,11 +1651,11 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
+checksum = "529ffacce2249ac60edba2941672dfedf3d96558b415d0d8083cd007456e0f55"
 dependencies = [
- "cranelift-entity 0.82.3",
+ "cranelift-entity 0.86.1",
 ]
 
 [[package]]
@@ -1669,17 +1669,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
+checksum = "427d105f617efc8cb55f8d036a7fded2e227892d8780b4985e5551f8d27c4a92"
 dependencies = [
- "cranelift-bforest 0.82.3",
- "cranelift-codegen-meta 0.82.3",
- "cranelift-codegen-shared 0.82.3",
- "cranelift-entity 0.82.3",
+ "cranelift-bforest 0.86.1",
+ "cranelift-codegen-meta 0.86.1",
+ "cranelift-codegen-shared 0.86.1",
+ "cranelift-entity 0.86.1",
+ "cranelift-isle 0.86.1",
  "gimli",
  "log",
- "regalloc",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
 ]
@@ -1696,7 +1697,7 @@ dependencies = [
  "cranelift-codegen-meta 0.88.1",
  "cranelift-codegen-shared 0.88.1",
  "cranelift-entity 0.88.1",
- "cranelift-isle",
+ "cranelift-isle 0.88.1",
  "gimli",
  "log",
  "regalloc2",
@@ -1706,11 +1707,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
+checksum = "551674bed85b838d45358e3eab4f0ffaa6790c70dc08184204b9a54b41cdb7d1"
 dependencies = [
- "cranelift-codegen-shared 0.82.3",
+ "cranelift-codegen-shared 0.86.1",
 ]
 
 [[package]]
@@ -1724,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
+checksum = "2b3a63ae57498c3eb495360944a33571754241e15e47e3bcae6082f40fec5866"
 
 [[package]]
 name = "cranelift-codegen-shared"
@@ -1736,9 +1737,9 @@ checksum = "2855c24219e2f08827f3f4ffb2da92e134ae8d8ecc185b11ec8f9878cf5f588e"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
+checksum = "11aa8aa624c72cc1c94ea3d0739fa61248260b5b14d3646f51593a88d67f3e6e"
 
 [[package]]
 name = "cranelift-entity"
@@ -1751,11 +1752,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
+checksum = "544ee8f4d1c9559c9aa6d46e7aaeac4a13856d620561094f35527356c7d21bd0"
 dependencies = [
- "cranelift-codegen 0.82.3",
+ "cranelift-codegen 0.86.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -1772,6 +1773,12 @@ dependencies = [
  "smallvec",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.86.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed16b14363d929b8c37e3c557d0a7396791b383ecc302141643c054343170aad"
 
 [[package]]
 name = "cranelift-isle"
@@ -5430,7 +5437,6 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
 dependencies = [
- "indexmap",
  "loupe-derive",
  "rustversion",
 ]
@@ -6183,9 +6189,6 @@ version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
 dependencies = [
- "crc32fast",
- "hashbrown 0.11.2",
- "indexmap",
  "memchr",
 ]
 
@@ -8914,17 +8917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc"
-version = "0.0.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
-dependencies = [
- "log",
- "rustc-hash",
- "smallvec",
-]
-
-[[package]]
 name = "regalloc2"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9152,6 +9144,7 @@ checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
 dependencies = [
  "bytecheck",
  "hashbrown 0.12.3",
+ "indexmap",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -10866,15 +10859,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_cbor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11172,8 +11156,6 @@ dependencies = [
  "wasmer-compiler-cranelift",
  "wasmer-compiler-llvm",
  "wasmer-compiler-singlepass",
- "wasmer-engine",
- "wasmer-engine-universal",
  "wasmer-middlewares",
  "wasmer-tunables",
  "wasmer-wasi-types",
@@ -13782,25 +13764,21 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
+checksum = "01fc47a9d4ebb42b3a9a3d802e809bbdb5afaf3028373a82b989e51f4e400903"
 dependencies = [
+ "bytes 1.1.0",
  "cfg-if",
  "indexmap",
  "js-sys",
- "loupe",
  "more-asserts",
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
- "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
- "wasmer-engine",
- "wasmer-engine-dylib",
- "wasmer-engine-universal",
  "wasmer-types",
  "wasmer-vm",
  "wat",
@@ -13808,47 +13786,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
-dependencies = [
- "enumset",
- "loupe",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
 name = "wasmer-compiler"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
+checksum = "54d7b5068f9ed673f0fc8513b4702067a0f5712d3ea226eb71fc4a9c6c4fe9c7"
 dependencies = [
+ "backtrace",
+ "cfg-if",
+ "enum-iterator",
  "enumset",
- "loupe",
- "rkyv",
- "serde",
- "serde_bytes",
+ "lazy_static",
+ "leb128",
+ "memmap2",
+ "more-asserts",
+ "region",
+ "rustc-demangle",
  "smallvec",
- "target-lexicon",
  "thiserror",
  "wasmer-types",
+ "wasmer-vm",
  "wasmparser 0.83.0",
+ "winapi",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
+checksum = "f0fac321e5d3dc4f157f28bf6001f06d2e821422ce60449da97d39af171b4169"
 dependencies = [
- "cranelift-codegen 0.82.3",
- "cranelift-entity 0.82.3",
- "cranelift-frontend 0.82.3",
+ "cranelift-codegen 0.86.1",
+ "cranelift-entity 0.86.1",
+ "cranelift-frontend 0.86.1",
  "gimli",
- "loupe",
  "more-asserts",
  "rayon",
  "smallvec",
@@ -13860,9 +13830,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-llvm"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69f50825c69be2efb71e3059a3222de6e5d06552da51907cac761f701bde83"
+checksum = "86c172bbe70b146d46b750d842e426f1abf1b698cf22fad7cdefb632a2b17dbd"
 dependencies = [
  "byteorder",
  "cc",
@@ -13870,7 +13840,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "libc",
- "loupe",
  "object 0.28.4",
  "rayon",
  "regex",
@@ -13885,16 +13854,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ca2a35204d8befa85062bc7aac259a8db8070b801b8a783770ba58231d729e"
+checksum = "20ae0bafb36a7ab8e4125474ebf19e640820797181bc19682d056d0cba037e6f"
 dependencies = [
  "byteorder",
  "dynasm",
  "dynasmrt",
  "gimli",
  "lazy_static",
- "loupe",
  "more-asserts",
  "rayon",
  "smallvec",
@@ -13904,9 +13872,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
+checksum = "02b38c7a442cffa5efb799631013bb30aeb1d553c50effa51905ea8b36ecc6c8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.40",
@@ -13915,112 +13883,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-engine"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
-dependencies = [
- "backtrace",
- "enumset",
- "lazy_static",
- "loupe",
- "memmap2",
- "more-asserts",
- "rustc-demangle",
- "serde",
- "serde_bytes",
- "target-lexicon",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-engine-dylib"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
-dependencies = [
- "cfg-if",
- "enum-iterator",
- "enumset",
- "leb128",
- "libloading 0.7.3",
- "loupe",
- "object 0.28.4",
- "rkyv",
- "serde",
- "tempfile",
- "tracing",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-object",
- "wasmer-types",
- "wasmer-vm",
- "which",
-]
-
-[[package]]
-name = "wasmer-engine-universal"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
-dependencies = [
- "cfg-if",
- "enumset",
- "leb128",
- "loupe",
- "region",
- "rkyv",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-engine-universal-artifact",
- "wasmer-types",
- "wasmer-vm",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-engine-universal-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
-dependencies = [
- "enum-iterator",
- "enumset",
- "loupe",
- "rkyv",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
 name = "wasmer-middlewares"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7812438ed2f37203a37007cdb5332b8475cb2b16e15d51299b2647894e9ed3a"
+checksum = "190f1fa6e3a5980c9a571af457cb810945d4cd11b674b3892db973220f87bb0f"
 dependencies = [
- "loupe",
  "wasmer",
  "wasmer-types",
  "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-object"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
-dependencies = [
- "object 0.28.4",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
 ]
 
 [[package]]
@@ -14033,25 +13903,24 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
+checksum = "7d47fb87929c956693d68393d4778670ed1ce9733804b74bbd5fa6fa6d725250"
 dependencies = [
- "backtrace",
  "enum-iterator",
+ "enumset",
  "indexmap",
- "loupe",
  "more-asserts",
  "rkyv",
- "serde",
+ "target-lexicon",
  "thiserror",
 ]
 
 [[package]]
 name = "wasmer-vm"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
+checksum = "6a72cac9f0ce7a9f3d0fe01604202270cdfe8d3dae9d84742b85c5d935cad74d"
 dependencies = [
  "backtrace",
  "cc",
@@ -14061,28 +13930,25 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "loupe",
  "mach",
  "memoffset",
  "more-asserts",
  "region",
- "rkyv",
  "scopeguard",
- "serde",
  "thiserror",
- "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
 
 [[package]]
 name = "wasmer-wasi-types"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dc83aadbdf97388de3211cb6f105374f245a3cf2a5c65a16776e7a087a8468"
+checksum = "a5ada7a7fc8ac363e750518f3a81257cbc9d7188895a05fbe5e557b9d7a6366c"
 dependencies = [
  "byteorder",
  "time 0.2.27",
+ "wasmer-derive",
  "wasmer-types",
 ]
 

--- a/crates/phactory/Cargo.toml
+++ b/crates/phactory/Cargo.toml
@@ -15,7 +15,7 @@ regex       = "1.5.5"
 bitcoin     = { version = "0.27.0", features = ["use-serde"]}
 bitcoin_hashes = { version = "0.10.0", default-features = false }
 
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "std", "rc"] }
 serde_json = "1.0"
 serde_cbor = "0.11.2"
 

--- a/crates/phactory/api/src/endpoints.rs
+++ b/crates/phactory/api/src/endpoints.rs
@@ -1,7 +1,9 @@
-use derive_more::FromStr;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "std")]
+use derive_more::FromStr;
 
 #[derive(
     Serialize,
@@ -16,8 +18,8 @@ use serde::{Deserialize, Serialize};
     Hash,
     PartialOrd,
     Ord,
-    FromStr,
 )]
+#[cfg_attr(feature = "std", derive(FromStr))]
 pub enum EndpointType {
     I2p = 0,
     Http,

--- a/crates/prpc-build/src/protos_codec_extension.rs
+++ b/crates/prpc-build/src/protos_codec_extension.rs
@@ -438,6 +438,7 @@ pub fn extend_types(
         r#"
     use ::prpc::codec::scale::{Encode, Decode, Error as ScaleDecodeError};
     use ::alloc::vec::Vec;
+    use ::alloc::string::String;
     "#,
     );
     if !mod_prefix.is_empty() {

--- a/crates/sidevm/env/src/args_stack.rs
+++ b/crates/sidevm/env/src/args_stack.rs
@@ -160,7 +160,7 @@ impl<A> ArgEncode<A> for &[u8] {
     }
 }
 
-impl<'a, A> ArgDecode<'a, A> for &'a [u8] {
+impl<'a, 'b, A> ArgDecode<'a, A> for &'b [u8] {
     type Encoded = (IntPtr, IntPtr);
 
     fn decode_arg(
@@ -171,7 +171,9 @@ impl<'a, A> ArgDecode<'a, A> for &'a [u8] {
         Self: Sized,
     {
         let ((len, ptr), stack) = stack.pop();
-        Ok((vm.slice_from_vm(ptr, len)?, stack))
+        let bytes = vm.slice_from_vm(ptr, len)?;
+        let bytes = unsafe { core::mem::transmute(bytes) };
+        Ok((bytes, stack))
     }
 }
 
@@ -184,7 +186,7 @@ impl<A> ArgEncode<A> for &str {
     }
 }
 
-impl<'a, A> ArgDecode<'a, A> for &'a str {
+impl<'a, 'b, A> ArgDecode<'a, A> for &'b str {
     type Encoded = (IntPtr, IntPtr);
 
     fn decode_arg(
@@ -212,7 +214,7 @@ impl<A> ArgEncode<A> for &mut [u8] {
     }
 }
 
-impl<'a, A> ArgDecode<'a, A> for &'a mut [u8] {
+impl<'a, 'b, A> ArgDecode<'a, A> for &'b mut [u8] {
     type Encoded = (IntPtr, IntPtr);
 
     fn decode_arg(
@@ -223,7 +225,9 @@ impl<'a, A> ArgDecode<'a, A> for &'a mut [u8] {
         Self: Sized,
     {
         let ((len, ptr), stack) = stack.pop();
-        Ok((vm.slice_from_vm_mut(ptr, len)?, stack))
+        let bytes = vm.slice_from_vm_mut(ptr, len)?;
+        let bytes = unsafe { core::mem::transmute(bytes) };
+        Ok((bytes, stack))
     }
 }
 

--- a/crates/sidevm/env/src/args_stack.rs
+++ b/crates/sidevm/env/src/args_stack.rs
@@ -33,11 +33,6 @@ impl<A, B> StackedArgs<(A, B)> {
         let (a, args) = self.args;
         (a, StackedArgs { args })
     }
-
-    fn split(self) -> (StackedArgs<A>, StackedArgs<B>) {
-        let (a, b) = self.args;
-        (StackedArgs { args: a }, StackedArgs { args: b })
-    }
 }
 
 impl<B> StackedArgs<B> {
@@ -165,7 +160,7 @@ impl ArgEncode for &[u8] {
     }
 }
 
-impl<'a, 'b> ArgDecode<'a> for &'b [u8] {
+impl<'a> ArgDecode<'a> for &'a [u8] {
     type Encoded = (IntPtr, IntPtr);
 
     fn decode_arg<A>(
@@ -177,7 +172,6 @@ impl<'a, 'b> ArgDecode<'a> for &'b [u8] {
     {
         let ((len, ptr), stack) = stack.pop();
         let bytes = vm.slice_from_vm(ptr, len)?;
-        let bytes = unsafe { core::mem::transmute(bytes) };
         Ok((bytes, stack))
     }
 }
@@ -191,7 +185,7 @@ impl ArgEncode for &str {
     }
 }
 
-impl<'a, 'b> ArgDecode<'a> for &'b str {
+impl<'a> ArgDecode<'a> for &'a str {
     type Encoded = (IntPtr, IntPtr);
 
     fn decode_arg<A>(
@@ -219,7 +213,7 @@ impl ArgEncode for &mut [u8] {
     }
 }
 
-impl<'a, 'b> ArgDecode<'a> for &'b mut [u8] {
+impl<'a> ArgDecode<'a> for &'a mut [u8] {
     type Encoded = (IntPtr, IntPtr);
 
     fn decode_arg<A>(
@@ -231,7 +225,6 @@ impl<'a, 'b> ArgDecode<'a> for &'b mut [u8] {
     {
         let ((len, ptr), stack) = stack.pop();
         let bytes = vm.slice_from_vm_mut(ptr, len)?;
-        let bytes = unsafe { core::mem::transmute(bytes) };
         Ok((bytes, stack))
     }
 }

--- a/crates/sidevm/env/src/tests.rs
+++ b/crates/sidevm/env/src/tests.rs
@@ -97,7 +97,7 @@ extern "C" fn sidevm_ocall(
     p2: IntPtr,
     p3: IntPtr,
 ) -> IntRet {
-    let result = dispatch_call(&mut TestHost, &TestHost, func_id, p0, p1, p2, p3);
+    let result = dispatch_call(&mut TestHost, func_id, p0, p1, p2, p3);
     println!("sidevm_ocall {} result={:?}", func_id, result);
     result.encode_ret()
 }
@@ -111,7 +111,7 @@ extern "C" fn sidevm_ocall_fast_return(
     p2: IntPtr,
     p3: IntPtr,
 ) -> IntRet {
-    let result = dispatch_call_fast_return(&mut TestHost, &TestHost, func_id, p0, p1, p2, p3);
+    let result = dispatch_call_fast_return(&mut TestHost, func_id, p0, p1, p2, p3);
     println!("sidevm_ocall_fast_return {} result={:?}", func_id, result);
     result.encode_ret()
 }

--- a/crates/sidevm/host-runtime/Cargo.toml
+++ b/crates/sidevm/host-runtime/Cargo.toml
@@ -13,15 +13,13 @@ loupe = "0.1.3"
 sidevm-env = { path = "../env", features = ["host"] }
 thread_local = "1.1"
 tokio = { version = "1.17.0", features = ["full"] }
-wasmer = "2.3"
-wasmer-wasi-types = "2.3"
-wasmer-compiler-singlepass = "2.3"
-wasmer-compiler-cranelift = { version = "2.3", optional = true }
-wasmer-compiler-llvm = { version = "2.3", optional = true }
-wasmer-engine = "2.3"
-wasmer-engine-universal = "2.3"
+wasmer = "3.0.0-beta.2"
+wasmer-wasi-types = "3.0.0-beta.2"
+wasmer-compiler-singlepass = "3.0.0-beta.2"
+wasmer-compiler-cranelift = { version = "3.0.0-beta.2", optional = true }
+wasmer-compiler-llvm = { version = "3.0.0-beta.2", optional = true }
 wasmer-tunables = { path = "../../wasmer-tunables" }
-wasmer-middlewares = "2.3"
+wasmer-middlewares = "3.0.0-beta.2"
 parity-wasm = "0.45.0"
 wasm-instrument = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/sidevm/host-runtime/src/env.rs
+++ b/crates/sidevm/host-runtime/src/env.rs
@@ -649,7 +649,6 @@ fn sidevm_ocall_fast_return(
         env::dispatch_call_fast_return(&mut state, &vm, func_id, p0, p1, p2, p3)
     });
 
-    let env = &mut *guard;
     if env.ocall_trace_enabled {
         let func_name = env::ocall_id2name(func_id);
         let vm_id = ShortId(&env.id);
@@ -682,7 +681,7 @@ fn sidevm_ocall(
         let mut state = env.make_mut(&mut func_env);
         env::dispatch_call(&mut state, &vm, func_id, p0, p1, p2, p3)
     });
-    let env = &mut *guard;
+
     if env.ocall_trace_enabled {
         let func_name = env::ocall_id2name(func_id);
         let vm_id = ShortId(&env.id);

--- a/crates/sidevm/host-runtime/src/env/wasi_env.rs
+++ b/crates/sidevm/host-runtime/src/env/wasi_env.rs
@@ -3,13 +3,12 @@ use libc::{
     clock_getres, clock_gettime, timespec, CLOCK_MONOTONIC, CLOCK_PROCESS_CPUTIME_ID,
     CLOCK_REALTIME, CLOCK_THREAD_CPUTIME_ID,
 };
-use sidevm_env::OcallFuncs;
-use ptr::WasmPtr;
+use sidevm_env::{OcallError, OcallFuncs};
 use thiserror::Error;
-use wasmer::{namespace, Array, Exports, Function, Store};
+use wasmer::{
+    namespace, AsStoreMut, Exports, Function, FunctionEnv, FunctionEnvMut, Memory32, WasmPtr,
+};
 use wasmer_wasi_types::*;
-
-mod ptr;
 
 /// This is returned in `RuntimeError`.
 /// Use `downcast` or `downcast_ref` to retrieve the `ExitCode`.
@@ -35,66 +34,66 @@ macro_rules! wasi_try {
     }};
 }
 
-pub(crate) fn wasi_imports(store: &Store, env: &WasiEnv) -> Exports {
+pub(crate) fn wasi_imports(store: &mut impl AsStoreMut, env: &FunctionEnv<WasiEnv>) -> Exports {
     namespace! {
-        "args_get" => Function::new_native_with_env(store, env.clone(), args_get),
-        "args_sizes_get" => Function::new_native_with_env(store, env.clone(), args_sizes_get),
-        "clock_res_get" => Function::new_native_with_env(store, env.clone(), clock_res_get),
-        "clock_time_get" => Function::new_native_with_env(store, env.clone(), clock_time_get),
-        "environ_get" => Function::new_native_with_env(store, env.clone(), environ_get),
-        "environ_sizes_get" => Function::new_native_with_env(store, env.clone(), environ_sizes_get),
-        "fd_advise" => Function::new_native_with_env(store, env.clone(), fd_advise),
-        "fd_allocate" => Function::new_native_with_env(store, env.clone(), fd_allocate),
-        "fd_close" => Function::new_native_with_env(store, env.clone(), fd_close),
-        "fd_datasync" => Function::new_native_with_env(store, env.clone(), fd_datasync),
-        "fd_fdstat_get" => Function::new_native_with_env(store, env.clone(), fd_fdstat_get),
-        "fd_fdstat_set_flags" => Function::new_native_with_env(store, env.clone(), fd_fdstat_set_flags),
-        "fd_fdstat_set_rights" => Function::new_native_with_env(store, env.clone(), fd_fdstat_set_rights),
-        "fd_filestat_get" => Function::new_native_with_env(store, env.clone(), fd_filestat_get),
-        "fd_filestat_set_size" => Function::new_native_with_env(store, env.clone(), fd_filestat_set_size),
-        "fd_filestat_set_times" => Function::new_native_with_env(store, env.clone(), fd_filestat_set_times),
-        "fd_pread" => Function::new_native_with_env(store, env.clone(), fd_pread),
-        "fd_prestat_get" => Function::new_native_with_env(store, env.clone(), fd_prestat_get),
-        "fd_prestat_dir_name" => Function::new_native_with_env(store, env.clone(), fd_prestat_dir_name),
-        "fd_pwrite" => Function::new_native_with_env(store, env.clone(), fd_pwrite),
-        "fd_read" => Function::new_native_with_env(store, env.clone(), fd_read),
-        "fd_readdir" => Function::new_native_with_env(store, env.clone(), fd_readdir),
-        "fd_renumber" => Function::new_native_with_env(store, env.clone(), fd_renumber),
-        "fd_seek" => Function::new_native_with_env(store, env.clone(), fd_seek),
-        "fd_sync" => Function::new_native_with_env(store, env.clone(), fd_sync),
-        "fd_tell" => Function::new_native_with_env(store, env.clone(), fd_tell),
-        "fd_write" => Function::new_native_with_env(store, env.clone(), fd_write),
-        "path_create_directory" => Function::new_native_with_env(store, env.clone(), path_create_directory),
-        "path_filestat_get" => Function::new_native_with_env(store, env.clone(), path_filestat_get),
-        "path_filestat_set_times" => Function::new_native_with_env(store, env.clone(), path_filestat_set_times),
-        "path_link" => Function::new_native_with_env(store, env.clone(), path_link),
-        "path_open" => Function::new_native_with_env(store, env.clone(), path_open),
-        "path_readlink" => Function::new_native_with_env(store, env.clone(), path_readlink),
-        "path_remove_directory" => Function::new_native_with_env(store, env.clone(), path_remove_directory),
-        "path_rename" => Function::new_native_with_env(store, env.clone(), path_rename),
-        "path_symlink" => Function::new_native_with_env(store, env.clone(), path_symlink),
-        "path_unlink_file" => Function::new_native_with_env(store, env.clone(), path_unlink_file),
-        "poll_oneoff" => Function::new_native_with_env(store, env.clone(), poll_oneoff),
-        "proc_exit" => Function::new_native_with_env(store, env.clone(), proc_exit),
-        "proc_raise" => Function::new_native_with_env(store, env.clone(), proc_raise),
-        "random_get" => Function::new_native_with_env(store, env.clone(), random_get),
-        "sched_yield" => Function::new_native_with_env(store, env.clone(), sched_yield),
-        "sock_recv" => Function::new_native_with_env(store, env.clone(), sock_recv),
-        "sock_send" => Function::new_native_with_env(store, env.clone(), sock_send),
-        "sock_shutdown" => Function::new_native_with_env(store, env.clone(), sock_shutdown),
+        "args_get" => Function::new_typed_with_env(store, env, args_get),
+        "args_sizes_get" => Function::new_typed_with_env(store, env, args_sizes_get),
+        "clock_res_get" => Function::new_typed_with_env(store, env, clock_res_get),
+        "clock_time_get" => Function::new_typed_with_env(store, env, clock_time_get),
+        "environ_get" => Function::new_typed_with_env(store, env, environ_get),
+        "environ_sizes_get" => Function::new_typed_with_env(store, env, environ_sizes_get),
+        "fd_advise" => Function::new_typed_with_env(store, env, fd_advise),
+        "fd_allocate" => Function::new_typed_with_env(store, env, fd_allocate),
+        "fd_close" => Function::new_typed_with_env(store, env, fd_close),
+        "fd_datasync" => Function::new_typed_with_env(store, env, fd_datasync),
+        "fd_fdstat_get" => Function::new_typed_with_env(store, env, fd_fdstat_get),
+        "fd_fdstat_set_flags" => Function::new_typed_with_env(store, env, fd_fdstat_set_flags),
+        "fd_fdstat_set_rights" => Function::new_typed_with_env(store, env, fd_fdstat_set_rights),
+        "fd_filestat_get" => Function::new_typed_with_env(store, env, fd_filestat_get),
+        "fd_filestat_set_size" => Function::new_typed_with_env(store, env, fd_filestat_set_size),
+        "fd_filestat_set_times" => Function::new_typed_with_env(store, env, fd_filestat_set_times),
+        "fd_pread" => Function::new_typed_with_env(store, env, fd_pread),
+        "fd_prestat_get" => Function::new_typed_with_env(store, env, fd_prestat_get),
+        "fd_prestat_dir_name" => Function::new_typed_with_env(store, env, fd_prestat_dir_name),
+        "fd_pwrite" => Function::new_typed_with_env(store, env, fd_pwrite),
+        "fd_read" => Function::new_typed_with_env(store, env, fd_read),
+        "fd_readdir" => Function::new_typed_with_env(store, env, fd_readdir),
+        "fd_renumber" => Function::new_typed_with_env(store, env, fd_renumber),
+        "fd_seek" => Function::new_typed_with_env(store, env, fd_seek),
+        "fd_sync" => Function::new_typed_with_env(store, env, fd_sync),
+        "fd_tell" => Function::new_typed_with_env(store, env, fd_tell),
+        "fd_write" => Function::new_typed_with_env(store, env, fd_write),
+        "path_create_directory" => Function::new_typed_with_env(store, env, path_create_directory),
+        "path_filestat_get" => Function::new_typed_with_env(store, env, path_filestat_get),
+        "path_filestat_set_times" => Function::new_typed_with_env(store, env, path_filestat_set_times),
+        "path_link" => Function::new_typed_with_env(store, env, path_link),
+        "path_open" => Function::new_typed_with_env(store, env, path_open),
+        "path_readlink" => Function::new_typed_with_env(store, env, path_readlink),
+        "path_remove_directory" => Function::new_typed_with_env(store, env, path_remove_directory),
+        "path_rename" => Function::new_typed_with_env(store, env, path_rename),
+        "path_symlink" => Function::new_typed_with_env(store, env, path_symlink),
+        "path_unlink_file" => Function::new_typed_with_env(store, env, path_unlink_file),
+        "poll_oneoff" => Function::new_typed_with_env(store, env, poll_oneoff),
+        "proc_exit" => Function::new_typed_with_env(store, env, proc_exit),
+        "proc_raise" => Function::new_typed_with_env(store, env, proc_raise),
+        "random_get" => Function::new_typed_with_env(store, env, random_get),
+        "sched_yield" => Function::new_typed_with_env(store, env, sched_yield),
+        "sock_recv" => Function::new_typed_with_env(store, env, sock_recv),
+        "sock_send" => Function::new_typed_with_env(store, env, sock_send),
+        "sock_shutdown" => Function::new_typed_with_env(store, env, sock_shutdown),
     }
 }
 
 pub fn args_get(
-    _env: &WasiEnv,
-    _argv: WasmPtr<WasmPtr<u8, Array>, Array>,
-    _argv_buf: WasmPtr<u8, Array>,
+    _env: FunctionEnvMut<WasiEnv>,
+    _argv: WasmPtr<WasmPtr<u8>>,
+    _argv_buf: WasmPtr<u8>,
 ) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn args_sizes_get(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _argc: WasmPtr<u32>,
     _argv_buf_size: WasmPtr<u32>,
 ) -> __wasi_errno_t {
@@ -102,7 +101,7 @@ pub fn args_sizes_get(
 }
 
 pub fn clock_res_get(
-    env: &WasiEnv,
+    env: FunctionEnvMut<WasiEnv>,
     clock_id: __wasi_clockid_t,
     resolution: WasmPtr<__wasi_timestamp_t>,
 ) -> __wasi_errno_t {
@@ -124,16 +123,19 @@ pub fn clock_res_get(
 
     let t_out = (timespec_out.tv_sec * 1_000_000_000).wrapping_add(timespec_out.tv_nsec);
 
-    let guard = env.inner.lock().unwrap();
-    let memory = guard.memory.unwrap_ref();
-    let resolution = wasi_try!(resolution.deref(memory));
-    resolution.set(t_out as __wasi_timestamp_t);
+    let guard = env.data().inner.lock().unwrap();
+    let memory = guard.memory.unwrap_ref().view(&env);
+    let resolution = resolution.deref(&memory);
+    wasi_try!(
+        resolution.write(t_out as __wasi_timestamp_t).ok(),
+        __WASI_EACCES
+    );
 
     __WASI_ESUCCESS
 }
 
 pub fn clock_time_get(
-    env: &WasiEnv,
+    env: FunctionEnvMut<WasiEnv>,
     clock_id: __wasi_clockid_t,
     _precision: __wasi_timestamp_t,
     time: WasmPtr<__wasi_timestamp_t>,
@@ -159,38 +161,38 @@ pub fn clock_time_get(
 
     let t_out = (timespec_out.tv_sec * 1_000_000_000).wrapping_add(timespec_out.tv_nsec);
 
-    let guard = env.inner.lock().unwrap();
-    let memory = guard.memory.unwrap_ref();
-    let time = wasi_try!(time.deref(memory));
-    time.set(t_out as __wasi_timestamp_t);
+    let guard = env.data().inner.lock().unwrap();
+    let memory = guard.memory.unwrap_ref().view(&env);
+    let time = time.deref(&memory);
+    wasi_try!(time.write(t_out as __wasi_timestamp_t).ok(), __WASI_EACCES);
 
     __WASI_ESUCCESS
 }
 
 pub fn environ_get(
-    _env: &WasiEnv,
-    _environ: WasmPtr<WasmPtr<u8, Array>, Array>,
-    _environ_buf: WasmPtr<u8, Array>,
+    _env: FunctionEnvMut<WasiEnv>,
+    _environ: WasmPtr<WasmPtr<u8>>,
+    _environ_buf: WasmPtr<u8>,
 ) -> __wasi_errno_t {
     __WASI_ESUCCESS
 }
 
 pub fn environ_sizes_get(
-    env: &WasiEnv,
+    env: FunctionEnvMut<WasiEnv>,
     environ_count: WasmPtr<u32>,
     environ_buf_size: WasmPtr<u32>,
 ) -> __wasi_errno_t {
-    let guard = env.inner.lock().unwrap();
-    let memory = guard.memory.unwrap_ref();
-    let environ_count = wasi_try!(environ_count.deref(memory));
-    let environ_buf_size = wasi_try!(environ_buf_size.deref(memory));
-    environ_count.set(0);
-    environ_buf_size.set(0);
+    let guard = env.data().inner.lock().unwrap();
+    let memory = guard.memory.unwrap_ref().view(&env);
+    let environ_count = environ_count.deref(&memory);
+    let environ_buf_size = environ_buf_size.deref(&memory);
+    wasi_try!(environ_count.write(0).ok(), __WASI_EACCES);
+    wasi_try!(environ_buf_size.write(0).ok(), __WASI_EACCES);
     __WASI_ESUCCESS
 }
 
 pub fn fd_advise(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _offset: __wasi_filesize_t,
     _len: __wasi_filesize_t,
@@ -200,7 +202,7 @@ pub fn fd_advise(
 }
 
 pub fn fd_allocate(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _offset: __wasi_filesize_t,
     _len: __wasi_filesize_t,
@@ -208,16 +210,16 @@ pub fn fd_allocate(
     __WASI_ENOSYS
 }
 
-pub fn fd_close(_env: &WasiEnv, _fd: __wasi_fd_t) -> __wasi_errno_t {
+pub fn fd_close(_env: FunctionEnvMut<WasiEnv>, _fd: __wasi_fd_t) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
-pub fn fd_datasync(_env: &WasiEnv, _fd: __wasi_fd_t) -> __wasi_errno_t {
+pub fn fd_datasync(_env: FunctionEnvMut<WasiEnv>, _fd: __wasi_fd_t) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn fd_fdstat_get(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _buf_ptr: WasmPtr<__wasi_fdstat_t>,
 ) -> __wasi_errno_t {
@@ -225,7 +227,7 @@ pub fn fd_fdstat_get(
 }
 
 pub fn fd_fdstat_set_flags(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _flags: __wasi_fdflags_t,
 ) -> __wasi_errno_t {
@@ -233,7 +235,7 @@ pub fn fd_fdstat_set_flags(
 }
 
 pub fn fd_fdstat_set_rights(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _fs_rights_base: __wasi_rights_t,
     _fs_rights_inheriting: __wasi_rights_t,
@@ -242,7 +244,7 @@ pub fn fd_fdstat_set_rights(
 }
 
 pub fn fd_filestat_get(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _buf: WasmPtr<__wasi_filestat_t>,
 ) -> __wasi_errno_t {
@@ -250,7 +252,7 @@ pub fn fd_filestat_get(
 }
 
 pub fn fd_filestat_set_size(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _st_size: __wasi_filesize_t,
 ) -> __wasi_errno_t {
@@ -258,7 +260,7 @@ pub fn fd_filestat_set_size(
 }
 
 pub fn fd_filestat_set_times(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _st_atim: __wasi_timestamp_t,
     _st_mtim: __wasi_timestamp_t,
@@ -268,9 +270,9 @@ pub fn fd_filestat_set_times(
 }
 
 pub fn fd_pread(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
-    _iovs: WasmPtr<__wasi_iovec_t, Array>,
+    _iovs: WasmPtr<__wasi_iovec_t<Memory32>>,
     _iovs_len: u32,
     _offset: __wasi_filesize_t,
     _nread: WasmPtr<u32>,
@@ -279,7 +281,7 @@ pub fn fd_pread(
 }
 
 pub fn fd_prestat_get(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _buf: WasmPtr<__wasi_prestat_t>,
 ) -> __wasi_errno_t {
@@ -287,18 +289,18 @@ pub fn fd_prestat_get(
 }
 
 pub fn fd_prestat_dir_name(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
-    _path: WasmPtr<u8, Array>,
+    _path: WasmPtr<u8>,
     _path_len: u32,
 ) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn fd_pwrite(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
-    _iovs: WasmPtr<__wasi_ciovec_t, Array>,
+    _iovs: WasmPtr<__wasi_ciovec_t<Memory32>>,
     _iovs_len: u32,
     _offset: __wasi_filesize_t,
     _nwritten: WasmPtr<u32>,
@@ -307,9 +309,9 @@ pub fn fd_pwrite(
 }
 
 pub fn fd_read(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
-    _iovs: WasmPtr<__wasi_iovec_t, Array>,
+    _iovs: WasmPtr<__wasi_iovec_t<Memory32>>,
     _iovs_len: u32,
     _nread: WasmPtr<u32>,
 ) -> __wasi_errno_t {
@@ -317,9 +319,9 @@ pub fn fd_read(
 }
 
 pub fn fd_readdir(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
-    _buf: WasmPtr<u8, Array>,
+    _buf: WasmPtr<u8>,
     _buf_len: u32,
     _cookie: __wasi_dircookie_t,
     _bufused: WasmPtr<u32>,
@@ -327,12 +329,16 @@ pub fn fd_readdir(
     __WASI_ENOSYS
 }
 
-pub fn fd_renumber(_env: &WasiEnv, _from: __wasi_fd_t, _to: __wasi_fd_t) -> __wasi_errno_t {
+pub fn fd_renumber(
+    _env: FunctionEnvMut<WasiEnv>,
+    _from: __wasi_fd_t,
+    _to: __wasi_fd_t,
+) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn fd_seek(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _offset: __wasi_filedelta_t,
     _whence: __wasi_whence_t,
@@ -341,12 +347,12 @@ pub fn fd_seek(
     __WASI_ENOSYS
 }
 
-pub fn fd_sync(_env: &WasiEnv, _fd: __wasi_fd_t) -> __wasi_errno_t {
+pub fn fd_sync(_env: FunctionEnvMut<WasiEnv>, _fd: __wasi_fd_t) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn fd_tell(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _offset: WasmPtr<__wasi_filesize_t>,
 ) -> __wasi_errno_t {
@@ -354,9 +360,9 @@ pub fn fd_tell(
 }
 
 pub fn fd_write(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
-    _iovs: WasmPtr<__wasi_ciovec_t, Array>,
+    _iovs: WasmPtr<__wasi_ciovec_t<Memory32>>,
     _iovs_len: u32,
     _nwritten: WasmPtr<u32>,
 ) -> __wasi_errno_t {
@@ -364,19 +370,19 @@ pub fn fd_write(
 }
 
 pub fn path_create_directory(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
-    _path: WasmPtr<u8, Array>,
+    _path: WasmPtr<u8>,
     _path_len: u32,
 ) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn path_filestat_get(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _flags: __wasi_lookupflags_t,
-    _path: WasmPtr<u8, Array>,
+    _path: WasmPtr<u8>,
     _path_len: u32,
     _buf: WasmPtr<__wasi_filestat_t>,
 ) -> __wasi_errno_t {
@@ -384,10 +390,10 @@ pub fn path_filestat_get(
 }
 
 pub fn path_filestat_set_times(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
     _flags: __wasi_lookupflags_t,
-    _path: WasmPtr<u8, Array>,
+    _path: WasmPtr<u8>,
     _path_len: u32,
     _st_atim: __wasi_timestamp_t,
     _st_mtim: __wasi_timestamp_t,
@@ -397,23 +403,23 @@ pub fn path_filestat_set_times(
 }
 
 pub fn path_link(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _old_fd: __wasi_fd_t,
     _old_flags: __wasi_lookupflags_t,
-    _old_path: WasmPtr<u8, Array>,
+    _old_path: WasmPtr<u8>,
     _old_path_len: u32,
     _new_fd: __wasi_fd_t,
-    _new_path: WasmPtr<u8, Array>,
+    _new_path: WasmPtr<u8>,
     _new_path_len: u32,
 ) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn path_open(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _dirfd: __wasi_fd_t,
     _dirflags: __wasi_lookupflags_t,
-    _path: WasmPtr<u8, Array>,
+    _path: WasmPtr<u8>,
     _path_len: u32,
     _o_flags: __wasi_oflags_t,
     _fs_rights_base: __wasi_rights_t,
@@ -425,11 +431,11 @@ pub fn path_open(
 }
 
 pub fn path_readlink(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _dir_fd: __wasi_fd_t,
-    _path: WasmPtr<u8, Array>,
+    _path: WasmPtr<u8>,
     _path_len: u32,
-    _buf: WasmPtr<u8, Array>,
+    _buf: WasmPtr<u8>,
     _buf_len: u32,
     _buf_used: WasmPtr<u32>,
 ) -> __wasi_errno_t {
@@ -437,87 +443,92 @@ pub fn path_readlink(
 }
 
 pub fn path_remove_directory(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
-    _path: WasmPtr<u8, Array>,
+    _path: WasmPtr<u8>,
     _path_len: u32,
 ) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn path_rename(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _old_fd: __wasi_fd_t,
-    _old_path: WasmPtr<u8, Array>,
+    _old_path: WasmPtr<u8>,
     _old_path_len: u32,
     _new_fd: __wasi_fd_t,
-    _new_path: WasmPtr<u8, Array>,
+    _new_path: WasmPtr<u8>,
     _new_path_len: u32,
 ) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn path_symlink(
-    _env: &WasiEnv,
-    _old_path: WasmPtr<u8, Array>,
+    _env: FunctionEnvMut<WasiEnv>,
+    _old_path: WasmPtr<u8>,
     _old_path_len: u32,
     _fd: __wasi_fd_t,
-    _new_path: WasmPtr<u8, Array>,
+    _new_path: WasmPtr<u8>,
     _new_path_len: u32,
 ) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn path_unlink_file(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _fd: __wasi_fd_t,
-    _path: WasmPtr<u8, Array>,
+    _path: WasmPtr<u8>,
     _path_len: u32,
 ) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
 pub fn poll_oneoff(
-    _env: &WasiEnv,
-    _in_: WasmPtr<__wasi_subscription_t, Array>,
-    _out_: WasmPtr<__wasi_event_t, Array>,
+    _env: FunctionEnvMut<WasiEnv>,
+    _in_: WasmPtr<__wasi_subscription_t>,
+    _out_: WasmPtr<__wasi_event_t>,
     _nsubscriptions: u32,
     _nevents: WasmPtr<u32>,
 ) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
-pub fn proc_exit(_env: &WasiEnv, code: __wasi_exitcode_t) -> Result<(), WasiError> {
+pub fn proc_exit(_env: FunctionEnvMut<WasiEnv>, code: __wasi_exitcode_t) -> Result<(), WasiError> {
     Err(WasiError::Exited(code))
 }
 
-pub fn proc_raise(_env: &WasiEnv, _sig: __wasi_signal_t) -> __wasi_errno_t {
+pub fn proc_raise(_env: FunctionEnvMut<WasiEnv>, _sig: __wasi_signal_t) -> __wasi_errno_t {
     __WASI_ENOSYS
 }
 
-pub fn random_get(env: &WasiEnv, buf: u32, buf_len: u32) -> Result<__wasi_errno_t> {
-    let mut env_guard = env.inner.lock().unwrap();
-    let env = &mut *env_guard;
-    let memory = env.memory.unwrap_ref();
+pub fn random_get(
+    mut env: FunctionEnvMut<WasiEnv>,
+    buf: u32,
+    buf_len: u32,
+) -> Result<__wasi_errno_t> {
+    let inner = env.data().inner.clone();
+    let mut env_guard = inner.lock().unwrap();
+
+    let inner = &mut *env_guard;
     let mut u8_buffer = vec![0; buf_len as usize];
-    env.state.getrandom(&mut u8_buffer)?;
-    unsafe {
-        memory
-            .uint8view()
-            .subarray(buf as u32, buf as u32 + buf_len as u32)
-            .copy_from(&u8_buffer);
-    }
+    inner.make_mut(&mut env).getrandom(&mut u8_buffer)?;
+    inner
+        .memory
+        .unwrap_ref()
+        .view(&env)
+        .write(buf as _, &u8_buffer)
+        .or(Err(OcallError::InvalidAddress))?;
     Ok(__WASI_ESUCCESS)
 }
 
-pub fn sched_yield(_env: &WasiEnv) -> __wasi_errno_t {
+pub fn sched_yield(_env: FunctionEnvMut<WasiEnv>) -> __wasi_errno_t {
     __WASI_ESUCCESS
 }
 
 pub fn sock_recv(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _sock: __wasi_fd_t,
-    _ri_data: WasmPtr<__wasi_iovec_t, Array>,
+    _ri_data: WasmPtr<__wasi_iovec_t<Memory32>>,
     _ri_data_len: u32,
     _ri_flags: __wasi_riflags_t,
     _ro_datalen: WasmPtr<u32>,
@@ -527,9 +538,9 @@ pub fn sock_recv(
 }
 
 pub fn sock_send(
-    _env: &WasiEnv,
+    _env: FunctionEnvMut<WasiEnv>,
     _sock: __wasi_fd_t,
-    _si_data: WasmPtr<__wasi_ciovec_t, Array>,
+    _si_data: WasmPtr<__wasi_ciovec_t<Memory32>>,
     _si_data_len: u32,
     _si_flags: __wasi_siflags_t,
     _so_datalen: WasmPtr<u32>,
@@ -537,6 +548,10 @@ pub fn sock_send(
     __WASI_ENOSYS
 }
 
-pub fn sock_shutdown(_env: &WasiEnv, _sock: __wasi_fd_t, _how: __wasi_sdflags_t) -> __wasi_errno_t {
+pub fn sock_shutdown(
+    _env: FunctionEnvMut<WasiEnv>,
+    _sock: __wasi_fd_t,
+    _how: __wasi_sdflags_t,
+) -> __wasi_errno_t {
     __WASI_ENOSYS
 }

--- a/crates/sidevm/host-runtime/src/env/wasi_env/ptr.rs
+++ b/crates/sidevm/host-runtime/src/env/wasi_env/ptr.rs
@@ -1,63 +1,6 @@
 use core::fmt;
 
-use wasmer::{Memory, WasmCell, WasmPtr as BaseWasmPtr};
+use wasmer::{Memory, WasmCell, WasmPtr};
 use wasmer::{FromToNativeWasmType, Item, ValueType};
 use wasmer_wasi_types::*;
 
-#[repr(transparent)]
-pub struct WasmPtr<T: Copy, Ty = Item>(BaseWasmPtr<T, Ty>);
-
-unsafe impl<T: Copy, Ty> ValueType for WasmPtr<T, Ty> {}
-impl<T: Copy, Ty> Copy for WasmPtr<T, Ty> {}
-
-impl<T: Copy, Ty> Clone for WasmPtr<T, Ty> {
-    fn clone(&self) -> Self {
-        #[allow(clippy::clone_on_copy)]
-        Self(self.0.clone())
-    }
-}
-
-impl<T: Copy, Ty> fmt::Debug for WasmPtr<T, Ty> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.0)
-    }
-}
-
-impl<T: Copy, Ty> From<i32> for WasmPtr<T, Ty> {
-    fn from(offset: i32) -> Self {
-        Self::new(offset as _)
-    }
-}
-
-unsafe impl<T: Copy, Ty> FromToNativeWasmType for WasmPtr<T, Ty> {
-    type Native = <BaseWasmPtr<T, Ty> as FromToNativeWasmType>::Native;
-
-    fn to_native(self) -> Self::Native {
-        self.0.to_native()
-    }
-    fn from_native(n: Self::Native) -> Self {
-        Self(BaseWasmPtr::from_native(n))
-    }
-}
-
-impl<T: Copy, Ty> PartialEq for WasmPtr<T, Ty> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<T: Copy, Ty> Eq for WasmPtr<T, Ty> {}
-
-impl<T: Copy, Ty> WasmPtr<T, Ty> {
-    #[inline(always)]
-    pub fn new(offset: u32) -> Self {
-        Self(BaseWasmPtr::new(offset))
-    }
-}
-
-impl<T: Copy + ValueType> WasmPtr<T, Item> {
-    #[inline(always)]
-    pub fn deref<'a>(self, memory: &'a Memory) -> Result<WasmCell<'a, T>, __wasi_errno_t> {
-        self.0.deref(memory).ok_or(__WASI_EFAULT)
-    }
-}

--- a/crates/sidevm/host-runtime/src/run.rs
+++ b/crates/sidevm/host-runtime/src/run.rs
@@ -3,7 +3,7 @@ use phala_scheduler::TaskScheduler;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use wasmer::{BaseTunables, Instance, Module, NativeFunc, Pages, RuntimeError, Store, Universal};
+use wasmer::{BaseTunables, Engine, Instance, Module, Pages, RuntimeError, Store, TypedFunction};
 #[cfg(feature = "wasmer-compiler-cranelift")]
 use wasmer_compiler_cranelift::Cranelift;
 #[cfg(feature = "wasmer-compiler-llvm")]
@@ -17,7 +17,8 @@ use crate::{async_context, env, metering::metering, VmId};
 pub struct WasmRun {
     id: VmId,
     env: env::Env,
-    wasm_poll_entry: NativeFunc<(), i32>,
+    store: Store,
+    wasm_poll_entry: TypedFunction<(), i32>,
     scheduler: TaskScheduler<VmId>,
 }
 
@@ -43,15 +44,14 @@ impl WasmRun {
             .map(AsRef::as_ref)
             .unwrap_or("singlepass");
 
-        let engine = match compiler_env {
-            "singlepass" => Universal::new(metering(Singlepass::default())),
+        let engine: Engine = match compiler_env {
+            "singlepass" => metering(Singlepass::default()).into(),
             #[cfg(feature = "wasmer-compiler-cranelift")]
-            "cranelift" => Universal::new(metering(Cranelift::default())),
+            "cranelift" => metering(Cranelift::default()).into(),
             #[cfg(feature = "wasmer-compiler-llvm")]
-            "llvm" => Universal::new(LLVM::default()),
+            "llvm" => LLVM::default().into(),
             _ => panic!("Unsupported compiler engine: {}", compiler_env),
-        }
-        .engine();
+        };
         let base = BaseTunables {
             // Always use dynamic heap memory to save memory
             static_memory_bound: Pages(0),
@@ -59,15 +59,15 @@ impl WasmRun {
             dynamic_memory_offset_guard_size: page_size::get() as _,
         };
         let tunables = LimitingTunables::new(base, Pages(max_pages));
-        let store = Store::new_with_tunables(&engine, tunables);
+        let mut store = Store::new_with_tunables(&engine, tunables);
         let module = Module::new(&store, code)?;
-        let (env, import_object) = env::create_env(id, &store, cache_ops);
-        let instance = Instance::new(&module, &import_object)?;
+        let (env, import_object) = env::create_env(id, &mut store, cache_ops);
+        let instance = Instance::new(&mut store, &module, &import_object)?;
         let memory = instance
             .exports
             .get_memory("memory")
             .context("No memory exported")?;
-        let wasm_poll_entry = instance.exports.get_native_function("sidevm_poll")?;
+        let wasm_poll_entry = instance.exports.get_typed_function(&store, "sidevm_poll")?;
         env.set_memory(memory.clone());
         env.set_instance(instance);
         env.set_gas_per_breath(gas_per_breath);
@@ -76,6 +76,7 @@ impl WasmRun {
             WasmRun {
                 env: env.clone(),
                 wasm_poll_entry,
+                store,
                 scheduler,
                 id,
             },
@@ -89,11 +90,13 @@ impl Future for WasmRun {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let _guard = futures::ready!(self.scheduler.poll_resume(cx, &self.id, self.env.weight()));
-        self.env.reset_gas_to_breath();
-        match async_context::set_task_cx(cx, || self.wasm_poll_entry.call()) {
+        let run = self.get_mut();
+        run.env.reset_gas_to_breath(&mut run.store);
+        match async_context::set_task_cx(cx, || run.wasm_poll_entry.call(&mut run.store))
+        {
             Ok(rv) => {
                 if rv == 0 {
-                    if self.env.has_more_ready() {
+                    if run.env.has_more_ready() {
                         cx.waker().wake_by_ref();
                     }
                     Poll::Pending
@@ -102,8 +105,10 @@ impl Future for WasmRun {
                 }
             }
             Err(err) => {
-                if self.env.is_stifled() {
-                    Poll::Ready(Err(RuntimeError::user(crate::env::OcallAborted::Stifled.into())))
+                if run.env.is_stifled(&mut run.store) {
+                    Poll::Ready(Err(RuntimeError::user(
+                        crate::env::OcallAborted::Stifled.into(),
+                    )))
                 } else {
                     Poll::Ready(Err(err))
                 }

--- a/crates/sidevm/macro/src/snapshots/sidevm_macro__tests__ocall.snap
+++ b/crates/sidevm/macro/src/snapshots/sidevm_macro__tests__ocall.snap
@@ -72,68 +72,66 @@ pub mod ocall_guest {
         }
     }
 }
-pub fn dispatch_call_fast_return<Env: Ocall + OcallEnv + VmMemory>(
+pub fn dispatch_ocall<Env: Ocall + OcallEnv, Vm: VmMemory>(
+    fast_return: bool,
     env: &mut Env,
+    vm: &Vm,
     id: i32,
     p0: IntPtr,
     p1: IntPtr,
     p2: IntPtr,
     p3: IntPtr,
 ) -> Result<i32> {
-    match id {
-        0 => {
-            let buffer = env.take_return().ok_or(OcallError::NotFound)?;
-            let len = p1 as usize;
-            if buffer.len() != len {
-                return Err(OcallError::InvalidParameter);
+    if fast_return {
+        match id {
+            0 => {
+                let buffer = env.take_return().ok_or(OcallError::NotFound)?;
+                let len = p1 as usize;
+                if buffer.len() != len {
+                    return Err(OcallError::InvalidParameter);
+                }
+                vm.copy_to_vm(&buffer, p0)?;
+                Ok(len as i32)
             }
-            env.copy_to_vm(&buffer, p0)?;
-            Ok(len as i32)
+            104 => {
+                let (a, b) = {
+                    let mut buf = vm.slice_from_vm(p0, p1)?;
+                    Decode::decode(&mut buf).or(Err(OcallError::InvalidParameter))?
+                };
+                env.call_fo(a, b).map(|x| x.to_i32())
+            }
+            102 => {
+                let stack =
+                    StackedArgs::load(&[p0, p1, p2, p3]).ok_or(OcallError::InvalidParameter)?;
+                let (b, stack) = stack.pop_arg(vm)?;
+                let (a, stack) = stack.pop_arg(vm)?;
+                let _: StackedArgs<()> = stack;
+                env.poll_fi_fo(a, b).map(|x| x.to_i32())
+            }
+            _ => Err(OcallError::UnknownCallNumber),
         }
-        104 => {
-            let (a, b) = {
-                let mut buf = env.slice_from_vm(p0, p1)?;
-                Decode::decode(&mut buf).or(Err(OcallError::InvalidParameter))?
-            };
-            env.call_fo(a, b).map(|x| x.to_i32())
-        }
-        102 => {
-            let stack = StackedArgs::load(&[p0, p1, p2, p3]).ok_or(OcallError::InvalidParameter)?;
-            let (b, stack) = stack.pop_arg(env)?;
-            let (a, stack) = stack.pop_arg(env)?;
-            let _: StackedArgs<()> = stack;
-            env.poll_fi_fo(a, b).map(|x| x.to_i32())
-        }
-        _ => Err(OcallError::UnknownCallNumber),
+    } else {
+        Ok(match id {
+            101 => {
+                let (a, b) = {
+                    let mut buf = vm.slice_from_vm(p0, p1)?;
+                    Decode::decode(&mut buf).or(Err(OcallError::InvalidParameter))?
+                };
+                let ret = env.call_slow(a, b);
+                env.put_return(ret?.encode()) as _
+            }
+            103 => {
+                let stack =
+                    StackedArgs::load(&[p0, p1, p2, p3]).ok_or(OcallError::InvalidParameter)?;
+                let (b, stack) = stack.pop_arg(vm)?;
+                let (a, stack) = stack.pop_arg(vm)?;
+                let _: StackedArgs<()> = stack;
+                let ret = env.call_fi(a, b);
+                env.put_return(ret?.encode()) as _
+            }
+            _ => return Err(OcallError::UnknownCallNumber),
+        })
     }
-}
-pub fn dispatch_call<Env: Ocall + OcallEnv + VmMemory>(
-    env: &mut Env,
-    id: i32,
-    p0: IntPtr,
-    p1: IntPtr,
-    p2: IntPtr,
-    p3: IntPtr,
-) -> Result<i32> {
-    Ok(match id {
-        101 => {
-            let (a, b) = {
-                let mut buf = env.slice_from_vm(p0, p1)?;
-                Decode::decode(&mut buf).or(Err(OcallError::InvalidParameter))?
-            };
-            let ret = env.call_slow(a, b);
-            env.put_return(ret?.encode()) as _
-        }
-        103 => {
-            let stack = StackedArgs::load(&[p0, p1, p2, p3]).ok_or(OcallError::InvalidParameter)?;
-            let (b, stack) = stack.pop_arg(env)?;
-            let (a, stack) = stack.pop_arg(env)?;
-            let _: StackedArgs<()> = stack;
-            let ret = env.call_fi(a, b);
-            env.put_return(ret?.encode()) as _
-        }
-        _ => return Err(OcallError::UnknownCallNumber),
-    })
 }
 pub fn ocall_id2name(id: i32) -> &'static str {
     match id {

--- a/crates/sidevm/macro/src/snapshots/sidevm_macro__tests__ocall.snap
+++ b/crates/sidevm/macro/src/snapshots/sidevm_macro__tests__ocall.snap
@@ -72,9 +72,8 @@ pub mod ocall_guest {
         }
     }
 }
-pub fn dispatch_call_fast_return<Env: Ocall + OcallEnv, Vm: VmMemory>(
+pub fn dispatch_call_fast_return<Env: Ocall + OcallEnv + VmMemory>(
     env: &mut Env,
-    vm: &Vm,
     id: i32,
     p0: IntPtr,
     p1: IntPtr,
@@ -88,29 +87,28 @@ pub fn dispatch_call_fast_return<Env: Ocall + OcallEnv, Vm: VmMemory>(
             if buffer.len() != len {
                 return Err(OcallError::InvalidParameter);
             }
-            vm.copy_to_vm(&buffer, p0)?;
+            env.copy_to_vm(&buffer, p0)?;
             Ok(len as i32)
         }
         104 => {
             let (a, b) = {
-                let mut buf = vm.slice_from_vm(p0, p1)?;
+                let mut buf = env.slice_from_vm(p0, p1)?;
                 Decode::decode(&mut buf).or(Err(OcallError::InvalidParameter))?
             };
             env.call_fo(a, b).map(|x| x.to_i32())
         }
         102 => {
             let stack = StackedArgs::load(&[p0, p1, p2, p3]).ok_or(OcallError::InvalidParameter)?;
-            let (b, stack) = stack.pop_arg(vm)?;
-            let (a, stack) = stack.pop_arg(vm)?;
+            let (b, stack) = stack.pop_arg(env)?;
+            let (a, stack) = stack.pop_arg(env)?;
             let _: StackedArgs<()> = stack;
             env.poll_fi_fo(a, b).map(|x| x.to_i32())
         }
         _ => Err(OcallError::UnknownCallNumber),
     }
 }
-pub fn dispatch_call<Env: Ocall + OcallEnv, Vm: VmMemory>(
+pub fn dispatch_call<Env: Ocall + OcallEnv + VmMemory>(
     env: &mut Env,
-    vm: &Vm,
     id: i32,
     p0: IntPtr,
     p1: IntPtr,
@@ -120,7 +118,7 @@ pub fn dispatch_call<Env: Ocall + OcallEnv, Vm: VmMemory>(
     Ok(match id {
         101 => {
             let (a, b) = {
-                let mut buf = vm.slice_from_vm(p0, p1)?;
+                let mut buf = env.slice_from_vm(p0, p1)?;
                 Decode::decode(&mut buf).or(Err(OcallError::InvalidParameter))?
             };
             let ret = env.call_slow(a, b);
@@ -128,8 +126,8 @@ pub fn dispatch_call<Env: Ocall + OcallEnv, Vm: VmMemory>(
         }
         103 => {
             let stack = StackedArgs::load(&[p0, p1, p2, p3]).ok_or(OcallError::InvalidParameter)?;
-            let (b, stack) = stack.pop_arg(vm)?;
-            let (a, stack) = stack.pop_arg(vm)?;
+            let (b, stack) = stack.pop_arg(env)?;
+            let (a, stack) = stack.pop_arg(env)?;
             let _: StackedArgs<()> = stack;
             let ret = env.call_fi(a, b);
             env.put_return(ret?.encode()) as _

--- a/crates/wasmer-tunables/Cargo.toml
+++ b/crates/wasmer-tunables/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 loupe = "0.1.3"
-wasmer = "2.3"
+wasmer = "3.0.0-beta.2"
 

--- a/crates/wasmer-tunables/src/lib.rs
+++ b/crates/wasmer-tunables/src/lib.rs
@@ -1,7 +1,5 @@
 use std::ptr::NonNull;
-use std::sync::Arc;
 
-use loupe::MemoryUsage;
 use wasmer::{
     vm::{self, MemoryError, MemoryStyle, TableStyle, VMMemoryDefinition, VMTableDefinition},
     MemoryType, Pages, TableType, Tunables,
@@ -11,7 +9,6 @@ use wasmer::{
 ///
 /// After adjusting the memory limits, it delegates all other logic
 /// to the base tunables.
-#[derive(MemoryUsage)]
 pub struct LimitingTunables<T: Tunables> {
     /// The maximum a linear memory is allowed to be (in Wasm pages, 64 KiB each).
     /// Since Wasmer ensures there is only none or one memory, this is practically
@@ -84,7 +81,7 @@ impl<T: Tunables> Tunables for LimitingTunables<T> {
         &self,
         ty: &MemoryType,
         style: &MemoryStyle,
-    ) -> Result<Arc<dyn vm::Memory>, MemoryError> {
+    ) -> Result<vm::VMMemory, MemoryError> {
         let adjusted = self.adjust_memory(ty);
         self.validate_memory(&adjusted)?;
         self.base.create_host_memory(&adjusted, style)
@@ -98,7 +95,7 @@ impl<T: Tunables> Tunables for LimitingTunables<T> {
         ty: &MemoryType,
         style: &MemoryStyle,
         vm_definition_location: NonNull<VMMemoryDefinition>,
-    ) -> Result<Arc<dyn vm::Memory>, MemoryError> {
+    ) -> Result<vm::VMMemory, MemoryError> {
         let adjusted = self.adjust_memory(ty);
         self.validate_memory(&adjusted)?;
         self.base
@@ -112,7 +109,7 @@ impl<T: Tunables> Tunables for LimitingTunables<T> {
         &self,
         ty: &TableType,
         style: &TableStyle,
-    ) -> Result<Arc<dyn vm::Table>, String> {
+    ) -> Result<vm::VMTable, String> {
         self.base.create_host_table(ty, style)
     }
 
@@ -124,7 +121,7 @@ impl<T: Tunables> Tunables for LimitingTunables<T> {
         ty: &TableType,
         style: &TableStyle,
         vm_definition_location: NonNull<VMTableDefinition>,
-    ) -> Result<Arc<dyn vm::Table>, String> {
+    ) -> Result<vm::VMTable, String> {
         self.base.create_vm_table(ty, style, vm_definition_location)
     }
 }

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.29.0",
+ "object",
  "rustc-demangle",
 ]
 
@@ -918,56 +918,57 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
+checksum = "529ffacce2249ac60edba2941672dfedf3d96558b415d0d8083cd007456e0f55"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
+checksum = "427d105f617efc8cb55f8d036a7fded2e227892d8780b4985e5551f8d27c4a92"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
+ "cranelift-isle",
  "gimli",
  "log",
- "regalloc",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
+checksum = "551674bed85b838d45358e3eab4f0ffaa6790c70dc08184204b9a54b41cdb7d1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
+checksum = "2b3a63ae57498c3eb495360944a33571754241e15e47e3bcae6082f40fec5866"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
+checksum = "11aa8aa624c72cc1c94ea3d0739fa61248260b5b14d3646f51593a88d67f3e6e"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.82.3"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
+checksum = "544ee8f4d1c9559c9aa6d46e7aaeac4a13856d620561094f35527356c7d21bd0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -976,13 +977,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
+name = "cranelift-isle"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
+checksum = "ed16b14363d929b8c37e3c557d0a7396791b383ecc302141643c054343170aad"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1183,7 +1181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
 dependencies = [
  "cfg-if",
- "hashbrown 0.12.3",
+ "hashbrown",
  "lock_api",
  "parking_lot_core",
 ]
@@ -2048,6 +2046,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generator"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2224,15 +2231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c171d55b98633f4ed3860808f004099b36c1cc29c42cfc53aa8591b21efcf2"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -2569,7 +2567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
  "serde",
 ]
 
@@ -2885,16 +2883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
 
 [[package]]
-name = "libloading"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2999,7 +2987,6 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
 dependencies = [
- "indexmap",
  "loupe-derive",
  "rustversion",
 ]
@@ -3020,7 +3007,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3106,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6566c70c1016f525ced45d7b7f97730a2bafb037c788211d0c186ef5b2189f0a"
 dependencies = [
  "hash-db",
- "hashbrown 0.12.3",
+ "hashbrown",
  "parity-util-mem",
 ]
 
@@ -3365,18 +3352,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
-dependencies = [
- "crc32fast",
- "hashbrown 0.11.2",
- "indexmap",
- "memchr",
 ]
 
 [[package]]
@@ -4248,7 +4223,7 @@ checksum = "c32561d248d352148124f036cac253a644685a21dc9fea383eb4907d7bd35a8f"
 dependencies = [
  "cfg-if",
  "ethereum-types",
- "hashbrown 0.12.3",
+ "hashbrown",
  "impl-trait-for-tuples",
  "lru",
  "parity-util-mem-derive",
@@ -5402,13 +5377,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc"
-version = "0.0.34"
+name = "regalloc2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
+checksum = "d43a209257d978ef079f3d446331d0f1794f5e0fc19b306a199983857833a779"
 dependencies = [
+ "fxhash",
  "log",
- "rustc-hash",
+ "slice-group-by",
  "smallvec",
 ]
 
@@ -5560,7 +5536,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
 dependencies = [
  "bytecheck",
- "hashbrown 0.12.3",
+ "hashbrown",
+ "indexmap",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -5961,15 +5938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_cbor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6155,8 +6123,6 @@ dependencies = [
  "wasm-instrument",
  "wasmer",
  "wasmer-compiler-singlepass",
- "wasmer-engine",
- "wasmer-engine-universal",
  "wasmer-middlewares",
  "wasmer-tunables",
  "wasmer-wasi-types",
@@ -6237,6 +6203,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "slice-group-by"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "slug"
@@ -6824,7 +6796,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.30#a3
 dependencies = [
  "ahash",
  "hash-db",
- "hashbrown 0.12.3",
+ "hashbrown",
  "lazy_static",
  "lru",
  "memory-db",
@@ -7462,7 +7434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7557,7 +7528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "004e1e8f92535694b4cb1444dc5a8073ecf0815e3357f729638b9f8fc4062908"
 dependencies = [
  "hash-db",
- "hashbrown 0.12.3",
+ "hashbrown",
  "log",
  "rustc-hex",
  "smallvec",
@@ -7959,25 +7930,21 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
+checksum = "01fc47a9d4ebb42b3a9a3d802e809bbdb5afaf3028373a82b989e51f4e400903"
 dependencies = [
+ "bytes",
  "cfg-if",
  "indexmap",
  "js-sys",
- "loupe",
  "more-asserts",
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
- "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
- "wasmer-engine",
- "wasmer-engine-dylib",
- "wasmer-engine-universal",
  "wasmer-types",
  "wasmer-vm",
  "wat",
@@ -7985,47 +7952,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
-dependencies = [
- "enumset",
- "loupe",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
 name = "wasmer-compiler"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
+checksum = "54d7b5068f9ed673f0fc8513b4702067a0f5712d3ea226eb71fc4a9c6c4fe9c7"
 dependencies = [
+ "backtrace",
+ "cfg-if",
+ "enum-iterator",
  "enumset",
- "loupe",
- "rkyv",
- "serde",
- "serde_bytes",
+ "lazy_static",
+ "leb128",
+ "memmap2",
+ "more-asserts",
+ "region",
+ "rustc-demangle",
  "smallvec",
- "target-lexicon",
  "thiserror",
  "wasmer-types",
+ "wasmer-vm",
  "wasmparser",
+ "winapi",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
+checksum = "f0fac321e5d3dc4f157f28bf6001f06d2e821422ce60449da97d39af171b4169"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "gimli",
- "loupe",
  "more-asserts",
  "rayon",
  "smallvec",
@@ -8037,16 +7996,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ca2a35204d8befa85062bc7aac259a8db8070b801b8a783770ba58231d729e"
+checksum = "20ae0bafb36a7ab8e4125474ebf19e640820797181bc19682d056d0cba037e6f"
 dependencies = [
  "byteorder",
  "dynasm",
  "dynasmrt",
  "gimli",
  "lazy_static",
- "loupe",
  "more-asserts",
  "rayon",
  "smallvec",
@@ -8056,9 +8014,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
+checksum = "02b38c7a442cffa5efb799631013bb30aeb1d553c50effa51905ea8b36ecc6c8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.43",
@@ -8067,112 +8025,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-engine"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
-dependencies = [
- "backtrace",
- "enumset",
- "lazy_static",
- "loupe",
- "memmap2",
- "more-asserts",
- "rustc-demangle",
- "serde",
- "serde_bytes",
- "target-lexicon",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-engine-dylib"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
-dependencies = [
- "cfg-if",
- "enum-iterator",
- "enumset",
- "leb128",
- "libloading",
- "loupe",
- "object 0.28.4",
- "rkyv",
- "serde",
- "tempfile",
- "tracing",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-object",
- "wasmer-types",
- "wasmer-vm",
- "which",
-]
-
-[[package]]
-name = "wasmer-engine-universal"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
-dependencies = [
- "cfg-if",
- "enumset",
- "leb128",
- "loupe",
- "region",
- "rkyv",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-engine-universal-artifact",
- "wasmer-types",
- "wasmer-vm",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-engine-universal-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
-dependencies = [
- "enum-iterator",
- "enumset",
- "loupe",
- "rkyv",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
 name = "wasmer-middlewares"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7812438ed2f37203a37007cdb5332b8475cb2b16e15d51299b2647894e9ed3a"
+checksum = "190f1fa6e3a5980c9a571af457cb810945d4cd11b674b3892db973220f87bb0f"
 dependencies = [
- "loupe",
  "wasmer",
  "wasmer-types",
  "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-object"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
-dependencies = [
- "object 0.28.4",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
 ]
 
 [[package]]
@@ -8185,25 +8045,24 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
+checksum = "7d47fb87929c956693d68393d4778670ed1ce9733804b74bbd5fa6fa6d725250"
 dependencies = [
- "backtrace",
  "enum-iterator",
+ "enumset",
  "indexmap",
- "loupe",
  "more-asserts",
  "rkyv",
- "serde",
+ "target-lexicon",
  "thiserror",
 ]
 
 [[package]]
 name = "wasmer-vm"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
+checksum = "6a72cac9f0ce7a9f3d0fe01604202270cdfe8d3dae9d84742b85c5d935cad74d"
 dependencies = [
  "backtrace",
  "cc",
@@ -8213,28 +8072,25 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "libc",
- "loupe",
  "mach",
  "memoffset",
  "more-asserts",
  "region",
- "rkyv",
  "scopeguard",
- "serde",
  "thiserror",
- "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
 
 [[package]]
 name = "wasmer-wasi-types"
-version = "2.3.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dc83aadbdf97388de3211cb6f105374f245a3cf2a5c65a16776e7a087a8468"
+checksum = "a5ada7a7fc8ac363e750518f3a81257cbc9d7188895a05fbe5e557b9d7a6366c"
 dependencies = [
  "byteorder",
  "time 0.2.27",
+ "wasmer-derive",
  "wasmer-types",
 ]
 


### PR DESCRIPTION
Wasmer 2.x will panic while compiling malformed WASM binaries. They fixed it on the 3.0 branch. Let's upgrade it.