### PR TITLE
FIX process_withdraw_queue panic issue

### DIFF
--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -371,6 +371,7 @@ impl stake_pool_v2::Config for Test {
 
 parameter_types! {
 	pub const InitialPriceCheckPoint: Balance = DOLLARS;
+	pub const WPhaMinBalance: Balance = CENTS;
 }
 
 impl vault::Config for Test {
@@ -381,6 +382,7 @@ impl vault::Config for Test {
 impl base_pool::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type MigrationAccountId = ConstU64<1234>;
+	type WPhaMinBalance = WPhaMinBalance;
 }
 
 impl stake_pool::Config for Test {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1399,6 +1399,7 @@ parameter_types! {
     pub const MaxPriorities: u32 = 3;
     pub const CollectionSymbolLimit: u32 = 100;
     pub const MaxResourcesOnMint: u32 = 100;
+    pub const WPhaMinBalance: Balance = CENTS;
 }
 impl pallet_rmrk_core::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
@@ -1449,6 +1450,7 @@ impl Get<AccountId32> for MigrationAccount {
 impl pallet_base_pool::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type MigrationAccountId = MigrationAccount;
+    type WPhaMinBalance = WPhaMinBalance;
 }
 
 parameter_types! {


### PR DESCRIPTION
**background**
The panic occurred when the withdrawal amount was less than the transfer function's min balance.
**fix**
Introducing min_balance const by runtime config, and only when the transfer amount is larger than the min balance, the transfer would actually happen; if not, we will just regard it as dust and erase it. And the free balances of the pool will also be checked in the same way when iterating withdrawal procession instead of the former check dust.