### PR TITLE
Upgrade prost(-build) to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7353,7 +7353,7 @@ dependencies = [
  "phala-trie-storage",
  "phala-types",
  "primitive-types",
- "prost 0.9.0",
+ "prost 0.11.2",
  "prpc",
  "prpc-build",
  "reqwest",
@@ -8434,7 +8434,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "parity-scale-codec",
- "prost 0.9.0",
+ "prost 0.11.2",
 ]
 
 [[package]]
@@ -8448,9 +8448,10 @@ dependencies = [
  "log",
  "multimap",
  "proc-macro2 1.0.47",
- "prost 0.9.0",
+ "prost 0.11.2",
+ "prost-build 0.11.2",
  "prost-build 0.9.0",
- "prost-types 0.9.0",
+ "prost-types 0.11.2",
  "quote 1.0.20",
  "syn 1.0.98",
 ]

--- a/crates/phactory/api/Cargo.toml
+++ b/crates/phactory/api/Cargo.toml
@@ -10,7 +10,7 @@ scale-info = { version = "2.1", default-features = false, features = ["derive"] 
 serde = { version = "1", features = ["derive"], default-features = false }
 base64 = { version = "0.13" }
 derive_more = { version = "0.99.17" }
-prost = { version = "0.9.0", default-features = false }
+prost = { version = "0.11.2", default-features = false }
 
 phala-trie-storage = { path = "../../../crates/phala-trie-storage", default-features = false, features = ["serde"] }
 phala-types = { path = "../../../crates/phala-types", default-features = false, features = ["enable_serde", "sgx"] }

--- a/crates/prpc-build/Cargo.toml
+++ b/crates/prpc-build/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-prost-build = { version = "0.9.0" }
+protoc = { version = "0.9", package = "prost-build" }
+prost-build = { version = "0.11.2" }
 syn = "1.0.98"
 quote = "1.0"
 proc-macro2 = "1.0"
 derive_wrapper = "0.1.7"
-prost-types = "0.9.0"
-prost = "0.9.0"
+prost-types = "0.11.2"
+prost = "0.11.2"
 itertools = "0.10.1"
 either = "1.6.1"
 multimap = "0.8.3"

--- a/crates/prpc-build/src/prost.rs
+++ b/crates/prpc-build/src/prost.rs
@@ -422,6 +422,9 @@ impl Builder {
 
         config.service_generator(Box::new(ServiceGenerator::new(self)));
 
+        if std::env::var("PROTOC").is_err() {
+            std::env::set_var("PROTOC", protoc::protoc());
+        }
         config.compile_protos(protos, includes)?;
 
         let patch_file = out_dir.join("protos_codec_extensions.rs");

--- a/crates/prpc/Cargo.toml
+++ b/crates/prpc/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.57"
 derive_more = "0.99.16"
-prost = { version = "0.9.0", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.11.2", default-features = false, features = ["prost-derive"] }
 anyhow = { version = "1.0.42", default-features = false }
 parity-scale-codec = { version = "3.1", default-features = false }

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -4487,7 +4487,7 @@ dependencies = [
  "phala-trie-storage",
  "phala-types",
  "primitive-types",
- "prost",
+ "prost 0.11.2",
  "prpc",
  "prpc-build",
  "scale-info",
@@ -4922,6 +4922,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "prettyplease"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5014,7 +5024,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.2",
 ]
 
 [[package]]
@@ -5030,9 +5050,31 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
  "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
+dependencies = [
+ "bytes",
+ "heck 0.4.0",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost 0.11.2",
+ "prost-types 0.11.2",
+ "regex",
+ "syn 1.0.99",
  "tempfile",
  "which",
 ]
@@ -5051,13 +5093,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.9.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+dependencies = [
+ "bytes",
+ "prost 0.11.2",
 ]
 
 [[package]]
@@ -5068,7 +5133,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "parity-scale-codec",
- "prost",
+ "prost 0.11.2",
 ]
 
 [[package]]
@@ -5082,9 +5147,10 @@ dependencies = [
  "log",
  "multimap",
  "proc-macro2 1.0.43",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.11.2",
+ "prost-build 0.11.2",
+ "prost-build 0.9.0",
+ "prost-types 0.11.2",
  "quote 1.0.21",
  "syn 1.0.99",
 ]


### PR DESCRIPTION
`prost-build` is no longer bundling with `protoc` from `0.11`. And the protoc installed with apt is too old to support `optional`. So, we use the `protoc` bundled in `prost-build 0.9` (which is 3.15.8) to build it.