### PR TITLE
Fix overflow in FixedPointConvert

### DIFF
--- a/pallets/phala/src/utils/balance_convert.rs
+++ b/pallets/phala/src/utils/balance_convert.rs
@@ -42,6 +42,7 @@ mod tests {
 
 	#[test]
 	fn max_supply_not_overflow() {
+		#[allow(clippy::inconsistent_digit_grouping)]
 		let balance = 1_000_000_000__000_000_000_000_u128;
 		let f = balance.to_fixed();
 		assert_eq!(f.to_string(), "1000000000");

--- a/pallets/phala/src/utils/balance_convert.rs
+++ b/pallets/phala/src/utils/balance_convert.rs
@@ -35,3 +35,16 @@ where
 {
 	FixedPointConvert::from_fixed(&(x.to_fixed() / y))
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn max_supply_not_overflow() {
+		let balance = 1_000_000_000__000_000_000_000_u128;
+		let f = balance.to_fixed();
+		assert_eq!(f.to_string(), "1000000000");
+		assert_eq!(u128::from_fixed(&f), balance);
+	}
+}

--- a/pallets/phala/src/utils/balance_convert.rs
+++ b/pallets/phala/src/utils/balance_convert.rs
@@ -1,6 +1,4 @@
-use fixed::types::U64F64;
-use fixed_macro::fixed;
-use U64F64 as FixedPoint;
+use fixed::types::{U64F64 as FixedPoint, U80F48};
 
 pub trait FixedPointConvert {
 	fn from_bits(bits: u128) -> Self;
@@ -8,7 +6,7 @@ pub trait FixedPointConvert {
 	fn to_fixed(&self) -> FixedPoint;
 }
 
-const FIXED_1E12: FixedPoint = fixed!(1_000_000_000_000: U64F64);
+const PHA: u128 = 1_000_000_000_000;
 
 // 12 decimals u128 conversion
 impl FixedPointConvert for u128 {
@@ -16,11 +14,11 @@ impl FixedPointConvert for u128 {
 		Self::from_fixed(&FixedPoint::from_bits(bits))
 	}
 	fn from_fixed(v: &FixedPoint) -> Self {
-		v.saturating_mul(FIXED_1E12).to_num()
+		U80F48::unwrapped_from_num(*v).unwrapped_mul_int(PHA).to_num()
 	}
 	fn to_fixed(&self) -> FixedPoint {
-		let v = FixedPoint::from_num(*self);
-		v.saturating_div(FIXED_1E12)
+		let v = U80F48::unwrapped_from_num(*self);
+		FixedPoint::unwrapped_from_num(v.unwrapped_div_int(PHA))
 	}
 }
 


### PR DESCRIPTION
A simpler version of #1093 
After the conversion, U64F64 itself can store `1.8*10^19` PHA. It should be enough for other calculations.

@h4x3rotab How do you think about this approach?
