### PR TITLE
Add nightly build github action

### DIFF
--- a/.github/actions/build-core/action.yml
+++ b/.github/actions/build-core/action.yml
@@ -1,0 +1,21 @@
+name: Build core block chain
+description: Build core block chain
+inputs:
+  profile:
+    description: "The `--profile` of cargo build"
+    required: true
+    default: "testnet"
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/install_toolchain
+    - name: Build core blockchain
+      run: cargo build -vv --profile ${{ inputs.profile }}
+      shell: bash
+    - name: Save core-blockchain binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: core-blockchain-binaries
+        path: |
+          ./target/${{ inputs.profile }}/phala-node
+          ./target/${{ inputs.profile }}/pherry

--- a/.github/actions/build-prouter/action.yml
+++ b/.github/actions/build-prouter/action.yml
@@ -1,0 +1,18 @@
+name: Build prouter
+description: Build prouter
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/install_toolchain
+    - name: Install prouter dependencies
+      run: sudo apt-get install libboost-all-dev libssl-dev zlib1g-dev miniupnpc
+      shell: bash
+    - name: Build prouter
+      run: cd ./standalone/prouter/ && cargo build -vv
+      shell: bash
+    - name: Save prouter binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: prouter-binaries
+        path: |
+          ./standalone/prouter/target/release/prouter

--- a/.github/actions/build-pruntime/action.yml
+++ b/.github/actions/build-pruntime/action.yml
@@ -1,0 +1,19 @@
+name: Build pruntime
+description: Build pruntime
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/install_toolchain
+    - name: Install gramine
+      run: sudo bash dockerfile.d/01_apt.sh
+      shell: bash
+    - name: Build pruntime
+      run: make -C ./standalone/pruntime/
+      shell: bash
+    - name: Save pruntime binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: pruntime-binaries
+        path: |
+          ./standalone/pruntime/bin/pruntime
+          ./standalone/pruntime/bin/Rocket.toml

--- a/.github/workflows/build-nightly-release.yml
+++ b/.github/workflows/build-nightly-release.yml
@@ -57,6 +57,7 @@ jobs:
             ./dist/core-blockchain-binaries/pherry
             ./e2e/res/system.contract
             ./e2e/res/log_server.contract
+            ./e2e/res/log_server.sidevm.wasm
             ./e2e/res/sidevm_deployer.contract
             ./e2e/res/tokenomic.contract
 

--- a/.github/workflows/build-nightly-release.yml
+++ b/.github/workflows/build-nightly-release.yml
@@ -1,0 +1,70 @@
+name: Nightly Build
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 1-5"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-core:
+    name: Build core
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: ./.github/actions/build-core
+        with:
+          profile: release
+
+  build-pruntime:
+    name: Build pruntime
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: ./.github/actions/build-pruntime
+
+  publish:
+    needs: [build-core, build-pruntime]
+    name: Pack and publish
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ./dist
+
+      - name: Publish
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: nightly-${{ steps.date.outputs.date }}
+          prerelease: true
+          body: Nighty build
+          files: |
+            ./dist/pruntime-binaries/pruntime
+            ./dist/core-blockchain-binaries/phala-node
+            ./dist/core-blockchain-binaries/pherry
+            ./e2e/res/system.contract
+            ./e2e/res/log_server.contract
+            ./e2e/res/sidevm_deployer.contract
+            ./e2e/res/tokenomic.contract
+
+      - name: Delete older nightly releases
+        uses: Phala-Network/delete-older-releases@master
+        with:
+          keep_latest: 10
+          delete_tags: true
+          delete_tag_pattern: nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-nightly-release.yml
+++ b/.github/workflows/build-nightly-release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Delete older nightly releases
         uses: Phala-Network/delete-older-releases@master
         with:
-          keep_latest: 10
+          keep_latest: 30
           delete_tags: true
           delete_tag_pattern: nightly
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Test (Gramine)
+name: Build and Test
 
 on:
   push:
@@ -9,24 +9,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-core-blockchain:
-    name: Build core blockchain
+  build-core:
+    name: Build core
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-      - uses: ./.github/actions/install_toolchain
-      - name: Build core blockchain
-        run: cargo build -vv --profile testnet
-      - name: Save core-blockchain binaries
-        uses: actions/upload-artifact@v3
-        with:
-          name: core-blockchain-binaries
-          path: |
-            ./target/testnet/phala-node
-            ./target/testnet/pherry
-
+      - uses: ./.github/actions/build-core
   build-pruntime:
     name: Build pruntime
     runs-on: ubuntu-20.04
@@ -34,20 +24,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-      - uses: ./.github/actions/install_toolchain
-      - name: Install gramine
-        run: sudo bash dockerfile.d/01_apt_gramine.sh
-      - name: Build pruntime
-        run: make V=1 dist -C ./standalone/pruntime/gramine-build/
-      - name: Save pruntime binaries
-        uses: actions/upload-artifact@v3
-        with:
-          name: pruntime-binaries
-          path: |
-            ./standalone/pruntime/bin/pruntime
-            ./standalone/pruntime/bin/pruntime.manifest
-            ./standalone/pruntime/bin/Rocket.toml
-
+      - uses: ./.github/actions/build-pruntime
   build-prouter:
     name: Build prouter
     runs-on: ubuntu-20.04
@@ -55,18 +32,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-      - uses: ./.github/actions/install_toolchain
-      - name: Install prouter dependencies
-        run: sudo apt-get install libboost-all-dev libssl-dev zlib1g-dev miniupnpc
-      - name: Build prouter
-        run: cd ./standalone/prouter/ && cargo build -vv
-      - name: Save prouter binaries
-        uses: actions/upload-artifact@v3
-        with:
-          name: prouter-binaries
-          path: |
-            ./standalone/prouter/target/release/prouter
-
+      - uses: ./.github/actions/build-prouter
   e2e-test:
     name: Run E2E tests
     runs-on: ubuntu-20.04
@@ -106,7 +72,7 @@ jobs:
         with:
           name: e2e-logs
           path: e2e-logs.tar.gz
-    needs: [ build-core-blockchain, build-pruntime ]
+    needs: [ build-core, build-pruntime ]
 
   cargo-tests:
     name: Run cargo tests


### PR DESCRIPTION
This PR adds GitHub action to build and publish nightly releases every morning.

- The artifacts would be published on the [GitHub Releases](https://github.com/Phala-Network/phala-blockchain/releases) page with the tag `Pre-release`.
- The binaries are built with `ubuntu-20.04`. So it might not run on other OS dist. Tried to build it with ubuntu-18.04 and the substrate failed to build. Also, GitHub Action will stop ubuntu-18.04 support on Apr 2023.
- We also do daily cleanup to old nightly releases, only the recent 30 releases are kept.
- Frontend tools can use [GitHub API](https://docs.github.com/en/rest/releases/releases#list-releases) to get a release list and download the assets from it. However, the API is almost unusable without authentication due to the [rate limiting](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting) policy.

# Preview
<img width="653" alt="image" src="https://user-images.githubusercontent.com/6442159/201844220-37b88525-1da6-49ac-8a94-2459990daab2.png">
