### PR TITLE
Add legacy rewards features and remove locks features

### DIFF
--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -520,10 +520,8 @@ pub mod pallet {
 			let mut record_vec = vec![];
 			let mut i = 0;
 			for ((cid, nft_id), _) in iter.by_ref() {
-				if cid >= RESERVE_CID_START {
-					if !pallet_rmrk_core::pallet::Nfts::<T>::contains_key(cid, nft_id) {
+				if cid >= RESERVE_CID_START && !pallet_rmrk_core::pallet::Nfts::<T>::contains_key(cid, nft_id) {
 						record_vec.push((cid, nft_id));
-					}
 				}
 				i += 1;
 				if i > max_iterations {
@@ -537,7 +535,7 @@ pub mod pallet {
 			}
 
 			for (cid, nft_id) in record_vec.iter() {
-				let _ = pallet_rmrk_core::pallet::Lock::<T>::remove((cid, nft_id));
+				pallet_rmrk_core::pallet::Lock::<T>::remove((cid, nft_id));
 			}
 
 			Ok(())
@@ -961,7 +959,7 @@ pub mod pallet {
 				Error::<T>::BurnNftFailed,
 			);
 			Self::remove_properties(cid, nft_id);
-			let _ = pallet_rmrk_core::pallet::Lock::<T>::remove((cid, nft_id));
+			pallet_rmrk_core::pallet::Lock::<T>::remove((cid, nft_id));
 			Ok(())
 		}
 

--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -90,10 +90,9 @@ pub mod pallet {
 	#[pallet::getter(fn next_nft_id)]
 	pub type NextNftId<T: Config> = StorageMap<_, Twox64Concat, CollectionId, NftId, ValueQuery>;
 
-	type PropertyKey<S> = (
+	type LockKey = (
 		CollectionId,
-		Option<NftId>,
-		BoundedVec<u8, <S as pallet_uniques::Config>::KeyLimit>,
+		NftId,
 	);
 
 	type ShareTransferProxy<T> = (
@@ -105,7 +104,7 @@ pub mod pallet {
 	);
 
 	#[pallet::storage]
-	pub type PropertyIterateStartPos<T> = StorageValue<_, Option<PropertyKey<T>>, ValueQuery>;
+	pub type LockIterateStartPos<T> = StorageValue<_, Option<LockKey>, ValueQuery>;
 
 	/// The number of total pools
 	#[pallet::storage]
@@ -498,34 +497,32 @@ pub mod pallet {
 
 		#[pallet::weight(0)]
 		#[frame_support::transactional]
-		pub fn reset_iter_pos(origin: OriginFor<T>) -> DispatchResult {
+		pub fn reset_lock_iter_pos(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::ensure_migration_root(who)?;
-			PropertyIterateStartPos::<T>::put(None::<PropertyKey<T>>);
+			LockIterateStartPos::<T>::put(None::<LockKey>);
 			Ok(())
 		}
 
 		#[pallet::weight(0)]
-		pub fn remove_unused_property(origin: OriginFor<T>, max_iterations: u32) -> DispatchResult {
+		pub fn remove_unused_lock(origin: OriginFor<T>, max_iterations: u32) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::ensure_migration_root(who)?;
-			let last_pos = PropertyIterateStartPos::<T>::get();
+			let last_pos = LockIterateStartPos::<T>::get();
 			let mut iter = match last_pos {
 				Some(pos) => {
 					let key: Vec<u8> =
-						pallet_rmrk_core::pallet::Properties::<T>::hashed_key_for(pos);
-					pallet_rmrk_core::pallet::Properties::<T>::iter_from(key)
+						pallet_rmrk_core::pallet::Lock::<T>::hashed_key_for(pos);
+					pallet_rmrk_core::pallet::Lock::<T>::iter_from(key)
 				}
-				None => pallet_rmrk_core::pallet::Properties::<T>::iter(),
+				None => pallet_rmrk_core::pallet::Lock::<T>::iter(),
 			};
 			let mut record_vec = vec![];
 			let mut i = 0;
-			for ((cid, maybe_nft_id, key), _) in iter.by_ref() {
+			for ((cid, nft_id), _) in iter.by_ref() {
 				if cid >= RESERVE_CID_START {
-					if let Some(nft_id) = maybe_nft_id {
-						if !pallet_rmrk_core::pallet::Nfts::<T>::contains_key(cid, nft_id) {
-							record_vec.push((cid, nft_id, key));
-						}
+					if !pallet_rmrk_core::pallet::Nfts::<T>::contains_key(cid, nft_id) {
+						record_vec.push((cid, nft_id));
 					}
 				}
 				i += 1;
@@ -533,18 +530,14 @@ pub mod pallet {
 					break;
 				}
 			}
-			if let Some(((cid, maybe_nft_id, key), _)) = iter.next() {
-				PropertyIterateStartPos::<T>::put(Some((cid, maybe_nft_id, key)));
+			if let Some(((cid, nft_id), _)) = iter.next() {
+				LockIterateStartPos::<T>::put(Some((cid, nft_id)));
 			} else {
-				PropertyIterateStartPos::<T>::put(None::<PropertyKey<T>>);
+				LockIterateStartPos::<T>::put(None::<LockKey>);
 			}
 
-			for (cid, nft_id, key) in record_vec.iter() {
-				let _ = pallet_rmrk_core::Pallet::<T>::do_remove_property(
-					*cid,
-					Some(*nft_id),
-					key.clone(),
-				);
+			for (cid, nft_id) in record_vec.iter() {
+				let _ = pallet_rmrk_core::pallet::Lock::<T>::remove((cid, nft_id));
 			}
 
 			Ok(())
@@ -968,6 +961,7 @@ pub mod pallet {
 				Error::<T>::BurnNftFailed,
 			);
 			Self::remove_properties(cid, nft_id);
+			let _ = pallet_rmrk_core::pallet::Lock::<T>::remove((cid, nft_id));
 			Ok(())
 		}
 

--- a/pallets/phala/src/compute/stake_pool_v2.rs
+++ b/pallets/phala/src/compute/stake_pool_v2.rs
@@ -83,6 +83,9 @@ pub mod pallet {
 	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
+
+	#[pallet::storage]
+	pub type LegacyRewards<T: Config> = StorageMap<_, Twox64Concat, (T::AccountId, u64), BalanceOf<T>>;
 	/// Mapping from workers to the pool they belong to
 	///
 	/// The map entry lasts from `add_worker()` to `remove_worker()` or force unbinding.
@@ -309,6 +312,8 @@ pub mod pallet {
 		WorkerIsNotReady,
 
 		LockAccountStakeError,
+
+		NoLegacyRewardToClaim,
 	}
 
 	#[pallet::call]
@@ -540,6 +545,33 @@ pub mod pallet {
 			}
 			Self::deposit_event(Event::<T>::PoolCommissionSet { pid, commission });
 
+			Ok(())
+		}
+
+		#[pallet::weight(0)]
+		pub fn claim_legacy_rewards(
+			origin: OriginFor<T>,
+			pid: u64,
+			target: T::AccountId,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			let rewards = LegacyRewards::<T>::take((who, pid)).ok_or(Error::<T>::NoLegacyRewardToClaim)?;
+			computation::Pallet::<T>::withdraw_subsidy_pool(&target, rewards)
+				.or(Err(Error::<T>::InternalSubsidyPoolCannotWithdraw))?;
+			Ok(())
+		}
+
+		#[pallet::weight(0)]
+		pub fn backfill_transfer_shares(
+			origin: OriginFor<T>,
+			input: Vec<(T::AccountId, u64, BalanceOf<T>)>,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			base_pool::Pallet::<T>::ensure_migration_root(who)?;
+
+			for (account_id, pid, balance) in input.iter() {
+				LegacyRewards::<T>::insert((account_id.clone(), *pid), *balance);
+			}
 			Ok(())
 		}
 

--- a/pallets/phala/src/compute/stake_pool_v2.rs
+++ b/pallets/phala/src/compute/stake_pool_v2.rs
@@ -562,7 +562,7 @@ pub mod pallet {
 		}
 
 		#[pallet::weight(0)]
-		pub fn backfill_transfer_shares(
+		pub fn push_legacy_rewards_data(
 			origin: OriginFor<T>,
 			input: Vec<(T::AccountId, u64, BalanceOf<T>)>,
 		) -> DispatchResult {

--- a/pallets/phala/src/compute/stake_pool_v2.rs
+++ b/pallets/phala/src/compute/stake_pool_v2.rs
@@ -549,6 +549,7 @@ pub mod pallet {
 		}
 
 		#[pallet::weight(0)]
+		#[frame_support::transactional]
 		pub fn claim_legacy_rewards(
 			origin: OriginFor<T>,
 			pid: u64,
@@ -562,7 +563,7 @@ pub mod pallet {
 		}
 
 		#[pallet::weight(0)]
-		pub fn push_legacy_rewards_data(
+		pub fn backfill_add_missing_reward(
 			origin: OriginFor<T>,
 			input: Vec<(T::AccountId, u64, BalanceOf<T>)>,
 		) -> DispatchResult {


### PR DESCRIPTION
**Add legacy rewards features**
Introducing new storage and two functions In order to fix the calculation mistake when migrating legacy stake rewards.
1.push_legacy_rewards_data
Push legacy rewards data calculated off-chain into the on-chain storage so that user could claim their rewards further.
2.claim_legacy_rewards
Allow user to claim their legacy rewards into the assigned account.
**Remove locks features**
Fix on-chain storage boost problem by remove locks in function burn_nft and providing historical data remove functions
1.remove_unused_lock
iterate the `Lock` storage map and remove items that not belongs to any nft alive, has a max iteration limitation.
