### PR TITLE
pherry: Talk to old pruntime

### DIFF
--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -282,6 +282,12 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             return Err(from_display("Runtime already initialized"));
         }
 
+        info!("Initializing runtime");
+        info!("is_parachain  : {is_parachain}");
+        info!("operator      : {operator:?}");
+        info!("ra_provider   : {attestation_provider:?}");
+        info!("debug_set_key : {debug_set_key:?}");
+
         // load chain genesis
         let genesis_block_hash = genesis.block_header.hash();
 

--- a/crates/phactory/src/system/gk.rs
+++ b/crates/phactory/src/system/gk.rs
@@ -766,7 +766,7 @@ impl<MsgChan: MessageChannel<Signer = Sr25519Signer>> ComputingEconomics<MsgChan
                 trace!(
                     target: "computing",
                     "[{}] Computing already stopped, do nothing.",
-                    hex::encode(&worker_info.state.pubkey)
+                    hex::encode(worker_info.state.pubkey)
                 );
                 continue;
             }
@@ -959,7 +959,7 @@ impl<MsgChan: MessageChannel<Signer = Sr25519Signer>> ComputingEconomics<MsgChan
                     trace!(
                         target: "computing",
                         "[{}] Computing already stopped, ignore the heartbeat.",
-                        hex::encode(&worker_info.state.pubkey)
+                        hex::encode(worker_info.state.pubkey)
                     );
                     return;
                 };
@@ -968,7 +968,7 @@ impl<MsgChan: MessageChannel<Signer = Sr25519Signer>> ComputingEconomics<MsgChan
                     trace!(
                         target: "computing",
                         "[{}] Heartbeat response to previous computing sessions, ignore it.",
-                        hex::encode(&worker_info.state.pubkey)
+                        hex::encode(worker_info.state.pubkey)
                     );
                     return;
                 }

--- a/crates/phaxt/src/dynamic/tx.rs
+++ b/crates/phaxt/src/dynamic/tx.rs
@@ -5,11 +5,17 @@ use subxt::{tx::StaticTxPayload, utils::Encoded};
 pub fn register_worker(
     pruntime_info: Vec<u8>,
     attestation: Vec<u8>,
+    v2: bool,
 ) -> StaticTxPayload<Encoded> {
     let args = (Encoded(pruntime_info), Encoded(attestation)).encode();
+    let call_name = if v2 {
+        "register_worker_v2"
+    } else {
+        "register_worker"
+    };
     StaticTxPayload::new(
         "PhalaRegistry",
-        "register_worker_v2",
+        call_name,
         Encoded(args),
         Default::default(),
     )


### PR DESCRIPTION
The latest Pherry can not be used to sync old pruntime since the AttestationProvider added.
This PR makes it compatible with old pRuntimes (with some other minor style refactor).