### PR TITLE
Refactor the chain storage inspecting in pRuntime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7316,6 +7316,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
+ "sp-state-machine",
  "sp-trie",
  "surf",
  "thiserror",

--- a/crates/phactory/Cargo.toml
+++ b/crates/phactory/Cargo.toml
@@ -38,6 +38,7 @@ sp-io                = { git = "https://github.com/paritytech/substrate", branch
 sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32", features = ["disable_target_static_assertions"] }
 sp-runtime           = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }
 sp-externalities     = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }
+sp-state-machine     = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.32" }
 parity-scale-codec   = { package = "parity-scale-codec", version = "3.1", default-features = false, features = ["derive", "full", "chain-error"] }
 scopeguard   = { version = "1.1", default-features = false }
 

--- a/crates/phactory/api/src/blocks.rs
+++ b/crates/phactory/api/src/blocks.rs
@@ -83,15 +83,6 @@ pub struct SyncHeaderReq {
     pub authority_set_change: Option<AuthoritySetChange>,
 }
 
-#[derive(TypeInfo, Encode, Decode, Clone, Debug, Default, PartialEq, Eq)]
-pub struct ParaId(pub u32);
-
-impl ParaId {
-    pub fn new(n: u32) -> ParaId {
-        ParaId(n)
-    }
-}
-
 #[derive(TypeInfo, Encode, Decode, Clone, Debug)]
 pub struct SyncParachainHeaderReq {
     pub headers: Headers,

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -52,7 +52,7 @@ use types::Error;
 pub use chain::BlockNumber;
 pub use contracts::pink;
 pub use prpc_service::RpcService;
-pub use storage::{Storage, StorageExt};
+pub use storage::ChainStorage;
 pub use system::gk;
 pub use types::BlockInfo;
 
@@ -83,7 +83,7 @@ struct RuntimeState {
     storage_synchronizer: Synchronizer<LightValidation<chain::Runtime>>,
 
     // TODO.kevin: use a better serialization approach
-    chain_storage: Storage,
+    chain_storage: ChainStorage,
 
     #[serde(with = "more::scale_bytes")]
     genesis_block_hash: H256,
@@ -230,9 +230,6 @@ pub struct Phactory<Platform> {
     #[serde(default = "Instant::now")]
     last_checkpoint: Instant,
     #[serde(skip)]
-    #[serde(default)]
-    last_storage_purge_at: chain::BlockNumber,
-    #[serde(skip)]
     #[serde(default = "default_query_scheduler")]
     query_scheduler: RequestScheduler<ContractId>,
 
@@ -263,7 +260,6 @@ impl<Platform: pal::Platform> Phactory<Platform> {
             signed_endpoints: None,
             handover_ecdh_key: None,
             last_checkpoint: Instant::now(),
-            last_storage_purge_at: 0,
             query_scheduler: default_query_scheduler(),
             netconfig: Default::default(),
         }

--- a/crates/phactory/src/light_validation/mod.rs
+++ b/crates/phactory/src/light_validation/mod.rs
@@ -398,7 +398,7 @@ pub mod utils {
     pub fn storage_map_prefix_twox_64_concat(
         module: &[u8],
         storage_item: &[u8],
-        key: &impl Encode,
+        key: &(impl Encode + ?Sized),
     ) -> Vec<u8> {
         let mut bytes = sp_core::twox_128(module).to_vec();
         bytes.extend(&sp_core::twox_128(storage_item)[..]);

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -232,21 +232,11 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             let state = self.runtime_state()?;
             state
                 .storage_synchronizer
-                .feed_block(&block, &mut state.chain_storage)
+                .feed_block(&block, state.chain_storage.inner_mut())
                 .map_err(from_display)?;
             info!("State synced");
             state.purge_mq();
             self.handle_inbound_messages(block.block_header.number)?;
-            if block
-                .block_header
-                .number
-                .saturating_sub(self.last_storage_purge_at)
-                >= self.args.gc_interval
-            {
-                self.last_storage_purge_at = block.block_header.number;
-                info!("Purging database");
-                self.runtime_state()?.chain_storage.purge();
-            }
             last_block = block.block_header.number;
 
             if let Err(e) = self.maybe_take_checkpoint(last_block) {

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -602,8 +602,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
 
         let now_ms = state
             .chain_storage
-            .timestamp_now()
-            .ok_or_else(|| from_display("No timestamp found in block"))?;
+            .timestamp_now();
 
         let mut block = BlockInfo {
             block_number,

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -165,10 +165,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
 
         let state = self.runtime_state()?;
 
-        let para_id = state
-            .chain_storage
-            .para_id()
-            .ok_or_else(|| from_display("No para_id"))?;
+        let para_id = state.chain_storage.para_id();
 
         let storage_key = light_validation::utils::storage_map_prefix_twox_64_concat(
             b"Paras", b"Heads", &para_id,

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::benchmark::Flags;
 use crate::hex;
-use crate::system::{chain_state, System};
+use crate::system::System;
 
 use super::*;
 use crate::contracts::ContractClusterId;
@@ -1141,9 +1141,10 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> PhactoryApi for Rpc
                 .map_err(|_| from_display("Invalid RA report from client"))?;
             let my_mrenclave = my_ias_fields.extend_mrenclave();
             let runtime_state = phactory.runtime_state()?;
-            let my_runtime_timestamp =
-                chain_state::get_pruntime_added_at(&runtime_state.chain_storage, &my_mrenclave)
-                    .ok_or_else(|| from_display("Key handover not supported in this pRuntime"))?;
+            let my_runtime_timestamp = runtime_state
+                .chain_storage
+                .get_pruntime_added_at(&my_mrenclave)
+                .ok_or_else(|| from_display("Key handover not supported in this pRuntime"))?;
 
             let attestation = attestation.ok_or_else(|| from_display("Attestation not found"))?;
             let mrenclave = match attestation {
@@ -1157,9 +1158,10 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> PhactoryApi for Rpc
                     ias_fields.extend_mrenclave()
                 }
             };
-            let req_runtime_timestamp =
-                chain_state::get_pruntime_added_at(&runtime_state.chain_storage, &mrenclave)
-                    .ok_or_else(|| from_display("Unknown target pRuntime version"))?;
+            let req_runtime_timestamp = runtime_state
+                .chain_storage
+                .get_pruntime_added_at(&mrenclave)
+                .ok_or_else(|| from_display("Unknown target pRuntime version"))?;
             // ATTENTION.shelven: relax this check for easy testing and restore it for release
             if my_runtime_timestamp >= req_runtime_timestamp {
                 return Err(from_display("No handover for old pRuntime"));

--- a/crates/phactory/src/storage.rs
+++ b/crates/phactory/src/storage.rs
@@ -36,10 +36,9 @@ impl BlockValidator for LightValidation<chain::Runtime> {
 
 mod storage_ext {
     use crate::{chain, light_validation::utils::storage_prefix};
-    use chain::{pallet_fat, pallet_mq, pallet_registry};
+    use chain::{pallet_fat, pallet_mq, pallet_registry, ParachainInfo};
     use log::error;
     use parity_scale_codec::{Decode, Error};
-    use phactory_api::blocks::ParaId;
     use phala_mq::{Message, MessageOrigin};
     use phala_trie_storage::TrieStorage;
     use serde::{Deserialize, Serialize};
@@ -103,8 +102,8 @@ mod storage_ext {
             sp_externalities::set_and_run_with_externalities(&mut ext, f)
         }
 
-        pub fn para_id(&self) -> Option<ParaId> {
-            self.get_decoded(storage_prefix("ParachainInfo", "ParachainId"))
+        pub fn para_id(&self) -> u32 {
+            self.execute_with(ParachainInfo::parachain_id).0
         }
 
         pub fn mq_messages(&self) -> Result<Vec<Message>, Error> {

--- a/crates/phactory/src/storage.rs
+++ b/crates/phactory/src/storage.rs
@@ -35,45 +35,59 @@ impl BlockValidator for LightValidation<chain::Runtime> {
 }
 
 mod storage_ext {
-    use crate::chain;
-    use crate::light_validation::utils::storage_prefix;
-    use phactory_api::blocks::ParaId;
+    use crate::{
+        chain,
+        light_validation::utils::{storage_map_prefix_twox_64_concat, storage_prefix},
+    };
     use log::error;
-    use parity_scale_codec::{Decode, Error};
+    use parity_scale_codec::{Decode, Encode, Error};
+    use phactory_api::blocks::ParaId;
     use phala_mq::Message;
     use phala_trie_storage::TrieStorage;
 
     pub type Storage = TrieStorage<crate::RuntimeHasher>;
 
-    pub trait StorageExt {
-        fn get_raw(&self, key: impl AsRef<[u8]>) -> Option<Vec<u8>>;
-        fn get_decoded_result<T: Decode>(&self, key: impl AsRef<[u8]>) -> Result<Option<T>, Error> {
-            self.get_raw(key)
-                .map(|v| match Decode::decode(&mut &v[..]) {
-                    Ok(decoded) => Ok(decoded),
-                    Err(e) => {
-                        error!("Decode storage value failed: {}", e);
-                        Err(e)
-                    }
-                })
-                .transpose()
+    // Hide the trait StorageGet behind this private mod sealed
+    mod sealed {
+        use super::*;
+        pub trait StorageGet {
+            fn get_raw(&self, key: impl AsRef<[u8]>) -> Option<Vec<u8>>;
+            fn get_decoded_result<T: Decode>(
+                &self,
+                key: impl AsRef<[u8]>,
+            ) -> Result<Option<T>, Error> {
+                self.get_raw(key)
+                    .map(|v| match Decode::decode(&mut &v[..]) {
+                        Ok(decoded) => Ok(decoded),
+                        Err(e) => {
+                            error!("Decode storage value failed: {}", e);
+                            Err(e)
+                        }
+                    })
+                    .transpose()
+            }
+            fn get_decoded<T: Decode>(&self, key: impl AsRef<[u8]>) -> Option<T> {
+                self.get_decoded_result(key).ok().flatten()
+            }
         }
-        fn get_decoded<T: Decode>(&self, key: impl AsRef<[u8]>) -> Option<T> {
-            self.get_decoded_result(key).ok().flatten()
+
+        impl StorageGet for Storage {
+            fn get_raw(&self, key: impl AsRef<[u8]>) -> Option<Vec<u8>> {
+                self.get(key)
+            }
         }
-        fn get_decoded_or_default<T: Decode + Default>(
-            &self,
-            key: impl AsRef<[u8]>,
-        ) -> Result<T, Error> {
-            self.get_decoded_result(key).map(|v| v.unwrap_or_default())
-        }
+    }
+
+    pub trait StorageExt: sealed::StorageGet {
         fn para_id(&self) -> Option<ParaId> {
             self.get_decoded(storage_prefix("ParachainInfo", "ParachainId"))
         }
+
         fn mq_messages(&self) -> Result<Vec<Message>, Error> {
             for key in ["OutboundMessagesV2", "OutboundMessages"] {
-                let messages: Vec<Message> =
-                    self.get_decoded_or_default(storage_prefix("PhalaMq", key))?;
+                let messages: Vec<Message> = self
+                    .get_decoded_result(storage_prefix("PhalaMq", key))
+                    .map(|v| v.unwrap_or_default())?;
                 if !messages.is_empty() {
                     info!("Got {} messages from {key}", messages.len());
                     return Ok(messages);
@@ -81,17 +95,41 @@ mod storage_ext {
             }
             Ok(vec![])
         }
+
         fn timestamp_now(&self) -> Option<chain::Moment> {
             self.get_decoded(storage_prefix("Timestamp", "Now"))
         }
+
         fn pink_system_code(&self) -> Option<(u16, Vec<u8>)> {
             self.get_decoded(storage_prefix("PhalaFatContracts", "PinkSystemCode"))
         }
-    }
 
-    impl StorageExt for Storage {
-        fn get_raw(&self, key: impl AsRef<[u8]>) -> Option<Vec<u8>> {
-            self.get(key)
+        /// Get the next mq sequnce number for given sender. Default to 0 if no message sent.
+        fn mq_sequence(&self, sender: &impl Encode) -> u64 {
+            use phala_pallets::pallet_mq::StorageMapTrait as _;
+            type OffchainIngress = phala_pallets::pallet_mq::OffchainIngress<chain::Runtime>;
+
+            let module_prefix = OffchainIngress::module_prefix();
+            let storage_prefix = OffchainIngress::storage_prefix();
+            let key = storage_map_prefix_twox_64_concat(module_prefix, storage_prefix, sender);
+            self.get_decoded(key).unwrap_or(0)
+        }
+
+        /// Return `None` if given pruntime hash is not allowed on-chain
+        fn get_pruntime_added_at(&self, runtime_hash: &[u8]) -> Option<chain::BlockNumber> {
+            let key = storage_map_prefix_twox_64_concat(
+                b"PhalaRegistry",
+                b"PRuntimeAddedAt",
+                runtime_hash,
+            );
+            self.get_decoded(key)
+        }
+
+        fn gatekeepers(&self) -> Vec<phala_types::WorkerPublicKey> {
+            let key = storage_prefix("PhalaRegistry", "Gatekeeper");
+            self.get_decoded(key).unwrap_or_default()
         }
     }
+
+    impl StorageExt for Storage {}
 }

--- a/crates/phactory/src/storage.rs
+++ b/crates/phactory/src/storage.rs
@@ -36,7 +36,7 @@ impl BlockValidator for LightValidation<chain::Runtime> {
 
 mod storage_ext {
     use crate::{chain, light_validation::utils::storage_prefix};
-    use chain::{pallet_fat, pallet_mq, pallet_registry, ParachainInfo};
+    use chain::{pallet_fat, pallet_mq, pallet_registry};
     use log::error;
     use parity_scale_codec::{Decode, Error};
     use phala_mq::{Message, MessageOrigin};
@@ -72,9 +72,6 @@ mod storage_ext {
                 })
                 .transpose()
         }
-        fn get_decoded<T: Decode>(&self, key: impl AsRef<[u8]>) -> Option<T> {
-            self.get_decoded_result(key).ok().flatten()
-        }
     }
 
     impl ChainStorage {
@@ -103,7 +100,7 @@ mod storage_ext {
         }
 
         pub fn para_id(&self) -> u32 {
-            self.execute_with(ParachainInfo::parachain_id).0
+            self.execute_with(chain::ParachainInfo::parachain_id).0
         }
 
         pub fn mq_messages(&self) -> Result<Vec<Message>, Error> {
@@ -119,8 +116,8 @@ mod storage_ext {
             Ok(vec![])
         }
 
-        pub fn timestamp_now(&self) -> Option<chain::Moment> {
-            self.get_decoded(storage_prefix("Timestamp", "Now"))
+        pub fn timestamp_now(&self) -> chain::Moment {
+            self.execute_with(chain::Timestamp::now)
         }
 
         pub fn pink_system_code(&self) -> (u16, Vec<u8>) {

--- a/crates/phactory/src/system/gk.rs
+++ b/crates/phactory/src/system/gk.rs
@@ -1697,7 +1697,7 @@ pub mod tests {
 
     fn with_block(block_number: chain::BlockNumber, call: impl FnOnce(&BlockInfo)) {
         // GK never use the storage ATM.
-        let storage = crate::Storage::default();
+        let storage = crate::ChainStorage::default();
         let mut recv_mq = phala_mq::MessageDispatcher::new();
         let mut send_mq = phala_mq::MessageSendQueue::new();
         let block = BlockInfo {

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -1594,12 +1594,10 @@ impl<Platform: pal::Platform> System<Platform> {
                 error!("Cluster {:?} is already deployed", &cluster_id);
                 return Err(TransactionError::DuplicatedClusterDeploy.into());
             }
-            let system_code = block
-                .storage
-                .pink_system_code()
-                .map(|it| it.1)
-                .filter(|code| !code.is_empty())
-                .ok_or(TransactionError::NoPinkSystemCode)?;
+            let system_code = block.storage.pink_system_code().1;
+            if system_code.is_empty() {
+                return Err(TransactionError::NoPinkSystemCode.into());
+            }
             info!(
                 "Worker: creating cluster {:?}, owner={:?}, code length={}",
                 cluster_id,

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -7,7 +7,6 @@ use crate::{
     pink::{cluster::ClusterKeeper, ContractEventCallback, Pink},
     secret_channel::{ecdh_serde, SecretReceiver},
     types::{BlockInfo, OpaqueError, OpaqueQuery, OpaqueReply},
-    StorageExt,
 };
 use anyhow::{anyhow, Context, Result};
 use core::fmt;
@@ -2105,9 +2104,9 @@ impl fmt::Display for Error {
 
 pub mod chain_state {
     use super::*;
-    use crate::storage::Storage;
+    use crate::storage::ChainStorage;
 
-    pub fn is_gatekeeper(pubkey: &WorkerPublicKey, chain_storage: &Storage) -> bool {
+    pub fn is_gatekeeper(pubkey: &WorkerPublicKey, chain_storage: &ChainStorage) -> bool {
         chain_storage.gatekeepers().contains(pubkey)
     }
 }

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -2105,30 +2105,9 @@ impl fmt::Display for Error {
 
 pub mod chain_state {
     use super::*;
-    use crate::light_validation::utils::{storage_map_prefix_twox_64_concat, storage_prefix};
-    use crate::storage::{Storage, StorageExt};
-    use parity_scale_codec::Decode;
+    use crate::storage::Storage;
 
     pub fn is_gatekeeper(pubkey: &WorkerPublicKey, chain_storage: &Storage) -> bool {
-        let key = storage_prefix("PhalaRegistry", "Gatekeeper");
-        let gatekeepers = chain_storage
-            .get(&key)
-            .map(|v| {
-                Vec::<WorkerPublicKey>::decode(&mut &v[..])
-                    .expect("Decode value of Gatekeeper Failed. (This should not happen)")
-            })
-            .unwrap_or_default();
-
-        gatekeepers.contains(pubkey)
-    }
-
-    /// Return `None` if given pruntime hash is not allowed on-chain
-    pub fn get_pruntime_added_at(
-        chain_storage: &Storage,
-        runtime_hash: &Vec<u8>,
-    ) -> Option<chain::BlockNumber> {
-        let key =
-            storage_map_prefix_twox_64_concat(b"PhalaRegistry", b"PRuntimeAddedAt", runtime_hash);
-        chain_storage.get_decoded(key)
+        chain_storage.gatekeepers().contains(pubkey)
     }
 }

--- a/crates/phactory/src/types.rs
+++ b/crates/phactory/src/types.rs
@@ -14,7 +14,7 @@ pub struct BlockInfo<'a> {
     /// The timestamp of this block.
     pub now_ms: u64,
     /// The storage snapshot after this block executed.
-    pub storage: &'a crate::Storage,
+    pub storage: &'a crate::ChainStorage,
     /// The message queue
     pub send_mq: &'a phala_mq::MessageSendQueue,
     pub recv_mq: &'a mut phala_mq::MessageDispatcher,

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -186,6 +186,10 @@ where
             })
             .collect()
     }
+
+    pub fn as_trie_backend(&self) -> &InMemoryBackend<H> {
+        &self.0
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/pallets/phala/src/puppets.rs
+++ b/pallets/phala/src/puppets.rs
@@ -17,7 +17,8 @@ pub mod parachain_info {
 		impl<T: Config> Pallet<T> {}
 
 		#[pallet::storage]
-		pub(super) type ParachainId<T: Config> = StorageValue<_, ParaId, ValueQuery>;
+		#[pallet::getter(fn parachain_id)]
+		pub type ParachainId<T: Config> = StorageValue<_, ParaId, ValueQuery>;
 
 		#[derive(Encode, Decode, TypeInfo, Default)]
 		pub struct ParaId(pub u32);

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -4452,6 +4452,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
+ "sp-state-machine",
  "sp-trie",
  "surf",
  "thiserror",
@@ -4600,6 +4601,7 @@ dependencies = [
  "parity-scale-codec",
  "phala-pallets",
  "phala-types",
+ "phat-offchain-rollup",
  "scale-info",
  "sp-api",
  "sp-authority-discovery",
@@ -4705,6 +4707,26 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
+]
+
+[[package]]
+name = "phat-offchain-rollup"
+version = "0.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "hex",
+ "hex-literal",
+ "log",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/standalone/replay/src/replay_gk.rs
+++ b/standalone/replay/src/replay_gk.rs
@@ -98,8 +98,7 @@ impl ReplayFactory {
 
         let now_ms = self
             .storage
-            .timestamp_now()
-            .ok_or("No timestamp found in block")?;
+            .timestamp_now();
 
         let block = BlockInfo {
             block_number,

--- a/standalone/replay/src/replay_gk/httpserver.rs
+++ b/standalone/replay/src/replay_gk/httpserver.rs
@@ -13,6 +13,7 @@ async fn meminfo(data: web::Data<AppState>) -> HttpResponse {
     let factory = data.factory.lock().await;
     let size = factory
         .storage
+        .inner()
         .pairs(&[])
         .iter()
         .map(|(k, v)| k.len() + v.len())


### PR DESCRIPTION
This PR gathers all codes, that get data from the chain storage with a manually composited key, into a single place.
So that we can easily audit it to see whether it is affected by the renaming PR. **Fortunately, nothing would be affected**.

Let's check it here: https://github.com/Phala-Network/phala-blockchain/blob/72b29828f5a3520309b79fa3dcc7f52324824443/crates/phactory/src/storage.rs#L82-L131


