### PR TITLE
[Back port] pruntime: Upgrade grandpa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "finality-grandpa"
+version = "0.16.0"
+source = "git+https://github.com/Phala-Network/finality-grandpa.git?branch=scale2#430cc8c7c1f000452546975c0ed83cca9beddf90"
+dependencies = [
+ "either",
+ "futures 0.3.18",
+ "num-traits",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
 name = "fixed"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6794,7 +6806,7 @@ dependencies = [
  "ciborium",
  "csv-core",
  "derive_more",
- "finality-grandpa",
+ "finality-grandpa 0.16.0",
  "fixed",
  "fixed-macro",
  "fixed-sqrt",
@@ -9018,7 +9030,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "dyn-clone",
- "finality-grandpa",
+ "finality-grandpa 0.14.4",
  "fork-tree",
  "futures 0.3.18",
  "futures-timer 3.0.2",
@@ -9052,7 +9064,7 @@ name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
 dependencies = [
  "derive_more",
- "finality-grandpa",
+ "finality-grandpa 0.14.4",
  "futures 0.3.18",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -10320,7 +10332,7 @@ dependencies = [
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
 dependencies = [
- "finality-grandpa",
+ "finality-grandpa 0.14.4",
  "log",
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,6 @@ members = [
 	"scripts/toml-upgrade-version",
 	"scripts/debug-cli"
 ]
+
+[patch.crates-io]
+finality-grandpa = { git = "https://github.com/Phala-Network/finality-grandpa.git", branch = "scale2" }

--- a/crates/phactory/Cargo.toml
+++ b/crates/phactory/Cargo.toml
@@ -61,7 +61,7 @@ csv-core = { version = "0.1.10", default-features = false }
 derive_more = "0.99.0"
 hash-db = { version = "0.15.2", default-features = false }
 num = { package = "num-traits", version = "0.2", default-features = false }
-finality-grandpa = { version = "0.14", default-features = false, features = ["derive-codec"] }
+finality-grandpa = { version = "0.16", default-features = false, features = ["derive-codec"] }
 trie = { package = "sp-trie", path = "../../substrate/primitives/trie" }
 frame-system = { package = "frame-system", path = "../../substrate/frame/system" }
 sp-finality-grandpa = { package = "sp-finality-grandpa", path = "../../substrate/primitives/finality-grandpa" }

--- a/crates/phactory/src/light_validation/justification.rs
+++ b/crates/phactory/src/light_validation/justification.rs
@@ -136,7 +136,7 @@ impl<Block: BlockT<Hash = H256>> GrandpaJustification<Block> {
         let ancestry_chain = AncestryChain::<Block>::new(&self.votes_ancestries);
 
         match finality_grandpa::validate_commit(&self.commit, voters, &ancestry_chain) {
-            Ok(ref result) if result.ghost().is_some() => {}
+            Ok(result) if result.is_valid() => {}
             _ => {
                 let msg = "invalid commit in grandpa justification".to_string();
                 return Err(anyhow::Error::msg(ClientError::BadJustification(msg)));

--- a/crates/phactory/src/light_validation/justification.rs
+++ b/crates/phactory/src/light_validation/justification.rs
@@ -1,33 +1,28 @@
-// Copyright 2018-2019 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
-// Substrate is free software: you can redistribute it and/or modify
+// Copyright (C) 2018-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
-
-use std::collections::{HashMap, HashSet};
-
-// #[cfg(test)]
-// use sc_client::Client;
-// #[cfg(test)]
-// use sc_client_api::{backend::Backend, CallExecutor};
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::error::JustificationError as ClientError;
 use anyhow::Result;
-use finality_grandpa::voter_set::VoterSet;
-use finality_grandpa::Error as GrandpaError;
+use sp_finality_grandpa::{AuthorityId, AuthoritySignature, RoundNumber, SetId};
+use std::collections::{HashMap, HashSet};
+
+use finality_grandpa::{voter_set::VoterSet, Error as GrandpaError};
 use parity_scale_codec::{Decode, Encode};
-use sp_core::H256;
-use sp_finality_grandpa::{AuthorityId, AuthoritySignature};
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 
 /// A GRANDPA justification for block finality, it includes a commit message and
@@ -45,40 +40,52 @@ pub struct GrandpaJustification<Block: BlockT> {
     votes_ancestries: Vec<Block::Header>,
 }
 
-impl<Block: BlockT<Hash = H256>> GrandpaJustification<Block> {
+impl<Block: BlockT> GrandpaJustification<Block> {
     // /// Create a GRANDPA justification from the given commit. This method
     // /// assumes the commit is valid and well-formed.
-    // #[cfg(test)]
-    // pub(crate) fn from_commit<B, E, RA>(
-    //     client: &Client<B, E, Block, RA>,
+    // pub fn from_commit<C>(
+    //     client: &Arc<C>,
     //     round: u64,
-    //     commit: Commit<Block>,
-    // ) -> Result<GrandpaJustification<Block>>
+    //     commit: Commit<Block::Header>,
+    // ) -> Result<Self, Error>
     // where
-    //     B: Backend<Block, Blake2Hasher>,
-    //     E: CallExecutor<Block, Blake2Hasher> + Send + Sync,
-    //     RA: Send + Sync,
+    //     C: HeaderBackend<Block>,
     // {
     //     let mut votes_ancestries_hashes = HashSet::new();
     //     let mut votes_ancestries = Vec::new();
 
     //     let error = || {
     //         let msg = "invalid precommits for target commit".to_string();
-    //         Err(anyhow::Error::msg(Error::Client(
-    //             ClientError::BadJustification(msg),
-    //         )))
+    //         Err(Error::Client(ClientError::BadJustification(msg)))
+    //     };
+
+    //     // we pick the precommit for the lowest block as the base that
+    //     // should serve as the root block for populating ancestry (i.e.
+    //     // collect all headers from all precommit blocks to the base)
+    //     let (base_hash, base_number) = match commit
+    //         .precommits
+    //         .iter()
+    //         .map(|signed| &signed.precommit)
+    //         .min_by_key(|precommit| precommit.target_number)
+    //         .map(|precommit| (precommit.target_hash, precommit.target_number))
+    //     {
+    //         None => return error(),
+    //         Some(base) => base,
     //     };
 
     //     for signed in commit.precommits.iter() {
     //         let mut current_hash = signed.precommit.target_hash;
     //         loop {
-    //             if current_hash == commit.target_hash {
+    //             if current_hash == base_hash {
     //                 break;
     //             }
 
     //             match client.header(BlockId::Hash(current_hash))? {
     //                 Some(current_header) => {
-    //                     if *current_header.number() <= commit.target_number {
+    //                     // NOTE: this should never happen as we pick the lowest block
+    //                     // as base and only traverse backwards from the other blocks
+    //                     // in the commit. but better be safe to avoid an unbound loop.
+    //                     if *current_header.number() <= base_number {
     //                         return error();
     //                     }
 
@@ -86,6 +93,7 @@ impl<Block: BlockT<Hash = H256>> GrandpaJustification<Block> {
     //                     if votes_ancestries_hashes.insert(current_hash) {
     //                         votes_ancestries.push(current_header);
     //                     }
+
     //                     current_hash = parent_hash;
     //                 }
     //                 _ => return error(),
@@ -93,26 +101,27 @@ impl<Block: BlockT<Hash = H256>> GrandpaJustification<Block> {
     //         }
     //     }
 
-    //     Ok(GrandpaJustification {
+    //     Ok(sp_finality_grandpa::GrandpaJustification {
     //         round,
     //         commit,
     //         votes_ancestries,
-    //     })
+    //     }
+    //     .into())
     // }
 
     /// Decode a GRANDPA justification and validate the commit and the votes'
     /// ancestry proofs finalize the given block.
-    pub(crate) fn decode_and_verify_finalizes(
+    pub fn decode_and_verify_finalizes(
         encoded: &[u8],
         finalized_target: (Block::Hash, NumberFor<Block>),
         set_id: u64,
         voters: &VoterSet<AuthorityId>,
-    ) -> Result<GrandpaJustification<Block>>
+    ) -> Result<Self, ClientError>
     where
         NumberFor<Block>: finality_grandpa::BlockNumberOps,
     {
         let justification = GrandpaJustification::<Block>::decode(&mut &*encoded)
-            .map_err(|_| anyhow::Error::msg(ClientError::JustificationDecode))?;
+            .map_err(|_| ClientError::JustificationDecode)?;
 
         if (
             justification.commit.target_hash,
@@ -120,14 +129,28 @@ impl<Block: BlockT<Hash = H256>> GrandpaJustification<Block> {
         ) != finalized_target
         {
             let msg = "invalid commit target in grandpa justification".to_string();
-            Err(anyhow::Error::msg(ClientError::BadJustification(msg)))
+            Err(ClientError::BadJustification(msg))
         } else {
-            justification.verify(set_id, voters).map(|_| justification)
+            justification
+                .verify_with_voter_set(set_id, voters)
+                .map(|_| justification)
         }
     }
 
+    // /// Validate the commit and the votes' ancestry proofs.
+    // pub fn verify(&self, set_id: u64, voters: &VoterSet<AuthorityId>) -> Result<(), ClientError>
+    // where
+    //     NumberFor<Block>: finality_grandpa::BlockNumberOps,
+    // {
+    //     self.verify_with_voter_set(set_id, voters)
+    // }
+
     /// Validate the commit and the votes' ancestry proofs.
-    pub(crate) fn verify(&self, set_id: u64, voters: &VoterSet<AuthorityId>) -> Result<()>
+    pub(crate) fn verify_with_voter_set(
+        &self,
+        set_id: u64,
+        voters: &VoterSet<AuthorityId>,
+    ) -> Result<(), ClientError>
     where
         NumberFor<Block>: finality_grandpa::BlockNumberOps,
     {
@@ -136,62 +159,78 @@ impl<Block: BlockT<Hash = H256>> GrandpaJustification<Block> {
         let ancestry_chain = AncestryChain::<Block>::new(&self.votes_ancestries);
 
         match finality_grandpa::validate_commit(&self.commit, voters, &ancestry_chain) {
-            Ok(result) if result.is_valid() => {}
+            Ok(ref result) if result.is_valid() => {}
             _ => {
                 let msg = "invalid commit in grandpa justification".to_string();
-                return Err(anyhow::Error::msg(ClientError::BadJustification(msg)));
+                return Err(ClientError::BadJustification(msg));
             }
         }
+
+        // we pick the precommit for the lowest block as the base that
+        // should serve as the root block for populating ancestry (i.e.
+        // collect all headers from all precommit blocks to the base)
+        let base_hash = self
+            .commit
+            .precommits
+            .iter()
+            .map(|signed| &signed.precommit)
+            .min_by_key(|precommit| precommit.target_number)
+            .map(|precommit| precommit.target_hash)
+            .expect(
+                "can only fail if precommits is empty; \
+				 commit has been validated above; \
+				 valid commits must include precommits; \
+				 qed.",
+            );
 
         let mut buf = Vec::new();
         let mut visited_hashes = HashSet::new();
         for signed in self.commit.precommits.iter() {
-            if communication::check_message_sig_with_buffer::<Block>(
+            if !check_message_signature_with_buffer(
                 &finality_grandpa::Message::Precommit(signed.precommit.clone()),
                 &signed.id,
                 &signed.signature,
                 self.round,
                 set_id,
                 &mut buf,
-            )
-            .is_err()
-            {
-                return Err(anyhow::Error::msg(ClientError::BadJustification(
+            ) {
+                return Err(ClientError::BadJustification(
                     "invalid signature for precommit in grandpa justification".to_string(),
-                )));
+                ));
             }
 
-            if self.commit.target_hash == signed.precommit.target_hash {
+            if base_hash == signed.precommit.target_hash {
                 continue;
             }
 
-            match ancestry_chain.ancestry(self.commit.target_hash, signed.precommit.target_hash) {
+            match ancestry_chain.ancestry(base_hash, signed.precommit.target_hash) {
                 Ok(route) => {
-                    // ancestry starts from parent hash but the precommit target hash has been visited
+                    // ancestry starts from parent hash but the precommit target hash has been
+                    // visited
                     visited_hashes.insert(signed.precommit.target_hash);
                     for hash in route {
                         visited_hashes.insert(hash);
                     }
                 }
                 _ => {
-                    return Err(anyhow::Error::msg(ClientError::BadJustification(
+                    return Err(ClientError::BadJustification(
                         "invalid precommit ancestry proof in grandpa justification".to_string(),
-                    )));
+                    ))
                 }
             }
         }
 
-        let ancestry_hashes = self
+        let ancestry_hashes: HashSet<_> = self
             .votes_ancestries
             .iter()
             .map(|h: &Block::Header| h.hash())
             .collect();
 
         if visited_hashes != ancestry_hashes {
-            return Err(anyhow::Error::msg(ClientError::BadJustification(
+            return Err(ClientError::BadJustification(
                 "invalid precommit ancestries in grandpa justification with unused headers"
                     .to_string(),
-            )));
+            ));
         }
 
         Ok(())
@@ -205,7 +244,7 @@ struct AncestryChain<Block: BlockT> {
     ancestry: HashMap<Block::Hash, Block::Header>,
 }
 
-impl<Block: BlockT<Hash = H256>> AncestryChain<Block> {
+impl<Block: BlockT> AncestryChain<Block> {
     fn new(ancestry: &[Block::Header]) -> AncestryChain<Block> {
         let ancestry: HashMap<_, _> = ancestry
             .iter()
@@ -246,8 +285,6 @@ where
     }
 }
 
-// copied
-
 /// A commit message for this chain's block type.
 pub type Commit<Block> = finality_grandpa::Commit<
     <Block as BlockT>::Hash,
@@ -256,43 +293,34 @@ pub type Commit<Block> = finality_grandpa::Commit<
     AuthorityId,
 >;
 
-mod communication {
-    use anyhow::Result;
-    use parity_scale_codec::Encode;
-    use sp_core::Pair;
-    use sp_finality_grandpa::{
-        AuthorityId, AuthorityPair, AuthoritySignature, RoundNumber, SetId as SetIdNumber,
-    };
-    use sp_runtime::traits::{Block as BlockT, NumberFor};
+pub fn check_message_signature_with_buffer<H, N>(
+    message: &finality_grandpa::Message<H, N>,
+    id: &AuthorityId,
+    signature: &AuthoritySignature,
+    round: RoundNumber,
+    set_id: SetId,
+    buf: &mut Vec<u8>,
+) -> bool
+where
+    H: Encode,
+    N: Encode,
+{
+    use sp_application_crypto::RuntimeAppPublic;
 
-    pub type Message<Block> = finality_grandpa::Message<<Block as BlockT>::Hash, NumberFor<Block>>;
+    localized_payload_with_buffer(round, set_id, message, buf);
 
-    pub(crate) fn check_message_sig_with_buffer<Block: BlockT>(
-        message: &Message<Block>,
-        id: &AuthorityId,
-        signature: &AuthoritySignature,
-        round: RoundNumber,
-        set_id: SetIdNumber,
-        buf: &mut Vec<u8>,
-    ) -> Result<()> {
-        let as_public = id.clone();
-        localized_payload_with_buffer(round, set_id, message, buf);
+    id.verify(&buf, signature)
+}
 
-        if AuthorityPair::verify(signature, buf, &as_public) {
-            Ok(())
-        } else {
-            debug!(target: "afg", "Bad signature on message from {:?} (round: {}, set_id: {})", id, round, set_id);
-            Err(anyhow::Error::msg(""))
-        }
-    }
-
-    pub(crate) fn localized_payload_with_buffer<E: Encode>(
-        round: RoundNumber,
-        set_id: SetIdNumber,
-        message: &E,
-        buf: &mut Vec<u8>,
-    ) {
-        buf.clear();
-        (message, round, set_id).encode_to(buf)
-    }
+/// Encode round message localized to a given round and set id using the given
+/// buffer. The given buffer will be cleared and the resulting encoded payload
+/// will always be written to the start of the buffer.
+pub fn localized_payload_with_buffer<E: Encode>(
+    round: RoundNumber,
+    set_id: SetId,
+    message: &E,
+    buf: &mut Vec<u8>,
+) {
+    buf.clear();
+    (message, round, set_id).encode_to(buf)
 }

--- a/standalone/pruntime/enclave/Cargo.lock
+++ b/standalone/pruntime/enclave/Cargo.lock
@@ -1236,6 +1236,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "finality-grandpa"
+version = "0.16.0"
+dependencies = [
+ "either",
+ "futures",
+ "num-traits",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
 name = "fixed"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,7 +3495,7 @@ dependencies = [
  "chrono",
  "csv-core",
  "derive_more",
- "finality-grandpa",
+ "finality-grandpa 0.16.0",
  "fixed",
  "fixed-macro",
  "fixed-sqrt",
@@ -5186,7 +5197,7 @@ dependencies = [
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
 dependencies = [
- "finality-grandpa",
+ "finality-grandpa 0.14.4",
  "log",
  "parity-scale-codec",
  "scale-info",

--- a/standalone/pruntime/enclave/Cargo.lock
+++ b/standalone/pruntime/enclave/Cargo.lock
@@ -1238,6 +1238,7 @@ dependencies = [
 [[package]]
 name = "finality-grandpa"
 version = "0.16.0"
+source = "git+https://github.com/Phala-Network/finality-grandpa.git?branch=scale2#430cc8c7c1f000452546975c0ed83cca9beddf90"
 dependencies = [
  "either",
  "futures",

--- a/standalone/pruntime/enclave/Cargo.toml
+++ b/standalone/pruntime/enclave/Cargo.toml
@@ -70,6 +70,7 @@ futures-executor = { git = "https://github.com/Phala-Network/futures-rs-sgx.git"
 event-listener = { git = "https://github.com/Phala-Network/event-listener-sgx.git", branch = "phala" }
 parking_lot_core = { git = "https://github.com/Phala-Network/parking_lot-sgx.git", branch = "phala" }
 cpufeatures = { git = "https://github.com/Phala-Network/cpufeatures-sgx.git", branch = "phala" }
+finality-grandpa = { git = "https://github.com/Phala-Network/finality-grandpa.git", branch = "scale2" }
 
 [patch.'https://github.com/apache/teaclave-sgx-sdk.git']
 # sgx_alloc = { path = "../../../teaclave-sgx-sdk/sgx_alloc" }


### PR DESCRIPTION
The new finality-grandpa uses `parity-scale-codec-3` which is not compatible with the old pruntime codebase.
If we upgrade to use codec 3, it would be a huge change. So the simplest way is for finality-grandpa and downgrades its scale to 2.0.
