### PR TITLE
Add dylint with custom lint rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ overflow-checks = true
 
 [workspace]
 resolver = "2"
+metadata.dylint.libraries = [
+    { git = "https://github.com/Phala-Network/dylint-rules.git", pattern = "rules/*" },
+]
 
 exclude = [
 	"subxt",

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ test:
 clippy:
 	cargo clippy --tests
 	make clippy -C standalone/pruntime
+
+lint:
+	cargo dylint --all --workspace


### PR DESCRIPTION
**Summary**

This PR adds dylint support for this repository. The dylint rules are defined in a separate repository at https://github.com/Phala-Network/dylint-rules.

Currently, there is only one rule called `arithmetic_op` which warns against the usage of arithmetic operators.

**Why is it bad?**

Using arithmetic operators can cause arithmetic overflows, which can be a bad situation
in a blockchain infrastructure or smart contract.
`ink!` framework forces overflow checks to be enabled in build scripts, but the pruntime
does not.
Regardless of whether the framework enables checks, we should always be careful when doing
arithmetic calculations.

**Example:**

Instead of:
```rust
// example code where a warning is issued
let released = original_stake - slashed;
```
Prefer:
```rust
// example code that does not raise a warning
let released = original_stake.saturating_sub(slashed);
```
Run `make lint` in the project root, it would produce some warnings like:
<img width="453" alt="image" src="https://user-images.githubusercontent.com/6442159/205799072-a65b09c1-4e21-47be-91e5-e25ec90102fb.png">

which helps us to review the arithmetic operator usage.

However, because the lint rule produces a lot of noise at the moment, we don't force apply it in the CI.