### PR TITLE
[subrpc] Make storage key computing more generic

### DIFF
--- a/crates/pink-libs/subrpc/src/hasher.rs
+++ b/crates/pink-libs/subrpc/src/hasher.rs
@@ -1,0 +1,63 @@
+use sp_core_hashing::*;
+
+/// Hasher to use to hash keys to insert to storage.
+pub trait Hasher: 'static {
+    type Output: AsRef<[u8]>;
+    fn hash(x: &[u8]) -> Self::Output;
+}
+
+pub struct Twox64Concat;
+impl Hasher for Twox64Concat {
+    type Output = Vec<u8>;
+    fn hash(x: &[u8]) -> Vec<u8> {
+        twox_64(x)
+            .iter()
+            .chain(x.iter())
+            .cloned()
+            .collect::<Vec<_>>()
+    }
+}
+
+pub struct Blake2_128Concat;
+impl Hasher for Blake2_128Concat {
+    type Output = Vec<u8>;
+    fn hash(x: &[u8]) -> Vec<u8> {
+        blake2_128(x)
+            .iter()
+            .chain(x.iter())
+            .cloned()
+            .collect::<Vec<_>>()
+    }
+}
+
+pub struct Blake2_128;
+impl Hasher for Blake2_128 {
+    type Output = [u8; 16];
+    fn hash(x: &[u8]) -> [u8; 16] {
+        blake2_128(x)
+    }
+}
+
+pub struct Blake2_256;
+impl Hasher for Blake2_256 {
+    type Output = [u8; 32];
+    fn hash(x: &[u8]) -> [u8; 32] {
+        blake2_256(x)
+    }
+}
+
+pub struct Twox128;
+impl Hasher for Twox128 {
+    type Output = [u8; 16];
+    fn hash(x: &[u8]) -> [u8; 16] {
+        twox_128(x)
+    }
+}
+
+pub struct Twox256;
+impl Hasher for Twox256 {
+    type Output = [u8; 32];
+    fn hash(x: &[u8]) -> [u8; 32] {
+        twox_256(x)
+    }
+}

--- a/crates/pink-libs/subrpc/src/lib.rs
+++ b/crates/pink-libs/subrpc/src/lib.rs
@@ -13,6 +13,7 @@ use pink_extension::chain_extension::{signing, SigType};
 use pink_json as json;
 use scale::{Compact, Decode, Encode};
 
+mod hasher;
 mod objects;
 mod primitives;
 mod rpc;

--- a/crates/pink-libs/subrpc/src/lib.rs
+++ b/crates/pink-libs/subrpc/src/lib.rs
@@ -13,7 +13,7 @@ use pink_extension::chain_extension::{signing, SigType};
 use pink_json as json;
 use scale::{Compact, Decode, Encode};
 
-mod hasher;
+pub mod hasher;
 mod objects;
 mod primitives;
 mod rpc;

--- a/crates/pink-libs/subrpc/src/storage.rs
+++ b/crates/pink-libs/subrpc/src/storage.rs
@@ -1,10 +1,11 @@
+use crate::hasher::{Hasher, Twox128};
 use alloc::vec::Vec;
 
 /// Returns the prefix of an storage item
 pub fn storage_prefix(pallet_name: &str, storage_name: &str) -> [u8; 32] {
     // Copied from Substrate function: `storage_prefix()`
-    let pallet_hash = sp_core_hashing::twox_128(pallet_name.as_bytes());
-    let storage_hash = sp_core_hashing::twox_128(storage_name.as_bytes());
+    let pallet_hash = Twox128::hash(pallet_name.as_bytes());
+    let storage_hash = Twox128::hash(storage_name.as_bytes());
 
     let mut final_key = [0u8; 32];
     final_key[..16].copy_from_slice(&pallet_hash);
@@ -12,9 +13,9 @@ pub fn storage_prefix(pallet_name: &str, storage_name: &str) -> [u8; 32] {
     final_key
 }
 
-/// Returns the storage key of a storage map entry (with Blake2_128 hash)
-pub fn storage_map_blake2_128_prefix(prefix: &[u8], key1: &[u8]) -> Vec<u8> {
-    let key1_hashed = sp_core_hashing::blake2_128(key1);
+/// Returns the storage key of a storage map entry
+pub fn storage_map_prefix<H: Hasher>(prefix: &[u8], key1: &[u8]) -> Vec<u8> {
+    let key1_hashed = H::hash(key1);
 
     let mut final_key = Vec::with_capacity(prefix.len() + key1_hashed.as_ref().len() + key1.len());
     final_key.extend_from_slice(prefix);
@@ -23,10 +24,14 @@ pub fn storage_map_blake2_128_prefix(prefix: &[u8], key1: &[u8]) -> Vec<u8> {
     final_key
 }
 
-/// Returns the storage key of a storage double map entry (with dual Blake2_128 hash)
-pub fn storage_double_map_blake2_128_prefix(prefix: &[u8], key1: &[u8], key2: &[u8]) -> Vec<u8> {
-    let key1_hashed = sp_core_hashing::blake2_128(key1);
-    let key2_hashed = sp_core_hashing::blake2_128(key2);
+/// Returns the storage key of a storage double map entry
+pub fn storage_double_map_prefix<H1: Hasher, H2: Hasher>(
+    prefix: &[u8],
+    key1: &[u8],
+    key2: &[u8],
+) -> Vec<u8> {
+    let key1_hashed = H1::hash(key1);
+    let key2_hashed = H2::hash(key2);
 
     let mut final_key = Vec::with_capacity(
         prefix.len()
@@ -46,13 +51,14 @@ pub fn storage_double_map_blake2_128_prefix(prefix: &[u8], key1: &[u8], key2: &[
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hasher::Blake2_128;
     #[test]
     fn storage_key_is_correct() {
         use scale::Encode;
         let map_key =
             hex_literal::hex!("0202020202020202020202020202020202020202020202020202020202020202")
                 .to_vec();
-        let key = storage_double_map_blake2_128_prefix(
+        let key = storage_double_map_prefix::<Blake2_128, Blake2_128>(
             &storage_prefix("PhatRollupAnchor", "States")[..],
             &hex_literal::hex!("0101010101010101010101010101010101010101010101010101010101010101"),
             &map_key.encode(),


### PR DESCRIPTION
# ❗️Breaking Changes❗️

The following interfaces have changed:
`pub fn storage_map_blake2_128_prefix(prefix: &[u8], key1: &[u8]) -> Vec<u8>` and `storage_double_map_blake2_128_prefix(prefix: &[u8], key1: &[u8], key2: &[u8])` are all deprecated, they have been replaced by a group of generic functions: `pub fn storage_map_prefix<H: Hasher>(prefix: &[u8], key1: &[u8]) -> Vec<u8>` and `pub fn storage_double_map_prefix<H1: Hasher, H2: Hasher>(
    prefix: &[u8],
    key1: &[u8],
    key2: &[u8],
) -> Vec<u8>`.

In this way, we can specify any supported hash functions we want to compute the storage key

