### PR TITLE
Check parachain id in worker registering

### DIFF
--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -51,6 +51,8 @@ pub enum Error {
     CannotLoadStateAfterSyncing,
 }
 
+impl std::error::Error for Error {}
+
 pub trait BlockValidator {
     fn submit_finalized_headers(
         &mut self,

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -312,13 +312,13 @@ impl<Platform: pal::Platform> Phactory<Platform> {
 
         // check genesis block hash
         if genesis_block_hash != data.genesis_block_hash {
-            panic!(
+            anyhow::bail!(
                 "Genesis block hash mismatches with saved keys, expected {}",
                 data.genesis_block_hash
             );
         }
         if para_id != data.para_id {
-            panic!(
+            anyhow::bail!(
                 "Parachain id mismatches, saved: {}, in state: {para_id}",
                 data.para_id
             );

--- a/crates/phactory/src/storage.rs
+++ b/crates/phactory/src/storage.rs
@@ -75,6 +75,14 @@ mod storage_ext {
     }
 
     impl ChainStorage {
+        pub fn from_pairs(
+            pairs: impl Iterator<Item = (impl AsRef<[u8]>, impl AsRef<[u8]>)>,
+        ) -> Self {
+            let mut me = Self::default();
+            me.load(pairs);
+            me
+        }
+
         pub fn load(&mut self, pairs: impl Iterator<Item = (impl AsRef<[u8]>, impl AsRef<[u8]>)>) {
             self.trie_storage.load(pairs);
         }

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -553,6 +553,18 @@ pub struct WorkerRegistrationInfo<AccountId> {
 }
 
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
+pub struct WorkerRegistrationInfoV2<AccountId> {
+    pub version: u32,
+    pub machine_id: MachineId,
+    pub pubkey: WorkerPublicKey,
+    pub ecdh_pubkey: EcdhPublicKey,
+    pub genesis_block_hash: H256,
+    pub features: Vec<u32>,
+    pub operator: Option<AccountId>,
+    pub para_id: u32,
+}
+
+#[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
 pub enum VersionedWorkerEndpoints {
     V1(Vec<String>),
 }

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -537,6 +537,7 @@ pub struct ChallengeHandlerInfo<BlockNumber> {
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
 pub struct EncryptedWorkerKey {
     pub genesis_block_hash: H256,
+    pub para_id: u32,
     pub dev_mode: bool,
     pub encrypted_key: messaging::EncryptedKey,
 }

--- a/pallets/phala/src/fat_tokenomic/tests/mock.rs
+++ b/pallets/phala/src/fat_tokenomic/tests/mock.rs
@@ -115,6 +115,7 @@ impl registry::Config for Test {
 	type VerifyPRuntime = VerifyPRuntime;
 	type VerifyRelaychainGenesisBlockHash = VerifyRelaychainGenesisBlockHash;
 	type GovernanceOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type ParachainId = ConstU32<0>;
 }
 
 impl fat::Config for Test {

--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -131,6 +131,7 @@ impl registry::Config for Test {
 	type VerifyPRuntime = VerifyPRuntime;
 	type VerifyRelaychainGenesisBlockHash = VerifyRelaychainGenesisBlockHash;
 	type GovernanceOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type ParachainId = ConstU32<0>;
 }
 
 impl mining::Config for Test {

--- a/pallets/phala/src/registry.rs
+++ b/pallets/phala/src/registry.rs
@@ -1304,12 +1304,13 @@ pub mod pallet {
 				assert_noop!(
 					PhalaRegistry::register_worker_v2(
 						Origin::signed(1),
-						WorkerRegistrationInfo::<u64> {
+						WorkerRegistrationInfoV2::<u64> {
 							version: 1,
 							machine_id: Default::default(),
 							pubkey: worker_pubkey(1),
 							ecdh_pubkey: ecdh_pubkey(1),
 							genesis_block_hash: Default::default(),
+							para_id: 0,
 							features: vec![4, 1],
 							operator: Some(1),
 						},
@@ -1318,15 +1319,35 @@ pub mod pallet {
 					Error::<Test>::GenesisBlockHashRejected
 				);
 
+				// New registration with wrong para_id
+				assert_noop!(
+					PhalaRegistry::register_worker_v2(
+						Origin::signed(1),
+						WorkerRegistrationInfoV2::<u64> {
+							version: 1,
+							machine_id: Default::default(),
+							pubkey: worker_pubkey(1),
+							ecdh_pubkey: ecdh_pubkey(1),
+							genesis_block_hash: H256::repeat_byte(1),
+							para_id: 1,
+							features: vec![4, 1],
+							operator: Some(1),
+						},
+						None
+					),
+					Error::<Test>::ParachainIdMismatch
+				);
+
 				// New registration
 				assert_ok!(PhalaRegistry::register_worker_v2(
 					Origin::signed(1),
-					WorkerRegistrationInfo::<u64> {
+					WorkerRegistrationInfoV2::<u64> {
 						version: 1,
 						machine_id: Default::default(),
 						pubkey: worker_pubkey(1),
 						ecdh_pubkey: ecdh_pubkey(1),
 						genesis_block_hash: H256::repeat_byte(1),
+						para_id: 0,
 						features: vec![4, 1],
 						operator: Some(1),
 					},
@@ -1338,12 +1359,13 @@ pub mod pallet {
 				elapse_seconds(100);
 				assert_ok!(PhalaRegistry::register_worker_v2(
 					Origin::signed(1),
-					WorkerRegistrationInfo::<u64> {
+					WorkerRegistrationInfoV2::<u64> {
 						version: 1,
 						machine_id: Default::default(),
 						pubkey: worker_pubkey(1),
 						ecdh_pubkey: ecdh_pubkey(1),
 						genesis_block_hash: H256::repeat_byte(1),
+						para_id: 0,
 						features: vec![4, 1],
 						operator: Some(2),
 					},
@@ -1394,10 +1416,7 @@ pub mod pallet {
 					sample
 				));
 				assert_noop!(
-					PhalaRegistry::add_relaychain_genesis_block_hash(
-						Origin::root(),
-						sample
-					),
+					PhalaRegistry::add_relaychain_genesis_block_hash(Origin::root(), sample),
 					Error::<Test>::GenesisBlockHashAlreadyExists
 				);
 				assert_eq!(RelaychainGenesisBlockHashAllowList::<Test>::get().len(), 1);
@@ -1406,10 +1425,7 @@ pub mod pallet {
 					sample
 				));
 				assert_noop!(
-					PhalaRegistry::remove_relaychain_genesis_block_hash(
-						Origin::root(),
-						sample
-					),
+					PhalaRegistry::remove_relaychain_genesis_block_hash(Origin::root(), sample),
 					Error::<Test>::GenesisBlockHashNotFound
 				);
 				assert_eq!(RelaychainGenesisBlockHashAllowList::<Test>::get().len(), 0);

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1292,6 +1292,7 @@ parameter_types! {
 	pub const NoneAttestationEnabled: bool = true;
 	pub const VerifyPRuntime: bool = false;
 	pub const VerifyRelaychainGenesisBlockHash: bool = false;
+	pub ParachainId: u32 = ParachainInfo::parachain_id().0;
 }
 
 impl pallet_registry::Config for Runtime {
@@ -1303,6 +1304,7 @@ impl pallet_registry::Config for Runtime {
 	type VerifyPRuntime = VerifyPRuntime;
 	type VerifyRelaychainGenesisBlockHash = VerifyRelaychainGenesisBlockHash;
 	type GovernanceOrigin = EnsureRootOrHalfCouncil;
+	type ParachainId = ParachainId;
 }
 impl pallet_mq::Config for Runtime {
 	type QueueNotifyConfig = msg_routing::MessageRouteConfig;


### PR DESCRIPTION
Otherwise, it can register workers synced state from other parachain on phala's parachain.

Key points:
- Remember the `para_id` from the `genesis state` passed in by `init_runtime`.
- Seal the para_id into the `runtime-data.seal` and ensure it matches in later `init_runtime`. This make sure the identity key would not be used to sync data from other parachain.
- Use the para_id from the `genesis state` rather than get it from each block state to validate the para header.
- Ensure the para_id reported by pRuntime matches the para_id of the chain in `fn register_worker_v2`.