### PR TITLE
pink: Add api worker_pubkey in Query

### DIFF
--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -326,6 +326,8 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         let ecdh_hex_pk = hex::encode(ecdh_pubkey.0.as_ref());
         info!("ECDH pubkey: {:?}", ecdh_hex_pk);
 
+        ::pink::runtime::set_worker_pubkey(ecdh_pubkey.0);
+
         // Measure machine score
         let cpu_core_num: u32 = self.platform.cpu_core_num();
         info!("CPU cores: {}", cpu_core_num);

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -1722,6 +1722,7 @@ impl<Platform: pal::Platform> System<Platform> {
 
 impl<P: pal::Platform> System<P> {
     pub fn on_restored(&mut self) -> Result<()> {
+        ::pink::runtime::set_worker_pubkey(self.ecdh_key.public());
         self.contracts.try_restart_sidevms(&self.sidevm_spawner);
         self.check_retirement();
         Ok(())

--- a/crates/pink/pink-extension-runtime/src/lib.rs
+++ b/crates/pink/pink-extension-runtime/src/lib.rs
@@ -9,7 +9,7 @@ use pink_extension::{
     chain_extension::{
         self as ext, HttpRequest, HttpResponse, PinkExtBackend, SigType, StorageQuotaExceeded,
     },
-    Balance, EcdsaPublicKey, EcdsaSignature, Hash,
+    Balance, EcdhPublicKey, EcdsaPublicKey, EcdsaSignature, Hash,
 };
 use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue},
@@ -271,6 +271,10 @@ impl<T: PinkRuntimeEnv, E: From<&'static str>> PinkExtBackend for DefaultPinkExt
             .duration_since(SystemTime::UNIX_EPOCH)
             .or(Err("The system time is earlier than UNIX_EPOCH"))?;
         Ok(duration.as_millis() as u64)
+    }
+
+    fn worker_pubkey(&self) -> Result<EcdhPublicKey, Self::Error> {
+        Ok(Default::default())
     }
 }
 

--- a/crates/pink/pink-extension-runtime/src/mock_ext.rs
+++ b/crates/pink/pink-extension-runtime/src/mock_ext.rs
@@ -126,6 +126,10 @@ impl ext::PinkExtBackend for MockExtension {
     fn untrusted_millis_since_unix_epoch(&self) -> Result<u64, Self::Error> {
         super::DefaultPinkExtension::new(self).untrusted_millis_since_unix_epoch()
     }
+
+    fn worker_pubkey(&self) -> Result<crate::EcdhPublicKey, Self::Error> {
+        Ok(Default::default())
+    }
 }
 
 thread_local! {

--- a/crates/pink/pink-extension/src/chain_extension.rs
+++ b/crates/pink/pink-extension/src/chain_extension.rs
@@ -113,6 +113,10 @@ pub trait PinkExt {
     #[ink(extension = 16, handle_status = false, returns_result = false)]
     fn balance_of(account: AccountId) -> (Balance, Balance);
 
+    /// Get worker public key. Query only.
+    #[ink(extension = 17, handle_status = false, returns_result = false)]
+    fn worker_pubkey() -> crate::EcdhPublicKey;
+
     /// Get current millis since unix epoch from the OS. (Query only)
     #[ink(extension = 18, handle_status = false, returns_result = false)]
     fn untrusted_millis_since_unix_epoch() -> u64;


### PR DESCRIPTION
This PR adds a chain extension `worker_pubkey` for pink query to get the worker's public key (identity). The feature is requested by @tolak.

Usage:
```rust
let worker_id = pink::ext().worker_pubkey();
```

Call it in a transaction would panic.

Note @h4x3rotab :
To simplify the implementation, we finally introduced another non-environmental global state in this PR.

Now we have two global states: the [`APPLICATION: Phactory`](https://github.com/Phala-Network/phala-blockchain/blob/c73e0c5fc3df7b082dd0960710d01fb77061bfbe/standalone/pruntime/src/runtime.rs#L9) created in pruntime bin and the WORKER_PUBKEY in crate `pink`.