### PR TITLE
headers-cache: Add --mirror --justification-interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,6 +3745,7 @@ dependencies = [
  "parity-scale-codec",
  "phala-rocket-middleware",
  "pherry",
+ "reqwest",
  "rocket",
  "rocksdb",
  "serde",
@@ -8871,9 +8872,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
@@ -8888,10 +8889,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite 0.2.9",
  "rustls 0.20.6",

--- a/standalone/headers-cache/Cargo.toml
+++ b/standalone/headers-cache/Cargo.toml
@@ -18,3 +18,4 @@ rocksdb = { version = "0.19.0", default-features = false, features = ["snappy", 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 phala-rocket-middleware = { path = "../../crates/phala-rocket-middleware" }
+reqwest = "0.11.12"

--- a/standalone/headers-cache/src/grab.rs
+++ b/standalone/headers-cache/src/grab.rs
@@ -1,66 +1,84 @@
 use anyhow::Context as _;
 use log::{info, warn};
+use scale::Encode;
 
-use pherry::headers_cache as cache;
+use pherry::{headers_cache as cache, types::rpc::ExtraRpcExt};
 
-use crate::db::CacheDB;
+use crate::{db::CacheDB, BlockNumber};
 
 pub async fn run(
     db: CacheDB,
     node_uri: &str,
     para_node_uri: &str,
-    interval: u64,
+    check_interval: u64,
+    justification_interval: BlockNumber,
 ) -> anyhow::Result<()> {
     let Some(mut metadata) = db.get_metadata()? else {
-        info!("No metadata in the DB, can not grab");
-        return Ok(());
+        anyhow::bail!("No metadata in the DB, can not grab");
     };
-    let Some(highest) = metadata.higest.header else {
-        info!("There aren't any headers in the DB, can not grab");
-        return Ok(());
+    let Some(highest) = metadata.recent_imported.header else {
+        anyhow::bail!("There aren't any headers in the DB, can not grab");
     };
 
-    let mut from_block = highest + 1;
+    let mut next_block = highest + 1;
 
     loop {
-        info!("Sleeping for {interval} seconds...");
-        tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
-
+        info!("Connecting to {node_uri}...");
         let Ok(api) = pherry::subxt_connect(node_uri).await else {
             warn!("Failed to connect to {node_uri}, try again later");
+            sleep(check_interval).await;
             continue;
         };
+
+        info!("Connecting to {para_node_uri}...");
         let Ok(para_api) = pherry::subxt_connect(para_node_uri).await else {
             warn!("Failed to connect to {para_node_uri}, try again later");
+            sleep(check_interval).await;
             continue;
         };
 
         loop {
-            info!("Starting to grab headers from {from_block}...");
-            let mut buffer = vec![];
-            let result =
-                cache::grap_headers_to_file(&api, &para_api, from_block, 10, 0, &mut buffer).await;
-            match result {
-                Ok(count) => {
-                    if count == 0 {
-                        break;
-                    }
-                    let count = cache::read_items(&buffer[..], |record| {
-                        let header = record.header().context("Failed to decode record header")?;
-                        db.put_header(header.number, record.payload())
-                            .context("Failed to put record to DB")?;
-                        metadata.update_header(header.number);
-                        Ok(false)
-                    })?;
-                    db.put_metadata(&metadata)
-                        .context("Failed to update metadata")?;
-                    from_block += count;
-                }
-                Err(err) => {
-                    warn!("Failed to grab header from node: {err:?}");
-                    break;
-                }
+            info!("Trying to grab next={next_block}, just_interval={justification_interval}");
+            let state = api.extra_rpc().system_sync_state().await?;
+            info!("Node state: {state:?}");
+            if (state.current_block as BlockNumber) < next_block + justification_interval {
+                info!("Continue waiting for enough blocks in node");
+                sleep(check_interval).await;
+                continue;
             }
+
+            info!("Grabbing...");
+            let result = cache::grab_headers(
+                &api,
+                &para_api,
+                next_block,
+                u32::MAX,
+                justification_interval,
+                |info| {
+                    if info.justification.is_some() {
+                        info!("Got justification at {}", info.header.number);
+                    }
+                    db.put_header(info.header.number, &info.encode())
+                        .context("Failed to put record to DB")?;
+                    metadata.update_header(info.header.number);
+                    next_block = info.header.number + 1;
+                    Ok(())
+                },
+            )
+            .await;
+            db.put_metadata(&metadata)
+                .context("Failed to update metadata")?;
+            if let Err(err) = result {
+                warn!("Failed to grab header from node: {err:?}");
+                sleep(check_interval).await;
+                break;
+            }
+            sleep(check_interval).await;
         }
     }
+}
+
+async fn sleep(secs: u64) {
+    info!("Sleeping for {secs} seconds...");
+    tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
 }

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -12,6 +12,12 @@ struct App {
     db: CacheDB,
 }
 
+#[get("/state")]
+fn state(app: &State<App>) -> String {
+    let metadata = app.db.get_metadata().ok().flatten().unwrap_or_default();
+    serde_json::to_string_pretty(&metadata).unwrap_or("{}".into())
+}
+
 #[get("/genesis/<block_number>")]
 fn get_genesis(app: &State<App>, block_number: BlockNumber) -> Result<Vec<u8>, NotFound<String>> {
     app.db
@@ -105,6 +111,7 @@ pub(crate) async fn serve(db: CacheDB) -> Result<()> {
         .mount(
             "/",
             routes![
+                state,
                 get_genesis,
                 get_header,
                 get_headers,

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -1,6 +1,7 @@
-use rocket::response::status::NotFound;
-use rocket::State;
-use rocket::{get, routes};
+use anyhow::{bail, Context, Result};
+use log::{debug, error, info};
+use pherry::headers_cache::BlockInfo;
+use rocket::{get, response::status::NotFound, routes, State};
 
 use scale::{Decode, Encode};
 
@@ -98,7 +99,7 @@ fn get_storage_changes(
     Ok(changes.encode())
 }
 
-pub(crate) async fn serve(db: CacheDB) -> anyhow::Result<()> {
+pub(crate) async fn serve(db: CacheDB) -> Result<()> {
     let _rocket = rocket::build()
         .manage(App { db })
         .mount(
@@ -115,4 +116,89 @@ pub(crate) async fn serve(db: CacheDB) -> anyhow::Result<()> {
         .launch()
         .await?;
     Ok(())
+}
+
+async fn http_get(url: &str) -> Result<Option<Vec<u8>>> {
+    let response = reqwest::get(url).await?;
+    if response.status() == 404 {
+        return Ok(None);
+    }
+    if !response.status().is_success() {
+        bail!("Http status error {}", response.status());
+    }
+    let body = response.bytes().await?;
+    Ok(Some(body.to_vec()))
+}
+
+pub(crate) async fn sync_from(
+    db: CacheDB,
+    base_uri: &str,
+    check_interval: u64,
+    genesis_block: BlockNumber,
+) -> Result<()> {
+    let mut metadata = db
+        .get_metadata()
+        .context("Failed to get metadata")?
+        .unwrap_or_default();
+    let highest = metadata.recent_imported.header.unwrap_or(genesis_block);
+
+    'sync_genesis: {
+        if metadata.genesis.is_empty() {
+            let url = format!("{base_uri}/genesis/{genesis_block}");
+            let body = match http_get(&url).await {
+                Ok(Some(body)) => body,
+                Ok(None) => {
+                    info!("Genesis {genesis_block} not found in upstream cache");
+                    break 'sync_genesis;
+                }
+                Err(err) => {
+                    error!("Failed to sync genesis from {url}: {err:?}");
+                    break 'sync_genesis;
+                }
+            };
+            db.put_genesis(genesis_block, &body)
+                .context("Failed to put genesis")?;
+            metadata.put_genesis(genesis_block);
+            db.put_metadata(&metadata)
+                .context("Failed to put metadata")?;
+            info!("Synced genesis block {genesis_block}");
+        }
+    }
+
+    let mut next_block = highest + 1;
+    loop {
+        loop {
+            info!("Syncing {next_block}");
+            let url = format!("{base_uri}/headers/{next_block}");
+            let body = match http_get(&url).await {
+                Ok(Some(body)) => body,
+                Ok(None) => {
+                    debug!("Block {next_block} not found in upstream cache");
+                    break;
+                }
+                Err(err) => {
+                    error!("Failed to sync blocks from {url}: {err:?}");
+                    break;
+                }
+            };
+            let headers: Vec<BlockInfo> = match Decode::decode(&mut &body[..]) {
+                Ok(headers) => headers,
+                Err(_) => {
+                    error!("Failed to decode the received blocks");
+                    break;
+                }
+            };
+            for info in headers {
+                db.put_header(info.header.number, &info.encode())
+                    .context("Failed to put record to DB")?;
+                metadata.update_header(info.header.number);
+                next_block = info.header.number + 1;
+            }
+            db.put_metadata(&metadata)
+                .context("Failed to update metadata")?;
+            info!("Synced to {} from upstream cache", next_block - 1);
+        }
+        info!("Sleeping for {check_interval} seconds...");
+        tokio::time::sleep(std::time::Duration::from_secs(check_interval)).await;
+    }
 }

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -162,7 +162,7 @@ pub async fn get_set_id(api: &RelaychainApi, block: BlockNumber) -> Result<(u64,
     Ok((set_id, block.justifications.is_some()))
 }
 
-async fn grab_headers(
+pub async fn grab_headers(
     api: &RelaychainApi,
     para_api: &ParachainApi,
     start_at: BlockNumber,
@@ -179,7 +179,7 @@ async fn grab_headers(
 
     let header_hash = crate::get_header_hash(api, Some(start_at - 1)).await?;
     let mut last_set = api.current_set_id(Some(header_hash)).await?;
-    let mut skip_justitication = justification_interval;
+    let mut skip_justitication = 0_u32;
     let mut grabbed = 0;
 
     let para_id = para_api.get_paraid(None).await?;
@@ -392,10 +392,7 @@ impl Client {
         start_number: BlockNumber,
         count: BlockNumber,
     ) -> Result<Vec<Header>> {
-        let url = format!(
-            "{}/parachain-headers/{start_number}/{count}",
-            self.base_uri
-        );
+        let url = format!("{}/parachain-headers/{start_number}/{count}", self.base_uri);
         self.request(&url).await
     }
 
@@ -404,10 +401,7 @@ impl Client {
         start_number: BlockNumber,
         count: BlockNumber,
     ) -> Result<Vec<BlockHeaderWithChanges>> {
-        let url = format!(
-            "{}/storage-changes/{start_number}/{count}",
-            self.base_uri
-        );
+        let url = format!("{}/storage-changes/{start_number}/{count}", self.base_uri);
         self.request(&url).await
     }
 


### PR DESCRIPTION
Two changes in this PR.

- Support setting `--justification-interval` for `serve --grab`.
  The interval was set to `0` before. It is not a big deal if it is running on the guest side. However, if we deploy the `headers-cache` as a public service and want it to grab new headers while serving, it is important to be able to set the justification interval.

- Add an option `--mirror` to sync `headers-cache` from another headers-cache instance(the public one for example).

# Usage
Mirroring
```bash
./headers-cache serve --mirror http://localhost:8003
```

@jasl 