### PR TITLE
Support fast sync new workers

### DIFF
--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -123,7 +123,7 @@ where
             main_bridge,
             header_number_next,
             block_number_next,
-            genesis_state_validated: true,
+            genesis_state_validated: false,
         }
     }
 
@@ -270,7 +270,7 @@ pub struct SolochainSynchronizer<Validator> {
 impl<Validator: BlockValidator> SolochainSynchronizer<Validator> {
     pub fn new(validator: Validator, main_bridge: u64) -> Self {
         Self {
-            sync_state: BlockSyncState::new(validator, main_bridge, 1, 1),
+            sync_state: BlockSyncState::new(validator, main_bridge, 0, 1),
             state_roots: Default::default(),
         }
     }
@@ -315,12 +315,11 @@ impl<Validator: BlockValidator> StorageSynchronizer for SolochainSynchronizer<Va
     }
 
     fn assume_at_block(&mut self, block_number: chain::BlockNumber) -> Result<()> {
-        if self.sync_state.block_number_next > 1 || self.sync_state.header_number_next > 1 {
+        if self.sync_state.block_number_next > 1 || self.sync_state.header_number_next > 0 {
             return Err(Error::CanNotLoadStateAfterSynced);
         }
 
         self.sync_state.block_number_next = block_number + 1;
-        self.sync_state.genesis_state_validated = false;
         Ok(())
     }
 }
@@ -338,7 +337,7 @@ impl<Validator: BlockValidator> ParachainSynchronizer<Validator> {
         Self {
             sync_state: BlockSyncState::new(validator, main_bridge, headernum_next, 1),
             last_relaychain_state_root: None,
-            para_header_number_next: 1,
+            para_header_number_next: 0,
             para_state_roots: Default::default(),
         }
     }
@@ -439,7 +438,6 @@ impl<Validator: BlockValidator> StorageSynchronizer for ParachainSynchronizer<Va
         }
         self.sync_state.block_number_next = block_number + 1;
         self.para_header_number_next = block_number;
-        self.sync_state.genesis_state_validated = false;
         Ok(())
     }
 }

--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -210,14 +210,15 @@ where
         }
 
         if !self.genesis_state_validated {
-            let genesis_state_root = state_roots.pop_front().ok_or(Error::NoStateRoot)?;
-            if storage.root() != &genesis_state_root {
-                panic!(
-                    "Genesis state root mismatch, expacted: {:?}, actual: {:?}",
-                    genesis_state_root,
-                    storage.root()
-                );
+            let genesis_state_root = state_roots.get(0).ok_or(Error::NoStateRoot)?;
+            if storage.root() != genesis_state_root {
+                return Err(Error::StateRootMismatch {
+                    block: self.block_number_next - 1,
+                    expected: genesis_state_root.clone(),
+                    actual: storage.root().clone(),
+                });
             }
+            _ = state_roots.pop_front();
             self.genesis_state_validated = true;
         }
 

--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -93,6 +93,7 @@ pub trait StorageSynchronizer {
 
     /// Assume synced to given block.
     fn assume_at_block(&mut self, block_number: chain::BlockNumber) -> Result<()>;
+    fn state_validated(&self) -> bool;
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -323,6 +324,10 @@ impl<Validator: BlockValidator> StorageSynchronizer for SolochainSynchronizer<Va
         self.sync_state.block_number_next = block_number + 1;
         Ok(())
     }
+
+    fn state_validated(&self) -> bool {
+        self.sync_state.genesis_state_validated
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -441,6 +446,10 @@ impl<Validator: BlockValidator> StorageSynchronizer for ParachainSynchronizer<Va
         self.para_header_number_next = block_number;
         Ok(())
     }
+
+    fn state_validated(&self) -> bool {
+        self.sync_state.genesis_state_validated
+    }
 }
 
 // We create this new type to help serialize the original dyn StorageSynchronizer.
@@ -512,5 +521,9 @@ impl<Validator: BlockValidator> StorageSynchronizer for Synchronizer<Validator> 
 
     fn assume_at_block(&mut self, block_number: chain::BlockNumber) -> Result<()> {
         self.as_dyn_mut().assume_at_block(block_number)
+    }
+
+    fn state_validated(&self) -> bool {
+        self.as_dyn().state_validated()
     }
 }

--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -51,6 +51,8 @@ pub enum Error {
     CannotLoadStateAfterSyncing,
 }
 
+impl std::error::Error for Error {}
+
 pub trait BlockValidator {
     fn submit_finalized_headers(
         &mut self,

--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -214,8 +214,8 @@ where
             if storage.root() != genesis_state_root {
                 return Err(Error::StateRootMismatch {
                     block: self.block_number_next - 1,
-                    expected: genesis_state_root.clone(),
-                    actual: storage.root().clone(),
+                    expected: *genesis_state_root,
+                    actual: *storage.root(),
                 });
             }
             _ = state_roots.pop_front();

--- a/crates/phactory/pal/src/lib.rs
+++ b/crates/phactory/pal/src/lib.rs
@@ -18,8 +18,13 @@ pub trait Sealing {
 
 pub trait RA {
     type Error: ErrorType;
-    fn create_attestation_report(&self, provider: Option<AttestationProvider>, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
+    fn create_attestation_report(
+        &self,
+        provider: Option<AttestationProvider>,
+        data: &[u8],
+    ) -> Result<Vec<u8>, Self::Error>;
     fn quote_test(&self, provider: Option<AttestationProvider>) -> Result<(), Self::Error>;
+    fn measurement(&self) -> Option<Vec<u8>>;
 }
 
 pub struct MemoryUsage {
@@ -48,5 +53,8 @@ pub trait AppInfo {
     fn app_version() -> AppVersion;
 }
 
-pub trait Platform: Sealing + RA + Machine + MemoryStats + AppInfo + Clone + Send + 'static {}
+pub trait Platform:
+    Sealing + RA + Machine + MemoryStats + AppInfo + Clone + Send + 'static
+{
+}
 impl<T: Sealing + RA + Machine + MemoryStats + AppInfo + Clone + Send + 'static> Platform for T {}

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -236,6 +236,9 @@ pub struct Phactory<Platform> {
 
     #[serde(default)]
     netconfig: Option<NetworkConfig>,
+
+    #[serde(skip)]
+    can_load_chain_state: bool,
 }
 
 fn default_query_scheduler() -> RequestScheduler<ContractId> {
@@ -263,6 +266,7 @@ impl<Platform: pal::Platform> Phactory<Platform> {
             last_checkpoint: Instant::now(),
             query_scheduler: default_query_scheduler(),
             netconfig: Default::default(),
+            can_load_chain_state: false,
         }
     }
 
@@ -279,6 +283,7 @@ impl<Platform: pal::Platform> Phactory<Platform> {
             benchmark::resume();
         }
 
+        self.can_load_chain_state = !system::gk_master_key_exists(&args.sealing_path);
         self.args = args;
     }
 

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -312,13 +312,13 @@ impl<Platform: pal::Platform> Phactory<Platform> {
 
         // check genesis block hash
         if genesis_block_hash != data.genesis_block_hash {
-            panic!(
+            anyhow::bail!(
                 "Genesis block hash mismatches with saved keys, expected {}",
                 data.genesis_block_hash
             );
         }
         if para_id != data.para_id {
-            panic!(
+            anyhow::bail!(
                 "Parachain id mismatches, saved: {}, in state: {para_id}",
                 data.para_id
             );

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -430,10 +430,6 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             .ok_or_else(|| from_display("Uninitiated runtime info"))?;
 
         let reset_operator = operator.is_some();
-        info!("validated_identity_key :{validated_identity_key}");
-        info!("validated_state        :{validated_state}");
-        info!("refresh_ra             :{refresh_ra}");
-        info!("reset_operator         :{reset_operator}");
         if reset_operator {
             let mut runtime_info = cached_resp
                 .decode_runtime_info()
@@ -452,9 +448,17 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             }
         }
 
+        let allow_attestation =
+            validated_state && (validated_identity_key || self.attestation_provider.is_none());
+        info!("validated_identity_key :{validated_identity_key}");
+        info!("validated_state        :{validated_state}");
+        info!("refresh_ra             :{refresh_ra}");
+        info!("reset_operator         :{reset_operator}");
+        info!("attestation_provider   :{:?}", self.attestation_provider);
+        info!("allow_attestation      :{allow_attestation}");
         // Never generate RA report for a potentially injected identity key
         // else he is able to fake a Secure Worker
-        if validated_identity_key && validated_state && cached_resp.attestation.is_none() {
+        if allow_attestation && cached_resp.attestation.is_none() {
             // We hash the encoded bytes directly
             let runtime_info_hash = sp_core::hashing::blake2_256(&cached_resp.encoded_runtime_info);
             info!("Encoded runtime info");

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -236,6 +236,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
                 .map_err(from_display)?;
             info!("State synced");
             state.purge_mq();
+            self.check_requirements();
             self.handle_inbound_messages(block.block_header.number)?;
             last_block = block.block_header.number;
 

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -840,6 +840,14 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         self.can_load_chain_state = false;
         Ok(())
     }
+
+    pub fn stop(&self, remove_checkpoints: bool) -> RpcResult<()> {
+        info!("Requested to stop remove_checkpoints={remove_checkpoints}");
+        if remove_checkpoints {
+            crate::maybe_remove_checkpoints(&self.args.sealing_path);
+        }
+        std::process::abort()
+    }
 }
 
 #[derive(Clone)]
@@ -1482,6 +1490,9 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> PhactoryApi for Rpc
     ) -> Result<(), prpc::server::Error> {
         self.lock_phactory()
             .load_chain_state(request.block_number, request.decode_state()?)
+    }
+    async fn stop(&mut self, request: pb::StopOptions) -> Result<(), prpc::server::Error> {
+        self.lock_phactory().stop(request.remove_checkpoints)
     }
 }
 

--- a/crates/phactory/src/storage.rs
+++ b/crates/phactory/src/storage.rs
@@ -143,5 +143,10 @@ mod storage_ext {
         pub(crate) fn gatekeepers(&self) -> Vec<phala_types::WorkerPublicKey> {
             self.execute_with(pallet_registry::Gatekeeper::<chain::Runtime>::get)
         }
+
+        pub(crate) fn is_worker_registered(&self, worker: &phala_types::WorkerPublicKey) -> bool {
+            self.execute_with(|| pallet_registry::Workers::<chain::Runtime>::get(worker))
+                .is_some()
+        }
     }
 }

--- a/crates/phactory/src/storage.rs
+++ b/crates/phactory/src/storage.rs
@@ -75,6 +75,14 @@ mod storage_ext {
     }
 
     impl ChainStorage {
+        pub fn from_pairs(
+            pairs: impl Iterator<Item = (impl AsRef<[u8]>, impl AsRef<[u8]>)>,
+        ) -> Self {
+            let mut me = Self::default();
+            me.load(pairs);
+            me
+        }
+
         pub fn load(&mut self, pairs: impl Iterator<Item = (impl AsRef<[u8]>, impl AsRef<[u8]>)>) {
             self.trie_storage.load(pairs);
         }

--- a/crates/phactory/src/storage.rs
+++ b/crates/phactory/src/storage.rs
@@ -148,5 +148,13 @@ mod storage_ext {
             self.execute_with(|| pallet_registry::Workers::<chain::Runtime>::get(worker))
                 .is_some()
         }
+
+        pub(crate) fn minimum_pruntime_version(&self) -> (u32, u32, u32) {
+            self.execute_with(pallet_registry::MinimumPRuntimeVersion::<chain::Runtime>::get)
+        }
+
+        pub(crate) fn pruntime_consensus_version(&self) -> u32 {
+            self.execute_with(pallet_registry::PRuntimeConsensusVersion::<chain::Runtime>::get)
+        }
     }
 }

--- a/crates/phactory/src/storage.rs
+++ b/crates/phactory/src/storage.rs
@@ -164,5 +164,15 @@ mod storage_ext {
         pub(crate) fn pruntime_consensus_version(&self) -> u32 {
             self.execute_with(pallet_registry::PRuntimeConsensusVersion::<chain::Runtime>::get)
         }
+
+        pub(crate) fn is_pruntime_in_whitelist(&self, measurement: &[u8]) -> bool {
+            let list = self.execute_with(pallet_registry::PRuntimeAllowList::<chain::Runtime>::get);
+            for hash in list.iter() {
+                if hash.starts_with(measurement) {
+                    return true;
+                }
+            }
+            false
+        }
     }
 }

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -22,7 +22,7 @@ use crate::contracts;
 use crate::pal;
 use chain::pallet_fat::ContractRegistryEvent;
 use chain::pallet_registry::RegistryEvent;
-pub use master_key::RotatedMasterKey;
+pub use master_key::{RotatedMasterKey, gk_master_key_exists};
 use parity_scale_codec::{Decode, Encode};
 pub use phactory_api::prpc::{GatekeeperRole, GatekeeperStatus, SystemInfo};
 use phala_crypto::{

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -457,6 +457,9 @@ pub struct System<Platform> {
     // Cached for query
     pub(crate) block_number: BlockNumber,
     pub(crate) now_ms: u64,
+
+    // If non-zero indicates the block which this worker loaded the chain state from.
+    pub(crate) genesis_block: BlockNumber,
 }
 
 thread_local! {
@@ -528,6 +531,7 @@ impl<Platform: pal::Platform> System<Platform> {
             block_number: 0,
             now_ms: 0,
             sidevm_spawner: create_sidevm_service(worker_threads),
+            genesis_block: 0,
         }
     }
 
@@ -843,6 +847,10 @@ impl<Platform: pal::Platform> System<Platform> {
             !master_key_history.is_empty(),
             "Init gatekeeper with no master key"
         );
+
+        if self.genesis_block != 0 {
+            panic!("Gatekeeper must be synced start from the first block");
+        }
 
         let master_key = sr25519::Pair::restore_from_secret_key(
             &master_key_history

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -1656,6 +1656,7 @@ impl<Platform: pal::Platform> System<Platform> {
             public_key: hex::encode(self.identity_key.public()),
             ecdh_public_key: hex::encode(self.ecdh_key.public()),
             max_supported_consensus_version: MAX_SUPPORTED_CONSENSUS_VERSION,
+            genesis_block: self.genesis_block,
         }
     }
 }

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -16,12 +16,7 @@ use parity_scale_codec::Codec;
 use sp_core::storage::ChildInfo;
 use sp_core::Hasher;
 use sp_state_machine::{Backend, TrieBackend, TrieBackendBuilder};
-use sp_trie::{
-    TrieMut,
-    trie_types::{
-        TrieDBMutBuilderV0 as TrieDBMutBuilder,
-    },
-};
+use sp_trie::{trie_types::TrieDBMutBuilderV0 as TrieDBMutBuilder, TrieMut};
 
 pub use memdb::GenericMemoryDB as MemoryDB;
 
@@ -104,9 +99,7 @@ where
     H::Out: Codec,
 {
     let root = trie.root();
-    let mdb = trie
-        .backend_storage()
-        .clone();
+    let mdb = trie.backend_storage().clone();
     TrieBackendBuilder::new(mdb, *root).build()
 }
 
@@ -153,10 +146,7 @@ where
     pub fn apply_changes(&mut self, root: H::Out, transaction: MemoryDB<H>) {
         let mut storage = core::mem::take(self).0.into_storage();
         storage.consolidate(transaction);
-        let _ = core::mem::replace(
-            &mut self.0,
-            TrieBackendBuilder::new(storage, root).build()
-        );
+        let _ = core::mem::replace(&mut self.0, TrieBackendBuilder::new(storage, root).build());
     }
 
     pub fn purge(&mut self) {}

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -553,6 +553,18 @@ pub struct WorkerRegistrationInfo<AccountId> {
 }
 
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
+pub struct WorkerRegistrationInfoV2<AccountId> {
+    pub version: u32,
+    pub machine_id: MachineId,
+    pub pubkey: WorkerPublicKey,
+    pub ecdh_pubkey: EcdhPublicKey,
+    pub genesis_block_hash: H256,
+    pub features: Vec<u32>,
+    pub operator: Option<AccountId>,
+    pub para_id: u32,
+}
+
+#[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
 pub enum VersionedWorkerEndpoints {
     V1(Vec<String>),
 }

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -113,22 +113,6 @@ pub mod messaging {
         }
     }
 
-    bind_topic!(PRuntimeManagementEvent, b"phala/pruntime/management");
-    #[derive(Encode, Decode, Debug, TypeInfo, Clone, PartialEq, Eq)]
-    pub enum PRuntimeManagementEvent {
-        RetirePRuntime(RetireCondition),
-        SetConsensusVersion(u32),
-    }
-
-    #[cfg_attr(feature = "enable_serde", derive(Serialize, Deserialize))]
-    #[derive(Encode, Decode, Debug, TypeInfo, Clone, PartialEq, Eq)]
-    pub enum RetireCondition {
-        /// pRuntimes of version less than given version will be retired.
-        VersionLessThan(u32, u32, u32),
-        /// pRuntimes of version equal to given version will be retired.
-        VersionIs(u32, u32, u32),
-    }
-
     #[derive(Encode, Decode, Debug, Default, Clone, PartialEq, Eq, TypeInfo)]
     pub struct HeartbeatChallenge {
         pub seed: U256,

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -563,6 +563,7 @@ pub struct WorkerRegistrationInfoV2<AccountId> {
     pub features: Vec<u32>,
     pub operator: Option<AccountId>,
     pub para_id: u32,
+    pub max_consensus_versioin: u32,
 }
 
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -537,6 +537,7 @@ pub struct ChallengeHandlerInfo<BlockNumber> {
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
 pub struct EncryptedWorkerKey {
     pub genesis_block_hash: H256,
+    pub para_id: u32,
     pub dev_mode: bool,
     pub encrypted_key: messaging::EncryptedKey,
 }

--- a/crates/prpc-build/src/protos_codec_extension.rs
+++ b/crates/prpc-build/src/protos_codec_extension.rs
@@ -436,6 +436,8 @@ pub fn extend_types(
     let mut buf = String::new();
     buf.push_str(
         r#"
+    #![allow(clippy::too_many_arguments)]
+
     use ::prpc::codec::scale::{Encode, Decode, Error as ScaleDecodeError};
     use ::alloc::vec::Vec;
     use ::alloc::string::String;

--- a/e2e/src/fullstack.js
+++ b/e2e/src/fullstack.js
@@ -849,7 +849,7 @@ function testPruntimeManagement(workDir) {
             await cluster.kill();
         });
 
-        it("can retirement old pruntimes", async () => {
+        it("can retire old pruntimes", async () => {
             await assert.txAccepted(
                 api.tx.sudo.sudo(
                     api.tx.phalaRegistry.setMinimumPruntimeVersion(

--- a/e2e/src/fullstack.js
+++ b/e2e/src/fullstack.js
@@ -803,9 +803,6 @@ function testPruntimeManagement(workDir) {
         let worker;
         let tmpPath;
         let test_case = 0;
-        let currentVersion;
-        let newerVersion;
-        let olderVersion;
 
         before(async () => {
             // Create polkadot api and keyring
@@ -844,9 +841,6 @@ function testPruntimeManagement(workDir) {
             }, 7000), 'stuck at block 0');
 
             info = await worker.api.getInfo();
-            currentVersion = versionToNumber(info.version);
-            newerVersion = currentVersion + 1;
-            olderVersion = currentVersion - 1;
         });
 
         afterEach(async () => {
@@ -855,69 +849,32 @@ function testPruntimeManagement(workDir) {
             await cluster.kill();
         });
 
-        it("can retirement pruntimes less than given version", async () => {
-            await checkRetireCondition('lessThan: olderVersion', {
-                lessThan: olderVersion,
-                causeExit: false
-            });
-
-            await checkRetireCondition('lessThan: currentVersion', {
-                lessThan: currentVersion,
-                causeExit: false
-            });
-
-            await checkRetireCondition('lessThan: newerVersion', {
-                lessThan: newerVersion,
-                causeExit: true
-            });
-        });
-
-        it("can retirement pruntimes matches given version", async () => {
-            await checkRetireCondition('equal: newerVersion', {
-                equal: newerVersion,
-                causeExit: false
-            });
-
-            await checkRetireCondition('equal: olderVersion', {
-                equal: olderVersion,
-                causeExit: false
-            });
-
-            await checkRetireCondition('equal: currentVersion', {
-                equal: currentVersion,
-                causeExit: true
-            });
-        });
-
-        it("can set consensus version", async () => {
-            const info = await worker.api.getInfo();
-            const { consensusVersion, maxSupportedConsensusVersion } = info.system;
-
-            assert.isTrue(consensusVersion != maxSupportedConsensusVersion);
+        it("can retirement old pruntimes", async () => {
             await assert.txAccepted(
                 api.tx.sudo.sudo(
-                    api.tx.phalaRegistry.setPruntimeConsensusVersion(
-                        maxSupportedConsensusVersion
+                    api.tx.phalaRegistry.setMinimumPruntimeVersion(
+                        999,
+                        0,
+                        0,
                     )
                 ),
                 alice,
             );
-            assert.isTrue(
+
+            assert.equal(
+                true,
                 await checkUntil(
                     async () => {
-                        const info = await worker.api.getInfo();
-                        const { consensusVersion } = info.system;
-                        return maxSupportedConsensusVersion == consensusVersion;
+                        return worker.processPRuntime.stopped;
                     },
                     6000
                 ),
-                `Failed to set consensus version to ${maxSupportedConsensusVersion}`
+                "Failed to retire old version pruntime"
             );
         });
 
         it("can not set consensus version over max supported", async () => {
-            const { consensusVersion, maxSupportedConsensusVersion } = (await worker.api.getInfo()).system;
-            assert.isTrue(consensusVersion != maxSupportedConsensusVersion);
+            const { maxSupportedConsensusVersion } = (await worker.api.getInfo()).system;
             await assert.txAccepted(
                 api.tx.sudo.sudo(
                     api.tx.phalaRegistry.setPruntimeConsensusVersion(
@@ -936,45 +893,7 @@ function testPruntimeManagement(workDir) {
                 'Failed to wait pruntime to exit'
             );
         });
-
-        async function checkRetireCondition(desc, { lessThan, equal, causeExit }) {
-            let condition;
-            if (lessThan)
-                condition = api.createType('PhalaTypesMessagingRetireCondition', { 'VersionLessThan': versionFromNumber(lessThan) })
-            if (equal)
-                condition = api.createType('PhalaTypesMessagingRetireCondition', { 'VersionIs': versionFromNumber(equal) })
-
-            await assert.txAccepted(
-                api.tx.sudo.sudo(
-                    api.tx.phalaRegistry.retirePruntime(
-                        condition
-                    )
-                ),
-                alice,
-            );
-
-            assert.equal(
-                causeExit,
-                await checkUntil(
-                    async () => {
-                        return worker.processPRuntime.stopped;
-                    },
-                    6000
-                ),
-                `Condition ${desc} failed`
-            );
-        }
     });
-}
-
-
-function versionToNumber(version) {
-    segs = version.split('.').map(n => parseInt(n));
-    return (segs[0] << 16) + (segs[1] << 8) + segs[2]
-}
-
-function versionFromNumber(n) {
-    return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff]
 }
 
 async function assertSubmission(txBuilder, signer, shouldSucceed = true) {

--- a/e2e/src/proto/pruntime_rpc.d.ts
+++ b/e2e/src/proto/pruntime_rpc.d.ts
@@ -413,6 +413,20 @@ export namespace pruntime_rpc {
          * @returns Promise
          */
         public loadChainState(request: pruntime_rpc.IChainState): Promise<google.protobuf.Empty>;
+
+        /**
+         * Calls Stop.
+         * @param request StopOptions message or plain object
+         * @param callback Node-style callback called with the error, if any, and Empty
+         */
+        public stop(request: pruntime_rpc.IStopOptions, callback: pruntime_rpc.PhactoryAPI.StopCallback): void;
+
+        /**
+         * Calls Stop.
+         * @param request StopOptions message or plain object
+         * @returns Promise
+         */
+        public stop(request: pruntime_rpc.IStopOptions): Promise<google.protobuf.Empty>;
     }
 
     namespace PhactoryAPI {
@@ -612,6 +626,13 @@ export namespace pruntime_rpc {
          * @param [response] Empty
          */
         type LoadChainStateCallback = (error: (Error|null), response?: google.protobuf.Empty) => void;
+
+        /**
+         * Callback as used by {@link pruntime_rpc.PhactoryAPI#stop}.
+         * @param error Error, if any
+         * @param [response] Empty
+         */
+        type StopCallback = (error: (Error|null), response?: google.protobuf.Empty) => void;
     }
 
     /** Properties of a PhactoryInfo. */
@@ -5847,6 +5868,96 @@ export namespace pruntime_rpc {
 
         /**
          * Converts this ChainState to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a StopOptions. */
+    interface IStopOptions {
+
+        /** StopOptions removeCheckpoints */
+        removeCheckpoints?: (boolean|null);
+    }
+
+    /** Represents a StopOptions. */
+    class StopOptions implements IStopOptions {
+
+        /**
+         * Constructs a new StopOptions.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: pruntime_rpc.IStopOptions);
+
+        /** StopOptions removeCheckpoints. */
+        public removeCheckpoints: boolean;
+
+        /**
+         * Creates a new StopOptions instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns StopOptions instance
+         */
+        public static create(properties?: pruntime_rpc.IStopOptions): pruntime_rpc.StopOptions;
+
+        /**
+         * Encodes the specified StopOptions message. Does not implicitly {@link pruntime_rpc.StopOptions.verify|verify} messages.
+         * @param message StopOptions message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: pruntime_rpc.IStopOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified StopOptions message, length delimited. Does not implicitly {@link pruntime_rpc.StopOptions.verify|verify} messages.
+         * @param message StopOptions message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: pruntime_rpc.IStopOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a StopOptions message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns StopOptions
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): pruntime_rpc.StopOptions;
+
+        /**
+         * Decodes a StopOptions message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns StopOptions
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): pruntime_rpc.StopOptions;
+
+        /**
+         * Verifies a StopOptions message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a StopOptions message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns StopOptions
+         */
+        public static fromObject(object: { [k: string]: any }): pruntime_rpc.StopOptions;
+
+        /**
+         * Creates a plain object from a StopOptions message. Also converts values to other types if specified.
+         * @param message StopOptions
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: pruntime_rpc.StopOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this StopOptions to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };

--- a/e2e/src/proto/pruntime_rpc.d.ts
+++ b/e2e/src/proto/pruntime_rpc.d.ts
@@ -842,9 +842,6 @@ export namespace pruntime_rpc {
         /** SystemInfo numberOfContracts */
         numberOfContracts?: (number|Long|null);
 
-        /** SystemInfo consensusVersion */
-        consensusVersion?: (number|null);
-
         /** SystemInfo maxSupportedConsensusVersion */
         maxSupportedConsensusVersion?: (number|null);
     }
@@ -875,9 +872,6 @@ export namespace pruntime_rpc {
 
         /** SystemInfo numberOfContracts. */
         public numberOfContracts: (number|Long);
-
-        /** SystemInfo consensusVersion. */
-        public consensusVersion: number;
 
         /** SystemInfo maxSupportedConsensusVersion. */
         public maxSupportedConsensusVersion: number;

--- a/e2e/src/proto/pruntime_rpc.d.ts
+++ b/e2e/src/proto/pruntime_rpc.d.ts
@@ -844,6 +844,9 @@ export namespace pruntime_rpc {
 
         /** SystemInfo maxSupportedConsensusVersion */
         maxSupportedConsensusVersion?: (number|null);
+
+        /** SystemInfo genesisBlock */
+        genesisBlock?: (number|null);
     }
 
     /** Represents a SystemInfo. */
@@ -875,6 +878,9 @@ export namespace pruntime_rpc {
 
         /** SystemInfo maxSupportedConsensusVersion. */
         public maxSupportedConsensusVersion: number;
+
+        /** SystemInfo genesisBlock. */
+        public genesisBlock: number;
 
         /**
          * Creates a new SystemInfo instance using the specified properties.

--- a/e2e/src/proto/pruntime_rpc.d.ts
+++ b/e2e/src/proto/pruntime_rpc.d.ts
@@ -399,6 +399,20 @@ export namespace pruntime_rpc {
          * @returns Promise
          */
         public getNetworkConfig(request: google.protobuf.IEmpty): Promise<pruntime_rpc.NetworkConfigResponse>;
+
+        /**
+         * Calls LoadChainState.
+         * @param request ChainState message or plain object
+         * @param callback Node-style callback called with the error, if any, and Empty
+         */
+        public loadChainState(request: pruntime_rpc.IChainState, callback: pruntime_rpc.PhactoryAPI.LoadChainStateCallback): void;
+
+        /**
+         * Calls LoadChainState.
+         * @param request ChainState message or plain object
+         * @returns Promise
+         */
+        public loadChainState(request: pruntime_rpc.IChainState): Promise<google.protobuf.Empty>;
     }
 
     namespace PhactoryAPI {
@@ -591,6 +605,13 @@ export namespace pruntime_rpc {
          * @param [response] NetworkConfigResponse
          */
         type GetNetworkConfigCallback = (error: (Error|null), response?: pruntime_rpc.NetworkConfigResponse) => void;
+
+        /**
+         * Callback as used by {@link pruntime_rpc.PhactoryAPI#loadChainState}.
+         * @param error Error, if any
+         * @param [response] Empty
+         */
+        type LoadChainStateCallback = (error: (Error|null), response?: google.protobuf.Empty) => void;
     }
 
     /** Properties of a PhactoryInfo. */
@@ -649,6 +670,9 @@ export namespace pruntime_rpc {
 
         /** PhactoryInfo system */
         system?: (pruntime_rpc.ISystemInfo|null);
+
+        /** PhactoryInfo canLoadChainState */
+        canLoadChainState?: (boolean|null);
     }
 
     /** Represents a PhactoryInfo. */
@@ -713,6 +737,9 @@ export namespace pruntime_rpc {
 
         /** PhactoryInfo system. */
         public system?: (pruntime_rpc.ISystemInfo|null);
+
+        /** PhactoryInfo canLoadChainState. */
+        public canLoadChainState: boolean;
 
         /** PhactoryInfo _genesisBlockHash. */
         public _genesisBlockHash?: "genesisBlockHash";
@@ -5724,6 +5751,102 @@ export namespace pruntime_rpc {
 
         /**
          * Converts this ContractId to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a ChainState. */
+    interface IChainState {
+
+        /** ChainState blockNumber */
+        blockNumber?: (number|null);
+
+        /** ChainState encodedState */
+        encodedState?: (Uint8Array|null);
+    }
+
+    /** Represents a ChainState. */
+    class ChainState implements IChainState {
+
+        /**
+         * Constructs a new ChainState.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: pruntime_rpc.IChainState);
+
+        /** ChainState blockNumber. */
+        public blockNumber: number;
+
+        /** ChainState encodedState. */
+        public encodedState: Uint8Array;
+
+        /**
+         * Creates a new ChainState instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns ChainState instance
+         */
+        public static create(properties?: pruntime_rpc.IChainState): pruntime_rpc.ChainState;
+
+        /**
+         * Encodes the specified ChainState message. Does not implicitly {@link pruntime_rpc.ChainState.verify|verify} messages.
+         * @param message ChainState message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: pruntime_rpc.IChainState, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified ChainState message, length delimited. Does not implicitly {@link pruntime_rpc.ChainState.verify|verify} messages.
+         * @param message ChainState message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: pruntime_rpc.IChainState, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a ChainState message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns ChainState
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): pruntime_rpc.ChainState;
+
+        /**
+         * Decodes a ChainState message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns ChainState
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): pruntime_rpc.ChainState;
+
+        /**
+         * Verifies a ChainState message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a ChainState message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns ChainState
+         */
+        public static fromObject(object: { [k: string]: any }): pruntime_rpc.ChainState;
+
+        /**
+         * Creates a plain object from a ChainState message. Also converts values to other types if specified.
+         * @param message ChainState
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: pruntime_rpc.ChainState, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this ChainState to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };

--- a/e2e/src/proto/pruntime_rpc.js
+++ b/e2e/src/proto/pruntime_rpc.js
@@ -1665,7 +1665,6 @@ $root.pruntime_rpc = (function() {
          * @property {pruntime_rpc.IGatekeeperStatus|null} [gatekeeper] SystemInfo gatekeeper
          * @property {number|Long|null} [numberOfClusters] SystemInfo numberOfClusters
          * @property {number|Long|null} [numberOfContracts] SystemInfo numberOfContracts
-         * @property {number|null} [consensusVersion] SystemInfo consensusVersion
          * @property {number|null} [maxSupportedConsensusVersion] SystemInfo maxSupportedConsensusVersion
          */
 
@@ -1733,14 +1732,6 @@ $root.pruntime_rpc = (function() {
         SystemInfo.prototype.numberOfContracts = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
 
         /**
-         * SystemInfo consensusVersion.
-         * @member {number} consensusVersion
-         * @memberof pruntime_rpc.SystemInfo
-         * @instance
-         */
-        SystemInfo.prototype.consensusVersion = 0;
-
-        /**
          * SystemInfo maxSupportedConsensusVersion.
          * @member {number} maxSupportedConsensusVersion
          * @memberof pruntime_rpc.SystemInfo
@@ -1784,10 +1775,8 @@ $root.pruntime_rpc = (function() {
                 writer.uint32(/* id 5, wireType 0 =*/40).uint64(message.numberOfClusters);
             if (message.numberOfContracts != null && Object.hasOwnProperty.call(message, "numberOfContracts"))
                 writer.uint32(/* id 6, wireType 0 =*/48).uint64(message.numberOfContracts);
-            if (message.consensusVersion != null && Object.hasOwnProperty.call(message, "consensusVersion"))
-                writer.uint32(/* id 7, wireType 0 =*/56).uint32(message.consensusVersion);
             if (message.maxSupportedConsensusVersion != null && Object.hasOwnProperty.call(message, "maxSupportedConsensusVersion"))
-                writer.uint32(/* id 8, wireType 0 =*/64).uint32(message.maxSupportedConsensusVersion);
+                writer.uint32(/* id 7, wireType 0 =*/56).uint32(message.maxSupportedConsensusVersion);
             return writer;
         };
 
@@ -1841,9 +1830,6 @@ $root.pruntime_rpc = (function() {
                     message.numberOfContracts = reader.uint64();
                     break;
                 case 7:
-                    message.consensusVersion = reader.uint32();
-                    break;
-                case 8:
                     message.maxSupportedConsensusVersion = reader.uint32();
                     break;
                 default:
@@ -1901,9 +1887,6 @@ $root.pruntime_rpc = (function() {
             if (message.numberOfContracts != null && message.hasOwnProperty("numberOfContracts"))
                 if (!$util.isInteger(message.numberOfContracts) && !(message.numberOfContracts && $util.isInteger(message.numberOfContracts.low) && $util.isInteger(message.numberOfContracts.high)))
                     return "numberOfContracts: integer|Long expected";
-            if (message.consensusVersion != null && message.hasOwnProperty("consensusVersion"))
-                if (!$util.isInteger(message.consensusVersion))
-                    return "consensusVersion: integer expected";
             if (message.maxSupportedConsensusVersion != null && message.hasOwnProperty("maxSupportedConsensusVersion"))
                 if (!$util.isInteger(message.maxSupportedConsensusVersion))
                     return "maxSupportedConsensusVersion: integer expected";
@@ -1951,8 +1934,6 @@ $root.pruntime_rpc = (function() {
                     message.numberOfContracts = object.numberOfContracts;
                 else if (typeof object.numberOfContracts === "object")
                     message.numberOfContracts = new $util.LongBits(object.numberOfContracts.low >>> 0, object.numberOfContracts.high >>> 0).toNumber(true);
-            if (object.consensusVersion != null)
-                message.consensusVersion = object.consensusVersion >>> 0;
             if (object.maxSupportedConsensusVersion != null)
                 message.maxSupportedConsensusVersion = object.maxSupportedConsensusVersion >>> 0;
             return message;
@@ -1986,7 +1967,6 @@ $root.pruntime_rpc = (function() {
                     object.numberOfContracts = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                 } else
                     object.numberOfContracts = options.longs === String ? "0" : 0;
-                object.consensusVersion = 0;
                 object.maxSupportedConsensusVersion = 0;
             }
             if (message.registered != null && message.hasOwnProperty("registered"))
@@ -2007,8 +1987,6 @@ $root.pruntime_rpc = (function() {
                     object.numberOfContracts = options.longs === String ? String(message.numberOfContracts) : message.numberOfContracts;
                 else
                     object.numberOfContracts = options.longs === String ? $util.Long.prototype.toString.call(message.numberOfContracts) : options.longs === Number ? new $util.LongBits(message.numberOfContracts.low >>> 0, message.numberOfContracts.high >>> 0).toNumber(true) : message.numberOfContracts;
-            if (message.consensusVersion != null && message.hasOwnProperty("consensusVersion"))
-                object.consensusVersion = message.consensusVersion;
             if (message.maxSupportedConsensusVersion != null && message.hasOwnProperty("maxSupportedConsensusVersion"))
                 object.maxSupportedConsensusVersion = message.maxSupportedConsensusVersion;
             return object;

--- a/e2e/src/proto/pruntime_rpc.js
+++ b/e2e/src/proto/pruntime_rpc.js
@@ -1666,6 +1666,7 @@ $root.pruntime_rpc = (function() {
          * @property {number|Long|null} [numberOfClusters] SystemInfo numberOfClusters
          * @property {number|Long|null} [numberOfContracts] SystemInfo numberOfContracts
          * @property {number|null} [maxSupportedConsensusVersion] SystemInfo maxSupportedConsensusVersion
+         * @property {number|null} [genesisBlock] SystemInfo genesisBlock
          */
 
         /**
@@ -1740,6 +1741,14 @@ $root.pruntime_rpc = (function() {
         SystemInfo.prototype.maxSupportedConsensusVersion = 0;
 
         /**
+         * SystemInfo genesisBlock.
+         * @member {number} genesisBlock
+         * @memberof pruntime_rpc.SystemInfo
+         * @instance
+         */
+        SystemInfo.prototype.genesisBlock = 0;
+
+        /**
          * Creates a new SystemInfo instance using the specified properties.
          * @function create
          * @memberof pruntime_rpc.SystemInfo
@@ -1777,6 +1786,8 @@ $root.pruntime_rpc = (function() {
                 writer.uint32(/* id 6, wireType 0 =*/48).uint64(message.numberOfContracts);
             if (message.maxSupportedConsensusVersion != null && Object.hasOwnProperty.call(message, "maxSupportedConsensusVersion"))
                 writer.uint32(/* id 7, wireType 0 =*/56).uint32(message.maxSupportedConsensusVersion);
+            if (message.genesisBlock != null && Object.hasOwnProperty.call(message, "genesisBlock"))
+                writer.uint32(/* id 8, wireType 0 =*/64).uint32(message.genesisBlock);
             return writer;
         };
 
@@ -1831,6 +1842,9 @@ $root.pruntime_rpc = (function() {
                     break;
                 case 7:
                     message.maxSupportedConsensusVersion = reader.uint32();
+                    break;
+                case 8:
+                    message.genesisBlock = reader.uint32();
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -1890,6 +1904,9 @@ $root.pruntime_rpc = (function() {
             if (message.maxSupportedConsensusVersion != null && message.hasOwnProperty("maxSupportedConsensusVersion"))
                 if (!$util.isInteger(message.maxSupportedConsensusVersion))
                     return "maxSupportedConsensusVersion: integer expected";
+            if (message.genesisBlock != null && message.hasOwnProperty("genesisBlock"))
+                if (!$util.isInteger(message.genesisBlock))
+                    return "genesisBlock: integer expected";
             return null;
         };
 
@@ -1936,6 +1953,8 @@ $root.pruntime_rpc = (function() {
                     message.numberOfContracts = new $util.LongBits(object.numberOfContracts.low >>> 0, object.numberOfContracts.high >>> 0).toNumber(true);
             if (object.maxSupportedConsensusVersion != null)
                 message.maxSupportedConsensusVersion = object.maxSupportedConsensusVersion >>> 0;
+            if (object.genesisBlock != null)
+                message.genesisBlock = object.genesisBlock >>> 0;
             return message;
         };
 
@@ -1968,6 +1987,7 @@ $root.pruntime_rpc = (function() {
                 } else
                     object.numberOfContracts = options.longs === String ? "0" : 0;
                 object.maxSupportedConsensusVersion = 0;
+                object.genesisBlock = 0;
             }
             if (message.registered != null && message.hasOwnProperty("registered"))
                 object.registered = message.registered;
@@ -1989,6 +2009,8 @@ $root.pruntime_rpc = (function() {
                     object.numberOfContracts = options.longs === String ? $util.Long.prototype.toString.call(message.numberOfContracts) : options.longs === Number ? new $util.LongBits(message.numberOfContracts.low >>> 0, message.numberOfContracts.high >>> 0).toNumber(true) : message.numberOfContracts;
             if (message.maxSupportedConsensusVersion != null && message.hasOwnProperty("maxSupportedConsensusVersion"))
                 object.maxSupportedConsensusVersion = message.maxSupportedConsensusVersion;
+            if (message.genesisBlock != null && message.hasOwnProperty("genesisBlock"))
+                object.genesisBlock = message.genesisBlock;
             return object;
         };
 

--- a/e2e/src/proto/pruntime_rpc.js
+++ b/e2e/src/proto/pruntime_rpc.js
@@ -941,6 +941,39 @@ $root.pruntime_rpc = (function() {
          * @variation 2
          */
 
+        /**
+         * Callback as used by {@link pruntime_rpc.PhactoryAPI#loadChainState}.
+         * @memberof pruntime_rpc.PhactoryAPI
+         * @typedef LoadChainStateCallback
+         * @type {function}
+         * @param {Error|null} error Error, if any
+         * @param {google.protobuf.Empty} [response] Empty
+         */
+
+        /**
+         * Calls LoadChainState.
+         * @function loadChainState
+         * @memberof pruntime_rpc.PhactoryAPI
+         * @instance
+         * @param {pruntime_rpc.IChainState} request ChainState message or plain object
+         * @param {pruntime_rpc.PhactoryAPI.LoadChainStateCallback} callback Node-style callback called with the error, if any, and Empty
+         * @returns {undefined}
+         * @variation 1
+         */
+        Object.defineProperty(PhactoryAPI.prototype.loadChainState = function loadChainState(request, callback) {
+            return this.rpcCall(loadChainState, $root.pruntime_rpc.ChainState, $root.google.protobuf.Empty, request, callback);
+        }, "name", { value: "LoadChainState" });
+
+        /**
+         * Calls LoadChainState.
+         * @function loadChainState
+         * @memberof pruntime_rpc.PhactoryAPI
+         * @instance
+         * @param {pruntime_rpc.IChainState} request ChainState message or plain object
+         * @returns {Promise<google.protobuf.Empty>} Promise
+         * @variation 2
+         */
+
         return PhactoryAPI;
     })();
 
@@ -968,6 +1001,7 @@ $root.pruntime_rpc = (function() {
          * @property {pruntime_rpc.IMemoryUsage|null} [memoryUsage] PhactoryInfo memoryUsage
          * @property {boolean|null} [waitingForParaheaders] PhactoryInfo waitingForParaheaders
          * @property {pruntime_rpc.ISystemInfo|null} [system] PhactoryInfo system
+         * @property {boolean|null} [canLoadChainState] PhactoryInfo canLoadChainState
          */
 
         /**
@@ -1129,6 +1163,14 @@ $root.pruntime_rpc = (function() {
          */
         PhactoryInfo.prototype.system = null;
 
+        /**
+         * PhactoryInfo canLoadChainState.
+         * @member {boolean} canLoadChainState
+         * @memberof pruntime_rpc.PhactoryInfo
+         * @instance
+         */
+        PhactoryInfo.prototype.canLoadChainState = false;
+
         // OneOf field names bound to virtual getters and setters
         var $oneOfFields;
 
@@ -1225,6 +1267,8 @@ $root.pruntime_rpc = (function() {
                 writer.uint32(/* id 21, wireType 0 =*/168).bool(message.waitingForParaheaders);
             if (message.system != null && Object.hasOwnProperty.call(message, "system"))
                 $root.pruntime_rpc.SystemInfo.encode(message.system, writer.uint32(/* id 23, wireType 2 =*/186).fork()).ldelim();
+            if (message.canLoadChainState != null && Object.hasOwnProperty.call(message, "canLoadChainState"))
+                writer.uint32(/* id 24, wireType 0 =*/192).bool(message.canLoadChainState);
             return writer;
         };
 
@@ -1312,6 +1356,9 @@ $root.pruntime_rpc = (function() {
                     break;
                 case 23:
                     message.system = $root.pruntime_rpc.SystemInfo.decode(reader, reader.uint32());
+                    break;
+                case 24:
+                    message.canLoadChainState = reader.bool();
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -1415,6 +1462,9 @@ $root.pruntime_rpc = (function() {
                 if (error)
                     return "system." + error;
             }
+            if (message.canLoadChainState != null && message.hasOwnProperty("canLoadChainState"))
+                if (typeof message.canLoadChainState !== "boolean")
+                    return "canLoadChainState: boolean expected";
             return null;
         };
 
@@ -1489,6 +1539,8 @@ $root.pruntime_rpc = (function() {
                     throw TypeError(".pruntime_rpc.PhactoryInfo.system: object expected");
                 message.system = $root.pruntime_rpc.SystemInfo.fromObject(object.system);
             }
+            if (object.canLoadChainState != null)
+                message.canLoadChainState = Boolean(object.canLoadChainState);
             return message;
         };
 
@@ -1529,6 +1581,7 @@ $root.pruntime_rpc = (function() {
                 object.memoryUsage = null;
                 object.waitingForParaheaders = false;
                 object.system = null;
+                object.canLoadChainState = false;
             }
             if (message.initialized != null && message.hasOwnProperty("initialized"))
                 object.initialized = message.initialized;
@@ -1581,6 +1634,8 @@ $root.pruntime_rpc = (function() {
                 object.waitingForParaheaders = message.waitingForParaheaders;
             if (message.system != null && message.hasOwnProperty("system"))
                 object.system = $root.pruntime_rpc.SystemInfo.toObject(message.system, options);
+            if (message.canLoadChainState != null && message.hasOwnProperty("canLoadChainState"))
+                object.canLoadChainState = message.canLoadChainState;
             return object;
         };
 
@@ -13680,6 +13735,225 @@ $root.pruntime_rpc = (function() {
         };
 
         return ContractId;
+    })();
+
+    pruntime_rpc.ChainState = (function() {
+
+        /**
+         * Properties of a ChainState.
+         * @memberof pruntime_rpc
+         * @interface IChainState
+         * @property {number|null} [blockNumber] ChainState blockNumber
+         * @property {Uint8Array|null} [encodedState] ChainState encodedState
+         */
+
+        /**
+         * Constructs a new ChainState.
+         * @memberof pruntime_rpc
+         * @classdesc Represents a ChainState.
+         * @implements IChainState
+         * @constructor
+         * @param {pruntime_rpc.IChainState=} [properties] Properties to set
+         */
+        function ChainState(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * ChainState blockNumber.
+         * @member {number} blockNumber
+         * @memberof pruntime_rpc.ChainState
+         * @instance
+         */
+        ChainState.prototype.blockNumber = 0;
+
+        /**
+         * ChainState encodedState.
+         * @member {Uint8Array} encodedState
+         * @memberof pruntime_rpc.ChainState
+         * @instance
+         */
+        ChainState.prototype.encodedState = $util.newBuffer([]);
+
+        /**
+         * Creates a new ChainState instance using the specified properties.
+         * @function create
+         * @memberof pruntime_rpc.ChainState
+         * @static
+         * @param {pruntime_rpc.IChainState=} [properties] Properties to set
+         * @returns {pruntime_rpc.ChainState} ChainState instance
+         */
+        ChainState.create = function create(properties) {
+            return new ChainState(properties);
+        };
+
+        /**
+         * Encodes the specified ChainState message. Does not implicitly {@link pruntime_rpc.ChainState.verify|verify} messages.
+         * @function encode
+         * @memberof pruntime_rpc.ChainState
+         * @static
+         * @param {pruntime_rpc.IChainState} message ChainState message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ChainState.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.blockNumber != null && Object.hasOwnProperty.call(message, "blockNumber"))
+                writer.uint32(/* id 1, wireType 0 =*/8).uint32(message.blockNumber);
+            if (message.encodedState != null && Object.hasOwnProperty.call(message, "encodedState"))
+                writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.encodedState);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified ChainState message, length delimited. Does not implicitly {@link pruntime_rpc.ChainState.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof pruntime_rpc.ChainState
+         * @static
+         * @param {pruntime_rpc.IChainState} message ChainState message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ChainState.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a ChainState message from the specified reader or buffer.
+         * @function decode
+         * @memberof pruntime_rpc.ChainState
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {pruntime_rpc.ChainState} ChainState
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ChainState.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.pruntime_rpc.ChainState();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.blockNumber = reader.uint32();
+                    break;
+                case 2:
+                    message.encodedState = reader.bytes();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a ChainState message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof pruntime_rpc.ChainState
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {pruntime_rpc.ChainState} ChainState
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ChainState.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a ChainState message.
+         * @function verify
+         * @memberof pruntime_rpc.ChainState
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        ChainState.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.blockNumber != null && message.hasOwnProperty("blockNumber"))
+                if (!$util.isInteger(message.blockNumber))
+                    return "blockNumber: integer expected";
+            if (message.encodedState != null && message.hasOwnProperty("encodedState"))
+                if (!(message.encodedState && typeof message.encodedState.length === "number" || $util.isString(message.encodedState)))
+                    return "encodedState: buffer expected";
+            return null;
+        };
+
+        /**
+         * Creates a ChainState message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof pruntime_rpc.ChainState
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {pruntime_rpc.ChainState} ChainState
+         */
+        ChainState.fromObject = function fromObject(object) {
+            if (object instanceof $root.pruntime_rpc.ChainState)
+                return object;
+            var message = new $root.pruntime_rpc.ChainState();
+            if (object.blockNumber != null)
+                message.blockNumber = object.blockNumber >>> 0;
+            if (object.encodedState != null)
+                if (typeof object.encodedState === "string")
+                    $util.base64.decode(object.encodedState, message.encodedState = $util.newBuffer($util.base64.length(object.encodedState)), 0);
+                else if (object.encodedState.length)
+                    message.encodedState = object.encodedState;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a ChainState message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof pruntime_rpc.ChainState
+         * @static
+         * @param {pruntime_rpc.ChainState} message ChainState
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        ChainState.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.blockNumber = 0;
+                if (options.bytes === String)
+                    object.encodedState = "";
+                else {
+                    object.encodedState = [];
+                    if (options.bytes !== Array)
+                        object.encodedState = $util.newBuffer(object.encodedState);
+                }
+            }
+            if (message.blockNumber != null && message.hasOwnProperty("blockNumber"))
+                object.blockNumber = message.blockNumber;
+            if (message.encodedState != null && message.hasOwnProperty("encodedState"))
+                object.encodedState = options.bytes === String ? $util.base64.encode(message.encodedState, 0, message.encodedState.length) : options.bytes === Array ? Array.prototype.slice.call(message.encodedState) : message.encodedState;
+            return object;
+        };
+
+        /**
+         * Converts this ChainState to JSON.
+         * @function toJSON
+         * @memberof pruntime_rpc.ChainState
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        ChainState.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return ChainState;
     })();
 
     return pruntime_rpc;

--- a/e2e/src/proto/pruntime_rpc.js
+++ b/e2e/src/proto/pruntime_rpc.js
@@ -974,6 +974,39 @@ $root.pruntime_rpc = (function() {
          * @variation 2
          */
 
+        /**
+         * Callback as used by {@link pruntime_rpc.PhactoryAPI#stop}.
+         * @memberof pruntime_rpc.PhactoryAPI
+         * @typedef StopCallback
+         * @type {function}
+         * @param {Error|null} error Error, if any
+         * @param {google.protobuf.Empty} [response] Empty
+         */
+
+        /**
+         * Calls Stop.
+         * @function stop
+         * @memberof pruntime_rpc.PhactoryAPI
+         * @instance
+         * @param {pruntime_rpc.IStopOptions} request StopOptions message or plain object
+         * @param {pruntime_rpc.PhactoryAPI.StopCallback} callback Node-style callback called with the error, if any, and Empty
+         * @returns {undefined}
+         * @variation 1
+         */
+        Object.defineProperty(PhactoryAPI.prototype.stop = function stop(request, callback) {
+            return this.rpcCall(stop, $root.pruntime_rpc.StopOptions, $root.google.protobuf.Empty, request, callback);
+        }, "name", { value: "Stop" });
+
+        /**
+         * Calls Stop.
+         * @function stop
+         * @memberof pruntime_rpc.PhactoryAPI
+         * @instance
+         * @param {pruntime_rpc.IStopOptions} request StopOptions message or plain object
+         * @returns {Promise<google.protobuf.Empty>} Promise
+         * @variation 2
+         */
+
         return PhactoryAPI;
     })();
 
@@ -13954,6 +13987,193 @@ $root.pruntime_rpc = (function() {
         };
 
         return ChainState;
+    })();
+
+    pruntime_rpc.StopOptions = (function() {
+
+        /**
+         * Properties of a StopOptions.
+         * @memberof pruntime_rpc
+         * @interface IStopOptions
+         * @property {boolean|null} [removeCheckpoints] StopOptions removeCheckpoints
+         */
+
+        /**
+         * Constructs a new StopOptions.
+         * @memberof pruntime_rpc
+         * @classdesc Represents a StopOptions.
+         * @implements IStopOptions
+         * @constructor
+         * @param {pruntime_rpc.IStopOptions=} [properties] Properties to set
+         */
+        function StopOptions(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * StopOptions removeCheckpoints.
+         * @member {boolean} removeCheckpoints
+         * @memberof pruntime_rpc.StopOptions
+         * @instance
+         */
+        StopOptions.prototype.removeCheckpoints = false;
+
+        /**
+         * Creates a new StopOptions instance using the specified properties.
+         * @function create
+         * @memberof pruntime_rpc.StopOptions
+         * @static
+         * @param {pruntime_rpc.IStopOptions=} [properties] Properties to set
+         * @returns {pruntime_rpc.StopOptions} StopOptions instance
+         */
+        StopOptions.create = function create(properties) {
+            return new StopOptions(properties);
+        };
+
+        /**
+         * Encodes the specified StopOptions message. Does not implicitly {@link pruntime_rpc.StopOptions.verify|verify} messages.
+         * @function encode
+         * @memberof pruntime_rpc.StopOptions
+         * @static
+         * @param {pruntime_rpc.IStopOptions} message StopOptions message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        StopOptions.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.removeCheckpoints != null && Object.hasOwnProperty.call(message, "removeCheckpoints"))
+                writer.uint32(/* id 1, wireType 0 =*/8).bool(message.removeCheckpoints);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified StopOptions message, length delimited. Does not implicitly {@link pruntime_rpc.StopOptions.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof pruntime_rpc.StopOptions
+         * @static
+         * @param {pruntime_rpc.IStopOptions} message StopOptions message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        StopOptions.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a StopOptions message from the specified reader or buffer.
+         * @function decode
+         * @memberof pruntime_rpc.StopOptions
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {pruntime_rpc.StopOptions} StopOptions
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        StopOptions.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.pruntime_rpc.StopOptions();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.removeCheckpoints = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a StopOptions message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof pruntime_rpc.StopOptions
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {pruntime_rpc.StopOptions} StopOptions
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        StopOptions.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a StopOptions message.
+         * @function verify
+         * @memberof pruntime_rpc.StopOptions
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        StopOptions.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.removeCheckpoints != null && message.hasOwnProperty("removeCheckpoints"))
+                if (typeof message.removeCheckpoints !== "boolean")
+                    return "removeCheckpoints: boolean expected";
+            return null;
+        };
+
+        /**
+         * Creates a StopOptions message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof pruntime_rpc.StopOptions
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {pruntime_rpc.StopOptions} StopOptions
+         */
+        StopOptions.fromObject = function fromObject(object) {
+            if (object instanceof $root.pruntime_rpc.StopOptions)
+                return object;
+            var message = new $root.pruntime_rpc.StopOptions();
+            if (object.removeCheckpoints != null)
+                message.removeCheckpoints = Boolean(object.removeCheckpoints);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a StopOptions message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof pruntime_rpc.StopOptions
+         * @static
+         * @param {pruntime_rpc.StopOptions} message StopOptions
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        StopOptions.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults)
+                object.removeCheckpoints = false;
+            if (message.removeCheckpoints != null && message.hasOwnProperty("removeCheckpoints"))
+                object.removeCheckpoints = message.removeCheckpoints;
+            return object;
+        };
+
+        /**
+         * Converts this StopOptions to JSON.
+         * @function toJSON
+         * @memberof pruntime_rpc.StopOptions
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        StopOptions.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return StopOptions;
     })();
 
     return pruntime_rpc;

--- a/pallets/phala/src/fat_tokenomic/tests/mock.rs
+++ b/pallets/phala/src/fat_tokenomic/tests/mock.rs
@@ -115,6 +115,7 @@ impl registry::Config for Test {
 	type VerifyPRuntime = VerifyPRuntime;
 	type VerifyRelaychainGenesisBlockHash = VerifyRelaychainGenesisBlockHash;
 	type GovernanceOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type ParachainId = ConstU32<0>;
 }
 
 impl fat::Config for Test {

--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -131,6 +131,7 @@ impl registry::Config for Test {
 	type VerifyPRuntime = VerifyPRuntime;
 	type VerifyRelaychainGenesisBlockHash = VerifyRelaychainGenesisBlockHash;
 	type GovernanceOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type ParachainId = ConstU32<0>;
 }
 
 impl mining::Config for Test {

--- a/pallets/phala/src/registry.rs
+++ b/pallets/phala/src/registry.rs
@@ -1304,12 +1304,13 @@ pub mod pallet {
 				assert_noop!(
 					PhalaRegistry::register_worker_v2(
 						Origin::signed(1),
-						WorkerRegistrationInfo::<u64> {
+						WorkerRegistrationInfoV2::<u64> {
 							version: 1,
 							machine_id: Default::default(),
 							pubkey: worker_pubkey(1),
 							ecdh_pubkey: ecdh_pubkey(1),
 							genesis_block_hash: Default::default(),
+							para_id: 0,
 							features: vec![4, 1],
 							operator: Some(1),
 						},
@@ -1318,15 +1319,35 @@ pub mod pallet {
 					Error::<Test>::GenesisBlockHashRejected
 				);
 
+				// New registration with wrong para_id
+				assert_noop!(
+					PhalaRegistry::register_worker_v2(
+						Origin::signed(1),
+						WorkerRegistrationInfoV2::<u64> {
+							version: 1,
+							machine_id: Default::default(),
+							pubkey: worker_pubkey(1),
+							ecdh_pubkey: ecdh_pubkey(1),
+							genesis_block_hash: H256::repeat_byte(1),
+							para_id: 1,
+							features: vec![4, 1],
+							operator: Some(1),
+						},
+						None
+					),
+					Error::<Test>::ParachainIdMismatch
+				);
+
 				// New registration
 				assert_ok!(PhalaRegistry::register_worker_v2(
 					Origin::signed(1),
-					WorkerRegistrationInfo::<u64> {
+					WorkerRegistrationInfoV2::<u64> {
 						version: 1,
 						machine_id: Default::default(),
 						pubkey: worker_pubkey(1),
 						ecdh_pubkey: ecdh_pubkey(1),
 						genesis_block_hash: H256::repeat_byte(1),
+						para_id: 0,
 						features: vec![4, 1],
 						operator: Some(1),
 					},
@@ -1338,12 +1359,13 @@ pub mod pallet {
 				elapse_seconds(100);
 				assert_ok!(PhalaRegistry::register_worker_v2(
 					Origin::signed(1),
-					WorkerRegistrationInfo::<u64> {
+					WorkerRegistrationInfoV2::<u64> {
 						version: 1,
 						machine_id: Default::default(),
 						pubkey: worker_pubkey(1),
 						ecdh_pubkey: ecdh_pubkey(1),
 						genesis_block_hash: H256::repeat_byte(1),
+						para_id: 0,
 						features: vec![4, 1],
 						operator: Some(2),
 					},
@@ -1394,10 +1416,7 @@ pub mod pallet {
 					sample
 				));
 				assert_noop!(
-					PhalaRegistry::add_relaychain_genesis_block_hash(
-						Origin::root(),
-						sample
-					),
+					PhalaRegistry::add_relaychain_genesis_block_hash(Origin::root(), sample),
 					Error::<Test>::GenesisBlockHashAlreadyExists
 				);
 				assert_eq!(RelaychainGenesisBlockHashAllowList::<Test>::get().len(), 1);
@@ -1406,10 +1425,7 @@ pub mod pallet {
 					sample
 				));
 				assert_noop!(
-					PhalaRegistry::remove_relaychain_genesis_block_hash(
-						Origin::root(),
-						sample
-					),
+					PhalaRegistry::remove_relaychain_genesis_block_hash(Origin::root(), sample),
 					Error::<Test>::GenesisBlockHashNotFound
 				);
 				assert_eq!(RelaychainGenesisBlockHashAllowList::<Test>::get().len(), 0);

--- a/pallets/phala/src/registry.rs
+++ b/pallets/phala/src/registry.rs
@@ -849,7 +849,7 @@ pub mod pallet {
 				|key, mut value| {
 					let old_worker = OldWorkerInfo::<T::AccountId>::decode(&mut value);
 
-					match old_worker.clone() {
+					match old_worker {
 						Ok(w) => {
 							// log::info!("Decoded old {}: {:?}", hex::encode(key), w);
 							// log::info!(

--- a/standalone/justification-validate/src/validator.rs
+++ b/standalone/justification-validate/src/validator.rs
@@ -141,7 +141,7 @@ fn do_validate(
     let to = headers.last().unwrap().header.number;
 
     let mut state_roots = VecDeque::new();
-    let result = client.sync_header(headers, auth_change, &mut state_roots);
+    let result = client.sync_header(headers, auth_change, &mut state_roots, 0);
     if let Err(err) = result {
         error!("Failed to sync header from={from:?} to={to:?}: {err:?}");
         std::process::exit(1);

--- a/standalone/pherry/src/chain_client.rs
+++ b/standalone/pherry/src/chain_client.rs
@@ -110,7 +110,7 @@ pub async fn update_signer_nonce(api: &ParachainApi, signer: &mut SrSigner) -> R
     Ok(())
 }
 
-pub async fn search_proper_genesis_for_worker(
+pub async fn search_suitable_genesis_for_worker(
     api: &ParachainApi,
     pubkey: &[u8],
 ) -> Result<(BlockNumber, Vec<(Vec<u8>, Vec<u8>)>)> {

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -495,10 +495,11 @@ async fn batch_sync_block(
     let mut synced_blocks: BlockNumber = 0;
 
     let hdr_synced_to = if parachain {
-        next_para_headernum - 1
+        next_para_headernum
     } else {
-        next_headernum - 1
-    };
+        next_headernum
+    }
+    .saturating_sub(1);
     macro_rules! sync_blocks_to {
         ($to: expr) => {
             if next_blocknum <= $to {

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -217,7 +217,7 @@ pub struct Args {
     #[arg(long, short = 'r', value_enum, default_value_t = RaOption::Ias)]
     attestation_provider: RaOption,
 
-    /// Try to load chain state from the greatest block that the worker haven't registered at.
+    /// Try to load chain state from the latest block that the worker haven't registered at.
     #[arg(long)]
     fast_sync: bool,
 

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -220,6 +220,10 @@ pub struct Args {
     /// Try to load chain state from the greatest block that the worker haven't registered at.
     #[arg(long)]
     fast_sync: bool,
+
+    /// The prefered block to load the genesis state from.
+    #[arg(long)]
+    prefer_genesis_at_block: Option<BlockNumber>,
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]
@@ -1081,10 +1085,13 @@ async fn bridge(
                 let Ok(pubkey) = hex::decode(pubkey) else {
                     return Err(anyhow!("pRuntime returned an invalid pubkey"));
                 };
-                let (block_number, state) =
-                    chain_client::search_suitable_genesis_for_worker(&para_api, &pubkey)
-                        .await
-                        .context("Failed to search suitable genesis state for worker")?;
+                let (block_number, state) = chain_client::search_suitable_genesis_for_worker(
+                    &para_api,
+                    &pubkey,
+                    args.prefer_genesis_at_block,
+                )
+                .await
+                .context("Failed to search suitable genesis state for worker")?;
                 pr.load_chain_state(prpc::ChainState::new(block_number, state))
                     .await?;
             }

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -199,7 +199,6 @@ pub struct Args {
     #[arg(long, help = "Restart if number of rpc errors reaches the threshold")]
     restart_on_rpc_error_threshold: Option<u64>,
 
-
     #[arg(long, help = "URI to fetch cached headers from")]
     #[arg(default_value = "")]
     headers_cache_uri: String,
@@ -1083,9 +1082,9 @@ async fn bridge(
                     return Err(anyhow!("pRuntime returned an invalid pubkey"));
                 };
                 let (block_number, state) =
-                    chain_client::search_proper_genesis_for_worker(&para_api, &pubkey)
+                    chain_client::search_suitable_genesis_for_worker(&para_api, &pubkey)
                         .await
-                        .context("Failed to search proper genesis state")?;
+                        .context("Failed to search suitable genesis state for worker")?;
                 pr.load_chain_state(prpc::ChainState::new(block_number, state))
                     .await?;
             }

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -971,7 +971,7 @@ async fn try_load_chain_state(pr: &PrClient, para_api: &ParachainApi, args: &Arg
         return Err(anyhow!("pRuntime returned an invalid pubkey"));
     };
     let (block_number, state) = chain_client::search_suitable_genesis_for_worker(
-        &para_api,
+        para_api,
         &pubkey,
         args.prefer_genesis_at_block,
     )
@@ -1106,7 +1106,7 @@ async fn bridge(
         }
 
         if args.fast_sync {
-            try_load_chain_state(&pr, &para_api, &args).await?;
+            try_load_chain_state(&pr, &para_api, args).await?;
         }
     }
 

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -5167,6 +5167,7 @@ dependencies = [
  "rocket_cors",
  "serde",
  "serde_json",
+ "sgx-api-lite",
  "urlencoding",
  "version",
 ]

--- a/standalone/pruntime/Cargo.toml
+++ b/standalone/pruntime/Cargo.toml
@@ -39,6 +39,7 @@ phactory-pal = { path = "../../crates/phactory/pal" }
 phala-allocator = { path = "../../crates/phala-allocator" }
 phala-rocket-middleware = { path = "../../crates/phala-rocket-middleware" }
 phala-types = { path = "../../crates/phala-types", features = ["enable_serde", "sgx"] }
+sgx-api-lite = { path = "../../crates/sgx-api-lite" }
 
 [patch.crates-io]
 rocket = { version = "0.5.0-rc.2", git = "https://github.com/SergioBenitez/Rocket" }

--- a/standalone/pruntime/src/api_server.rs
+++ b/standalone/pruntime/src/api_server.rs
@@ -199,6 +199,7 @@ fn rpc_type(method: &str) -> RpcType {
             HttpFetch => Private,
             GetNetworkConfig => Private,
             LoadChainState => Private,
+            Stop => Private,
             // Public RPCs
             GetInfo => Public,
             ContractQuery => Public,
@@ -242,6 +243,7 @@ fn default_payload_limit_for_method(method: PhactoryAPIMethod) -> ByteUnit {
         CalculateContractId => 1.kibibytes(),
         GetNetworkConfig => 1.kibibytes(),
         LoadChainState => 500.mebibytes(),
+        Stop => 1.kibibytes(),
     }
 }
 

--- a/standalone/pruntime/src/api_server.rs
+++ b/standalone/pruntime/src/api_server.rs
@@ -198,6 +198,7 @@ fn rpc_type(method: &str) -> RpcType {
             ConfigNetwork => Private,
             HttpFetch => Private,
             GetNetworkConfig => Private,
+            LoadChainState => Private,
             // Public RPCs
             GetInfo => Public,
             ContractQuery => Public,
@@ -240,6 +241,7 @@ fn default_payload_limit_for_method(method: PhactoryAPIMethod) -> ByteUnit {
         UploadSidevmCode => 32.mebibytes(),
         CalculateContractId => 1.kibibytes(),
         GetNetworkConfig => 1.kibibytes(),
+        LoadChainState => 500.mebibytes(),
     }
 }
 

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<(), rocket::Error> {
         libc::mallopt(libc::M_ARENA_MAX, 1);
     }
 
-    let running_under_gramine = std::path::Path::new("/dev/attestation/user_report_data").exists();
+    let running_under_gramine = pal_gramine::is_gramine();
     let sealing_path;
     let storage_path;
     if running_under_gramine {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1292,6 +1292,7 @@ parameter_types! {
 	pub const NoneAttestationEnabled: bool = true;
 	pub const VerifyPRuntime: bool = false;
 	pub const VerifyRelaychainGenesisBlockHash: bool = false;
+	pub ParachainId: u32 = ParachainInfo::parachain_id().0;
 }
 
 impl pallet_registry::Config for Runtime {
@@ -1303,6 +1304,7 @@ impl pallet_registry::Config for Runtime {
 	type VerifyPRuntime = VerifyPRuntime;
 	type VerifyRelaychainGenesisBlockHash = VerifyRelaychainGenesisBlockHash;
 	type GovernanceOrigin = EnsureRootOrHalfCouncil;
+	type ParachainId = ParachainId;
 }
 impl pallet_mq::Config for Runtime {
 	type QueueNotifyConfig = msg_routing::MessageRouteConfig;


### PR DESCRIPTION
3 major changes in this PR:

- pRuntime: Added a new prpc::LoadChainState
    which can load a given block of chain state into pRuntime if the worker hasn't been registered at that block.

- pherry: Added a new option `--fast-sync`
    which finds a suitable chain state for pRuntime and loads it.

- Changed the previous mq message PRuntimeManagement to using chain storage as flags for version management.
    Because pRuntime can load from arbitrary block state, it can not rely on mq to maintain the states in pRuntime now.

Another change in this PR:

- By default, without `load_chain_state`, pruntime will require syncing para headers starting from `0`(`para_headernum = 0` in get_info, it was `1` before) to validate the genesis state. CC @krhougs 

Since the GK requires tracking all workers' states, initiating a GK instance is forbidden if the worker has loaded from a chain state.