### PR TITLE
fix display error in phactory-api

### DIFF
--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -21,10 +21,10 @@ pub enum Error {
     /// No Justification found in the last header
     MissingJustification,
     /// Header validation failed
-    #[display(fmt = "HeaderValidateFailed({})", .0)]
+    #[display(fmt = "HeaderValidateFailed({})", self)]
     HeaderValidateFailed(String),
     /// Storage proof failed
-    #[display(fmt = "StorageProofFailed({})", .0)]
+    #[display(fmt = "StorageProofFailed({})", self)]
     StorageProofFailed(String),
     /// Relay chain header not synced before syncing parachain header
     RelaychainHeaderNotSynced,

--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -21,10 +21,10 @@ pub enum Error {
     /// No Justification found in the last header
     MissingJustification,
     /// Header validation failed
-    #[display(fmt = "HeaderValidateFailed({})", self)]
+    #[display(fmt = "HeaderValidateFailed({})", _0)]
     HeaderValidateFailed(String),
     /// Storage proof failed
-    #[display(fmt = "StorageProofFailed({})", self)]
+    #[display(fmt = "StorageProofFailed({})", _0)]
     StorageProofFailed(String),
     /// Relay chain header not synced before syncing parachain header
     RelaychainHeaderNotSynced,

--- a/crates/prpc/src/lib.rs
+++ b/crates/prpc/src/lib.rs
@@ -25,7 +25,7 @@ pub mod server {
         /// Some error occurred when handling the request
         AppError(String),
         /// Error for contract query
-        #[display(fmt = "ContractQueryError({})", .0)]
+        #[display(fmt = "ContractQueryError({})", _0)]
         ContractQueryError(String),
     }
 


### PR DESCRIPTION
As mentioned in [issue#992](https://github.com/Phala-Network/phala-blockchain/issues/992)
A display error terminate `cargo build --release` process.
```
error: expected identifier or literal
  --> crates/phactory/api/src/storage_sync.rs:24:49
   |
24 |     #[display(fmt = "HeaderValidateFailed({})", .0)]
   |                                                 ^

error: could not compile `phactory-api` due to previous error
```

This error seems caused by display macro dependency had changed. The original code is compatible with [displaythis crate](https://docs.rs/displaythis/latest/displaythis/).

I replace 
```
pub enum Error {
    /// Header validation failed
    #[display(fmt = "HeaderValidateFailed({})", .0)]
    HeaderValidateFailed(String),
    /// Storage proof failed
    #[display(fmt = "StorageProofFailed({})", .0)]
    StorageProofFailed(String),
}
```
with 
```
pub enum Error {
    /// Header validation failed
    #[display(fmt = "HeaderValidateFailed({})", self)]
    HeaderValidateFailed(String),
    /// Storage proof failed
    #[display(fmt = "StorageProofFailed({})", self)]
    StorageProofFailed(String),
}
```
The problem solved.
