### PR TITLE
headers-cache: Auto grab new headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "headers-cache"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/standalone/headers-cache/Cargo.toml
+++ b/standalone/headers-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headers-cache"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/standalone/headers-cache/src/grab.rs
+++ b/standalone/headers-cache/src/grab.rs
@@ -27,16 +27,16 @@ pub async fn run(
         tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
 
         let Ok(api) = pherry::subxt_connect(node_uri).await else {
-            warn!("Failed to connect to substrate, try again later");
+            warn!("Failed to connect to {node_uri}, try again later");
             continue;
         };
         let Ok(para_api) = pherry::subxt_connect(para_node_uri).await else {
-            warn!("Failed to connect to substrate, try again later");
+            warn!("Failed to connect to {para_node_uri}, try again later");
             continue;
         };
 
         loop {
-            info!("Start to grabing headers from {from_block}...");
+            info!("Starting to grab headers from {from_block}...");
             let mut buffer = vec![];
             let result =
                 cache::grap_headers_to_file(&api, &para_api, from_block, 10, 0, &mut buffer).await;

--- a/standalone/headers-cache/src/grab.rs
+++ b/standalone/headers-cache/src/grab.rs
@@ -1,0 +1,66 @@
+use anyhow::Context as _;
+use log::{info, warn};
+
+use pherry::headers_cache as cache;
+
+use crate::db::CacheDB;
+
+pub async fn run(
+    db: CacheDB,
+    node_uri: &str,
+    para_node_uri: &str,
+    interval: u64,
+) -> anyhow::Result<()> {
+    let Some(mut metadata) = db.get_metadata()? else {
+        info!("No metadata in the DB, can not grab");
+        return Ok(());
+    };
+    let Some(highest) = metadata.higest.header else {
+        info!("There aren't any headers in the DB, can not grab");
+        return Ok(());
+    };
+
+    let mut from_block = highest + 1;
+
+    loop {
+        info!("Sleeping for {interval} seconds...");
+        tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
+
+        let Ok(api) = pherry::subxt_connect(node_uri).await else {
+            warn!("Failed to connect to substrate, try again later");
+            continue;
+        };
+        let Ok(para_api) = pherry::subxt_connect(para_node_uri).await else {
+            warn!("Failed to connect to substrate, try again later");
+            continue;
+        };
+
+        loop {
+            info!("Start to grabing headers from {from_block}...");
+            let mut buffer = vec![];
+            let result =
+                cache::grap_headers_to_file(&api, &para_api, from_block, 10, 0, &mut buffer).await;
+            match result {
+                Ok(count) => {
+                    if count == 0 {
+                        break;
+                    }
+                    let count = cache::read_items(&buffer[..], |record| {
+                        let header = record.header().context("Failed to decode record header")?;
+                        db.put_header(header.number, record.payload())
+                            .context("Failed to put record to DB")?;
+                        metadata.update_header(header.number);
+                        Ok(false)
+                    })?;
+                    db.put_metadata(&metadata)
+                        .context("Failed to update metadata")?;
+                    from_block += count;
+                }
+                Err(err) => {
+                    warn!("Failed to grab header from node: {err:?}");
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -2,13 +2,14 @@ use std::fs::File;
 use std::io::Write;
 
 use anyhow::Context;
-use log::info;
+use log::{error, info};
 use scale::{Decode, Encode};
 
 use clap::{AppSettings, Parser, Subcommand};
 use pherry::headers_cache as cache;
 
 mod db;
+mod grab;
 mod web_api;
 
 type BlockNumber = u32;
@@ -140,6 +141,18 @@ enum Action {
         /// The database file to use
         #[clap(long, default_value = "cache.db")]
         db: String,
+        /// Auto grab new headers from the node
+        #[clap(long)]
+        grab: bool,
+        /// The relaychain RPC endpoint
+        #[clap(long, default_value = "ws://localhost:9945")]
+        node_uri: String,
+        /// The parachain RPC endpoint
+        #[clap(long, default_value = "ws://localhost:9944")]
+        para_node_uri: String,
+        /// Interval that start a batch of grab
+        #[clap(long, default_value_t = 600)]
+        interval: u64,
     },
     /// Split given grabbed headers file into chunks
     Split {
@@ -263,7 +276,7 @@ async fn main() -> anyhow::Result<()> {
                             metadata.update_header(header.number);
                             Ok(false)
                         })?;
-                        cache.put_metadata(metadata)?;
+                        cache.put_metadata(&metadata)?;
                         println!("{count} headers imported");
                     }
                 }
@@ -281,7 +294,7 @@ async fn main() -> anyhow::Result<()> {
                             metadata.update_para_header(header.number);
                             Ok(false)
                         })?;
-                        cache.put_metadata(metadata)?;
+                        cache.put_metadata(&metadata)?;
                         println!("{count} headers imported");
                     }
                 }
@@ -299,7 +312,7 @@ async fn main() -> anyhow::Result<()> {
                             metadata.update_storage_changes(header.number);
                             Ok(false)
                         })?;
-                        cache.put_metadata(metadata)?;
+                        cache.put_metadata(&metadata)?;
                         println!("{count} blocks imported");
                     }
                 }
@@ -310,14 +323,30 @@ async fn main() -> anyhow::Result<()> {
                     cache.put_genesis(info.block_header.number, &data)?;
                     let mut metadata = cache.get_metadata()?.unwrap_or_default();
                     metadata.put_genesis(info.block_header.number);
-                    cache.put_metadata(metadata)?;
+                    cache.put_metadata(&metadata)?;
                     println!("genesis at {} put", info.block_header.number);
                 }
             }
             cache.flush()?;
         }
-        Action::Serve { db } => {
-            web_api::serve(&db).await?;
+        Action::Serve {
+            db,
+            grab,
+            node_uri,
+            para_node_uri,
+            interval,
+        } => {
+            let db = db::CacheDB::open(&db)?;
+            if grab {
+                let db = db.clone();
+                tokio::spawn(async move {
+                    let result = grab::run(db, &node_uri, &para_node_uri, interval).await;
+                    if let Err(err) = result {
+                        error!("The grabbing task exited with error: {}", err);
+                    }
+                });
+            }
+            web_api::serve(db).await?;
         }
         Action::ShowSetId { uri, block } => {
             let api = pherry::subxt_connect(&uri).await?;

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -98,11 +98,9 @@ fn get_storage_changes(
     Ok(changes.encode())
 }
 
-pub(crate) async fn serve(db: &str) -> anyhow::Result<()> {
+pub(crate) async fn serve(db: CacheDB) -> anyhow::Result<()> {
     let _rocket = rocket::build()
-        .manage(App {
-            db: CacheDB::open(db)?,
-        })
+        .manage(App { db })
         .mount(
             "/",
             routes![


### PR DESCRIPTION
This PR adds command line args to `headers-cache` to allow it auto grab new headers from chain nodes.
Usage:
```
ROCKET_PORT=8002 ./headers-cache serve --grab --node-uri=wss://miner-node.phala.network:443/kusama/ws --para-node-uri=wss://miner-node.phala.network:443/khala/ws
```
