### PR TITLE
pink: Add helper Result::log_err

### DIFF
--- a/crates/pink/pink-extension/src/lib.rs
+++ b/crates/pink/pink-extension/src/lib.rs
@@ -30,6 +30,8 @@ pub mod predefined_accounts {
     }
 }
 
+pub use logger::ResultExt;
+
 const PINK_EVENT_TOPIC: &[u8] = b"phala.pink.event";
 
 pub type EcdhPublicKey = [u8; 32];

--- a/crates/pink/pink-extension/src/logger.rs
+++ b/crates/pink/pink-extension/src/logger.rs
@@ -69,3 +69,28 @@ macro_rules! debug {
 macro_rules! trace {
     ($($arg:tt)+) => {{ log!($crate::logger::Level::Trace, $($arg)+) }}
 }
+
+/// An extension for Result<T, E> to log error conveniently.
+pub trait ResultExt {
+    /// Log the the error message with `pink::error!` with a tip `msg` in front if the Result is Err.
+    fn log_err(self, msg: &str) -> Self
+    where
+        Self: Sized,
+    {
+        self.log_err_with_level(Level::Error, msg)
+    }
+
+    /// Log the the error message with `level` and a tip `msg` in front if the Result is Err.
+    fn log_err_with_level(self, level: Level, msg: &str) -> Self
+    where
+        Self: Sized;
+}
+
+impl<T, E: core::fmt::Debug> ResultExt for Result<T, E> {
+    fn log_err_with_level(self, level: Level, msg: &str) -> Self {
+        if let Err(err) = &self {
+            log!(level, "{msg}: {err:?}");
+        }
+        self
+    }
+}


### PR DESCRIPTION
This makes it easier to emit a log message in pink when some API returns a `Result::Err`.
It's similar to `Result::expect` but doesn't panic, and should be preferred over `expect`.

# Example

```rust
use pink::ResultExt;

let dollars = bank.withdraw(much).log_err("Failed to withdraw my money")?;
```