### PR TITLE
Don't store command args in checkpoint

### DIFF
--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -155,6 +155,7 @@ enum RuntimeDataSeal {
 #[serde(bound(deserialize = "Platform: Deserialize<'de>"))]
 pub struct Phactory<Platform> {
     platform: Platform,
+    #[serde(skip)]
     args: InitArgs,
     skip_ra: bool,
     dev_mode: bool,


### PR DESCRIPTION
This fixes the checkpoint incompatible issue.