### PR TITLE
pink-runtime: Add immutable execute fn

### DIFF
--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -425,7 +425,7 @@ pub mod cluster {
             &self.key
         }
 
-        pub fn system_contract(&mut self) -> Option<AccountId32> {
+        pub fn system_contract(&self) -> Option<AccountId32> {
             self.storage.system_contract()
         }
 
@@ -454,7 +454,7 @@ pub mod cluster {
         }
 
         pub fn get_resource(
-            &mut self,
+            &self,
             resource_type: ResourceType,
             hash: &Hash,
         ) -> Option<Vec<u8>> {

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -1849,7 +1849,7 @@ fn apply_instantiating_events(
             .derive_ecdh_key()
             .expect("Derive ecdh_key should not fail");
         let id = pink.id();
-        let code_hash = pink.instance.code_hash(&mut cluster.storage);
+        let code_hash = pink.instance.code_hash(&cluster.storage);
         let result = install_contract(
             contracts,
             id,

--- a/crates/pink/src/contract.rs
+++ b/crates/pink/src/contract.rs
@@ -213,7 +213,7 @@ impl Contract {
             gas_free,
         } = args;
         let gas_limit = gas_limit.set_proof_size(u64::MAX);
-        storage.execute_with(in_query, callbacks, move || {
+        storage.execute_mut(in_query, callbacks, move || {
             let result = contract_tx(
                 origin.clone(),
                 block_number,
@@ -280,7 +280,7 @@ impl Contract {
         } = tx_args;
         let addr = self.address.clone();
         let gas_limit = gas_limit.set_proof_size(u64::MAX);
-        storage.execute_with(in_query, callbacks, move || {
+        storage.execute_mut(in_query, callbacks, move || {
             let result = contract_tx(
                 origin.clone(),
                 block_number,
@@ -365,7 +365,7 @@ impl Contract {
         self.hooks.on_block_end = Some((selector, Weight::from_ref_time(gas_limit)));
     }
 
-    pub fn code_hash(&self, storage: &mut Storage) -> Option<Hash> {
+    pub fn code_hash(&self, storage: &Storage) -> Option<Hash> {
         storage.code_hash(&self.address)
     }
 }

--- a/crates/pink/src/runtime.rs
+++ b/crates/pink/src/runtime.rs
@@ -362,7 +362,7 @@ mod tests {
 
         let total_issue = Balance::MAX.saturating_div(2);
 
-        storage.execute_with(false, None, || {
+        storage.execute_mut(false, None, || {
             _ = Balances::deposit_creating(&ALICE, total_issue);
         });
 

--- a/crates/pink/src/storage.rs
+++ b/crates/pink/src/storage.rs
@@ -1,5 +1,7 @@
 use crate::{
-    runtime::{Balances, BoxedEventCallbacks, Contracts, ExecSideEffects, Pink as PalletPink},
+    runtime::{
+        Balances, BoxedEventCallbacks, CallMode, Contracts, ExecSideEffects, Pink as PalletPink,
+    },
     types::{AccountId, Balance, Hash, Hashing},
 };
 use frame_support::traits::Currency;
@@ -66,23 +68,23 @@ where
     Backend: StorageBackend<Hashing> + CommitTransaction + AsTrieBackend<Hashing>,
 {
     pub fn execute_with<R>(
-        &mut self,
-        rollback: bool,
+        &self,
+        in_query: bool,
         callbacks: Option<BoxedEventCallbacks>,
         f: impl FnOnce() -> R,
-    ) -> (R, ExecSideEffects) {
+    ) -> (R, ExecSideEffects, OverlayedChanges) {
         let backend = self.backend.as_trie_backend();
 
         let mut overlay = OverlayedChanges::default();
         overlay.start_transaction();
         let mut cache = StorageTransactionCache::default();
         let mut ext = Ext::new(&mut overlay, &mut cache, backend, None);
-        let r = sp_externalities::set_and_run_with_externalities(&mut ext, move || {
+        let (rv, effects) = sp_externalities::set_and_run_with_externalities(&mut ext, move || {
             crate::runtime::System::reset_events();
-            let mode = if rollback {
-                crate::runtime::CallMode::Query
+            let mode = if in_query {
+                CallMode::Query
             } else {
-                crate::runtime::CallMode::Command
+                CallMode::Command
             };
             let r = crate::runtime::using_mode(mode, callbacks, f);
             (r, crate::runtime::get_side_effects())
@@ -90,10 +92,20 @@ where
         overlay
             .commit_transaction()
             .expect("BUG: mis-paired transaction");
-        if !rollback {
+        (rv, effects, overlay)
+    }
+
+    pub fn execute_mut<R>(
+        &mut self,
+        in_query: bool,
+        callbacks: Option<BoxedEventCallbacks>,
+        f: impl FnOnce() -> R,
+    ) -> (R, ExecSideEffects) {
+        let (rv, effects, overlay) = self.execute_with(in_query, callbacks, f);
+        if !in_query {
             self.commit_changes(overlay);
         }
-        r
+        (rv, effects)
     }
 
     pub fn changes_transaction(&self, changes: OverlayedChanges) -> (Hash, Backend::Transaction) {
@@ -117,7 +129,7 @@ where
     }
 
     pub fn set_cluster_id(&mut self, cluster_id: &[u8]) {
-        self.execute_with(false, None, || {
+        self.execute_mut(false, None, || {
             PalletPink::set_cluster_id(cluster_id);
         });
     }
@@ -128,7 +140,7 @@ where
         deposit_per_byte: Balance,
         treasury_account: &AccountId,
     ) {
-        self.execute_with(false, None, || {
+        self.execute_mut(false, None, || {
             PalletPink::set_gas_price(gas_price);
             PalletPink::set_deposit_per_item(deposit_per_item);
             PalletPink::set_deposit_per_byte(deposit_per_byte);
@@ -137,13 +149,13 @@ where
     }
 
     pub fn deposit(&mut self, who: &AccountId, value: Balance) {
-        self.execute_with(false, None, || {
+        self.execute_mut(false, None, || {
             let _ = Balances::deposit_creating(who, value);
         });
     }
 
     pub fn set_key_seed(&mut self, seed: Sr25519SecretKey) {
-        self.execute_with(false, None, || {
+        self.execute_mut(false, None, || {
             PalletPink::set_key_seed(seed);
         });
     }
@@ -153,7 +165,7 @@ where
         account: &AccountId,
         code: Vec<u8>,
     ) -> Result<Hash, DispatchError> {
-        self.execute_with(false, None, || {
+        self.execute_mut(false, None, || {
             crate::runtime::Contracts::bare_upload_code(account.clone(), code, None)
         })
         .0
@@ -165,26 +177,26 @@ where
         account: &AccountId,
         code: Vec<u8>,
     ) -> Result<Hash, DispatchError> {
-        self.execute_with(false, None, || {
+        self.execute_mut(false, None, || {
             PalletPink::put_sidevm_code(account.clone(), code)
         })
         .0
     }
 
-    pub fn get_sidevm_code(&mut self, hash: &Hash) -> Option<Vec<u8>> {
-        self.execute_with(false, None, || {
+    pub fn get_sidevm_code(&self, hash: &Hash) -> Option<Vec<u8>> {
+        self.execute_with(true, None, || {
             PalletPink::sidevm_codes(&hash).map(|v| v.code)
         })
         .0
     }
 
     pub fn set_system_contract(&mut self, address: AccountId) {
-        self.execute_with(false, None, move || {
+        self.execute_mut(false, None, move || {
             PalletPink::set_system_contract(address);
         });
     }
 
-    pub fn system_contract(&mut self) -> Option<AccountId> {
+    pub fn system_contract(&self) -> Option<AccountId> {
         self.execute_with(true, None, PalletPink::system_contract).0
     }
 
@@ -196,17 +208,17 @@ where
         *self.backend.as_trie_backend().root()
     }
 
-    pub fn free_balance(&mut self, account: &AccountId) -> Balance {
+    pub fn free_balance(&self, account: &AccountId) -> Balance {
         self.execute_with(true, None, || Balances::free_balance(account))
             .0
     }
 
-    pub fn total_balance(&mut self, account: &AccountId) -> Balance {
+    pub fn total_balance(&self, account: &AccountId) -> Balance {
         self.execute_with(true, None, || Balances::total_balance(account))
             .0
     }
 
-    pub fn code_hash(&mut self, account: &AccountId) -> Option<Hash> {
+    pub fn code_hash(&self, account: &AccountId) -> Option<Hash> {
         self.execute_with(true, None, || Contracts::code_hash(account))
             .0
     }


### PR DESCRIPTION
This distinguishes mutable/immutable execute fn in pink runtime to avoid unnecessary `&mut` requirements.