### PR TITLE
Backport TrieLayoutV1 to pruntime-v0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethbloom"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,6 +3630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
 ]
 
 [[package]]
@@ -6572,8 +6608,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if 1.0.0",
+ "ethereum-types",
  "hashbrown 0.11.2",
  "impl-trait-for-tuples",
+ "lru 0.6.6",
  "parity-util-mem-derive",
  "parking_lot",
  "primitive-types",
@@ -7210,10 +7248,13 @@ dependencies = [
 name = "phala-trie-storage"
 version = "0.1.0"
 dependencies = [
+ "hash-db",
  "hash256-std-hasher",
  "hex",
  "impl-serde",
  "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
  "serde",
  "serde_json",
  "sp-application-crypto",
@@ -7222,6 +7263,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie 4.0.0-dev",
+ "trie-db 0.23.1",
 ]
 
 [[package]]
@@ -7616,6 +7658,7 @@ checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -8319,6 +8362,16 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes 1.1.0",
+ "rustc-hex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,12 +3248,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -3623,7 +3632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
  "serde",
 ]
 
@@ -4966,7 +4975,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -4975,7 +4984,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c748cfe47cb8da225c37595b3108bea1c198c84aaae8ea0ba76d01dda9fc803"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -5122,7 +5131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de006e09d04fc301a5f7e817b75aa49801c4479a8af753764416b085337ddcc5"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.11.2",
  "parity-util-mem",
 ]
 
@@ -5419,7 +5428,7 @@ dependencies = [
  "hash256-std-hasher",
  "sp-core",
  "sp-runtime",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
 ]
 
 [[package]]
@@ -5490,7 +5499,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "wat",
 ]
 
@@ -6292,7 +6301,7 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-std",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
 ]
 
 [[package]]
@@ -6563,7 +6572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown",
+ "hashbrown 0.11.2",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot",
@@ -6855,7 +6864,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-trie",
+ "sp-trie 4.0.0",
  "surf",
  "thiserror",
  "webpki 0.21.4",
@@ -7016,7 +7025,7 @@ dependencies = [
  "sp-tracing",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-cli",
@@ -7212,7 +7221,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
 ]
 
 [[package]]
@@ -8785,7 +8794,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-storage",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "substrate-prometheus-endpoint",
 ]
 
@@ -8810,7 +8819,7 @@ dependencies = [
  "sp-database",
  "sp-runtime",
  "sp-state-machine",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
 ]
 
 [[package]]
@@ -8968,7 +8977,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-runtime-interface",
  "sp-tasks",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "sp-version",
  "sp-wasm-interface",
  "wasmi",
@@ -9347,7 +9356,7 @@ dependencies = [
  "sp-tracing",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "sp-version",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -9386,7 +9395,7 @@ dependencies = [
  "sp-state-machine",
  "sp-storage",
  "sp-tracing",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "substrate-test-runtime",
  "substrate-test-runtime-client",
  "tempfile",
@@ -10375,7 +10384,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-tracing",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "sp-wasm-interface",
  "tracing",
  "tracing-core",
@@ -10572,11 +10581,11 @@ dependencies = [
  "sp-externalities",
  "sp-panic-handler",
  "sp-std",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "thiserror",
  "tracing",
- "trie-db",
- "trie-root",
+ "trie-db 0.22.6",
+ "trie-root 0.16.0",
 ]
 
 [[package]]
@@ -10653,7 +10662,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-std",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
 ]
 
 [[package]]
@@ -10666,8 +10675,22 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-std",
- "trie-db",
- "trie-root",
+ "trie-db 0.22.6",
+ "trie-root 0.16.0",
+]
+
+[[package]]
+name = "sp-trie"
+version = "4.0.0"
+dependencies = [
+ "hash-db",
+ "memory-db",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-std",
+ "trie-db 0.23.1",
+ "trie-root 0.17.0",
 ]
 
 [[package]]
@@ -11131,10 +11154,10 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-transaction-pool",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "sp-version",
  "substrate-wasm-builder",
- "trie-db",
+ "trie-db 0.22.6",
 ]
 
 [[package]]
@@ -11786,7 +11809,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eac131e334e81b6b3be07399482042838adcd7957aa0010231d0813e39e02fa"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.11.2",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.12.3",
  "log",
  "rustc-hex",
  "smallvec",
@@ -11797,6 +11833,15 @@ name = "trie-root"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "652931506d2c1244d7217a70b99f56718a7b4161b37f04e7cd868072a99f68cd"
+dependencies = [
+ "hash-db",
+]
+
+[[package]]
+name = "trie-root"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a36c5ca3911ed3c9a5416ee6c679042064b93fc637ded67e25f92e68d783891"
 dependencies = [
  "hash-db",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
 	"crates/phaxt",
 	"crates/pink/pink-extension/macro",
 	"crates/phala-serde-more",
+	"crates/sp-trie",
 	"pallets/phala",
 	"pallets/phala/mq-runtime-api",
 	"pallets/bridge",

--- a/crates/phactory/Cargo.toml
+++ b/crates/phactory/Cargo.toml
@@ -62,7 +62,7 @@ derive_more = "0.99.0"
 hash-db = { version = "0.15.2", default-features = false }
 num = { package = "num-traits", version = "0.2", default-features = false }
 finality-grandpa = { version = "0.16", default-features = false, features = ["derive-codec"] }
-trie = { package = "sp-trie", path = "../../substrate/primitives/trie" }
+trie = { package = "sp-trie", path = "../sp-trie" }
 frame-system = { package = "frame-system", path = "../../substrate/frame/system" }
 sp-finality-grandpa = { package = "sp-finality-grandpa", path = "../../substrate/primitives/finality-grandpa" }
 sp-application-crypto = { package = "sp-application-crypto", path = "../../substrate/primitives/application-crypto" }

--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -211,7 +211,7 @@ pub mod cluster {
                 .clusters
                 .entry(cluster_id.clone())
                 .or_insert_with(|| Cluster {
-                    storage: Default::default(),
+                    storage: pink::Storage::new_empty(),
                     contracts: Default::default(),
                     key: contract_key.clone(),
                 });

--- a/crates/phala-trie-storage/Cargo.toml
+++ b/crates/phala-trie-storage/Cargo.toml
@@ -8,13 +8,17 @@ homepage = "https://phala.network/"
 repository = "https://github.com/Phala-Network/phala-blockchain"
 
 [dependencies]
-parity-scale-codec = { version = "2.0.0", default-features = false }
+parity-scale-codec = { version = "2", default-features = false }
+scale-info = { version = "1", default-features = false }
 sp-core = { path = "../../substrate/primitives/core", default-features = false, features = ["full_crypto"] }
 sp-trie = { path = "../../substrate/primitives/trie", default-features = false }
 sp-io   = { path = "../../substrate/primitives/io", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
 sp-state-machine = { path = "../../substrate/primitives/state-machine", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
+hash-db = "0.15.2"
+trie-db = "0.23.0"
+parity-util-mem = "0.10"
 
 [dev-dependencies]
 sp-runtime = { path = "../../substrate/primitives/runtime", default-features = false }

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -1,20 +1,24 @@
-#![no_std]
-
 extern crate alloc;
 
 #[cfg(feature = "serde")]
 pub mod ser;
+
+mod memdb;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use core::iter::FromIterator;
 
 use alloc::vec::Vec;
 
 use parity_scale_codec::Codec;
-use serde::{Serialize, Serializer, Deserializer, Deserialize};
 use sp_core::storage::ChildInfo;
 use sp_core::Hasher;
 use sp_state_machine::{Backend, TrieBackend};
-use sp_trie::{trie_types::TrieDBMut, MemoryDB, TrieMut, HashDBT};
+use sp_trie::{trie_types::TrieDBMut, TrieMut};
+
+pub use memdb::GenericMemoryDB as MemoryDB;
 
 /// Storage key.
 pub type StorageKey = Vec<u8>;
@@ -28,14 +32,24 @@ pub type StorageCollection = Vec<(StorageKey, Option<StorageValue>)>;
 /// In memory arrays of storage values for multiple child tries.
 pub type ChildStorageCollection = Vec<(StorageKey, StorageCollection)>;
 
-pub struct TrieStorage<H: Hasher>(TrieBackend<MemoryDB<H>, H>);
+pub type InMemoryBackend<H> = TrieBackend<MemoryDB<H>, H>;
+pub struct TrieStorage<H: Hasher>(InMemoryBackend<H>)
+where
+    H::Out: Ord;
+
+pub fn new_backend<H: Hasher>() -> InMemoryBackend<H>
+where
+    H::Out: Codec + Ord,
+{
+    TrieBackend::new(Default::default(), Default::default())
+}
 
 impl<H: Hasher> Default for TrieStorage<H>
 where
-    H::Out: Codec,
+    H::Out: Codec + Ord,
 {
     fn default() -> Self {
-        Self(TrieBackend::new(Default::default(), Default::default()))
+        Self(new_backend())
     }
 }
 
@@ -43,7 +57,7 @@ pub fn load_trie_backend<H: Hasher>(
     pairs: impl Iterator<Item = (impl AsRef<[u8]>, impl AsRef<[u8]>)>,
 ) -> TrieBackend<MemoryDB<H>, H>
 where
-    H::Out: Codec,
+    H::Out: Codec + Ord,
 {
     let mut root = Default::default();
     let mut mdb = Default::default();
@@ -58,41 +72,47 @@ where
     TrieBackend::new(mdb, root)
 }
 
+#[cfg(feature = "serde")]
 pub fn serialize_trie_backend<H: Hasher, S>(
     trie: &TrieBackend<MemoryDB<H>, H>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
-    H::Out: Codec + Serialize,
+    H::Out: Codec + Serialize + Ord,
     S: Serializer,
 {
     let root = trie.root();
-    let kvs: Vec<_> = trie
-        .backend_storage()
-        .clone()
-        .drain()
-        .into_iter()
-        .map(|it| it.1)
-        .collect();
-    (root, kvs).serialize(serializer)
+    let kvs = trie.backend_storage();
+    (root, ser::SerAsSeq(kvs)).serialize(serializer)
 }
 
+#[cfg(feature = "serde")]
 pub fn deserialize_trie_backend<'de, H: Hasher, De>(
     deserializer: De,
 ) -> Result<TrieBackend<MemoryDB<H>, H>, De::Error>
 where
-    H::Out: Codec + Deserialize<'de>,
+    H::Out: Codec + Deserialize<'de> + Ord,
     De: Deserializer<'de>,
 {
     let (root, kvs): (H::Out, Vec<(Vec<u8>, i32)>) = Deserialize::deserialize(deserializer)?;
-    let mut mdb = MemoryDB::default();
-    for value in kvs {
-        for _ in 0..value.1 {
-            mdb.insert((&[], None), &value.0);
-        }
-    }
+    let mdb = MemoryDB::from_inner(
+        kvs.into_iter()
+            .map(|(data, rc)| (H::hash(data.as_ref()), (data, rc)))
+            .collect(),
+    );
     let backend = TrieBackend::new(mdb, root);
     Ok(backend)
+}
+
+pub fn clone_trie_backend<H: Hasher>(
+    trie: &TrieBackend<MemoryDB<H>, H>,
+) -> TrieBackend<MemoryDB<H>, H>
+where
+    H::Out: Codec + Ord,
+{
+    let root = trie.root();
+    let mdb = trie.backend_storage().clone();
+    TrieBackend::new(mdb, *root)
 }
 
 impl<H: Hasher> TrieStorage<H>
@@ -140,12 +160,7 @@ where
         let _ = core::mem::replace(&mut self.0, TrieBackend::new(storage, root));
     }
 
-    pub fn purge(&mut self) {
-        let root = *self.0.root();
-        let mut storage = core::mem::take(self).0.into_storage();
-        storage.purge();
-        let _ = core::mem::replace(&mut self.0, TrieBackend::new(storage, root));
-    }
+    pub fn purge(&mut self) {}
 
     /// Return the state root hash
     pub fn root(&self) -> &H::Out {
@@ -171,6 +186,10 @@ where
                 (key, value)
             })
             .collect()
+    }
+
+    pub fn as_trie_backend(&self) -> &InMemoryBackend<H> {
+        &self.0
     }
 }
 

--- a/crates/phala-trie-storage/src/memdb.rs
+++ b/crates/phala-trie-storage/src/memdb.rs
@@ -1,0 +1,772 @@
+//! Reference-counted memory-based `HashDB` implementation.
+use hash_db::{
+    AsHashDB, AsPlainDB, HashDB, HashDBRef, Hasher as KeyHasher, PlainDB, PlainDBRef, Prefix,
+};
+use parity_util_mem::{malloc_size, MallocSizeOf, MallocSizeOfOps};
+pub(crate) use std::collections::btree_map::{BTreeMap as HashMap, Entry};
+use std::{borrow::Borrow, cmp::Eq, hash, marker::PhantomData, mem};
+
+use sp_state_machine::{backend::Consolidate, DefaultError, TrieBackendStorage};
+use trie_db::DBValue;
+
+pub trait MaybeDebug: std::fmt::Debug {}
+impl<T: std::fmt::Debug> MaybeDebug for T {}
+
+pub type DefaultMemTracker<T> = MemCounter<T>;
+
+pub struct MemoryDB<H, KF, T, M = DefaultMemTracker<T>>
+where
+    H: KeyHasher,
+    KF: KeyFunction<H>,
+    M: MemTracker<T>,
+{
+    data: HashMap<KF::Key, (T, i32)>,
+    malloc_tracker: M,
+    hashed_null_node: H::Out,
+    null_node_data: T,
+    _kf: PhantomData<KF>,
+}
+
+impl<H, KF, T, M> Clone for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    KF: KeyFunction<H>,
+    T: Clone,
+    M: MemTracker<T> + Copy,
+{
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            hashed_null_node: self.hashed_null_node,
+            null_node_data: self.null_node_data.clone(),
+            malloc_tracker: self.malloc_tracker,
+            _kf: Default::default(),
+        }
+    }
+}
+
+pub trait KeyFunction<H: KeyHasher> {
+    type Key: Send + Sync + Clone + hash::Hash + Eq;
+
+    fn key(hash: &H::Out, prefix: Prefix) -> Self::Key;
+}
+
+/// Key function that only uses the hash
+pub struct HashKey<H>(PhantomData<H>);
+
+impl<H> Clone for HashKey<H> {
+    fn clone(&self) -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<H> core::fmt::Debug for HashKey<H> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::write!(f, "HashKey")
+    }
+}
+
+impl<H: KeyHasher> KeyFunction<H> for HashKey<H> {
+    type Key = H::Out;
+
+    fn key(hash: &H::Out, prefix: Prefix) -> H::Out {
+        hash_key::<H>(hash, prefix)
+    }
+}
+
+/// Make database key from hash only.
+pub fn hash_key<H: KeyHasher>(key: &H::Out, _prefix: Prefix) -> H::Out {
+    *key
+}
+
+/// Key function that concatenates prefix and hash.
+pub struct PrefixedKey<H>(PhantomData<H>);
+
+impl<H> Clone for PrefixedKey<H> {
+    fn clone(&self) -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<H> core::fmt::Debug for PrefixedKey<H> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::write!(f, "PrefixedKey")
+    }
+}
+
+impl<H: KeyHasher> KeyFunction<H> for PrefixedKey<H> {
+    type Key = Vec<u8>;
+
+    fn key(hash: &H::Out, prefix: Prefix) -> Vec<u8> {
+        prefixed_key::<H>(hash, prefix)
+    }
+}
+
+/// Derive a database key from hash value of the node (key) and  the node prefix.
+pub fn prefixed_key<H: KeyHasher>(key: &H::Out, prefix: Prefix) -> Vec<u8> {
+    let mut prefixed_key = Vec::with_capacity(key.as_ref().len() + prefix.0.len() + 1);
+    prefixed_key.extend_from_slice(prefix.0);
+    if let Some(last) = prefix.1 {
+        prefixed_key.push(last);
+    }
+    prefixed_key.extend_from_slice(key.as_ref());
+    prefixed_key
+}
+
+impl<H, KF, T, M> Default for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: for<'a> From<&'a [u8]> + Clone,
+    KF: KeyFunction<H>,
+    M: MemTracker<T> + Default,
+    KF::Key: Ord,
+{
+    fn default() -> Self {
+        Self::from_null_node(&[0u8][..], [0u8][..].into())
+    }
+}
+
+/// Create a new `MemoryDB` from a given null key/data
+impl<H, KF, T, M> MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + Clone,
+    KF: KeyFunction<H>,
+    M: MemTracker<T>,
+    KF::Key: Ord,
+{
+    /// Remove an element and delete it from storage if reference count reaches zero.
+    /// If the value was purged, return the old value.
+    pub fn remove_and_purge(&mut self, key: &<H as KeyHasher>::Out, prefix: Prefix) -> Option<T> {
+        if key == &self.hashed_null_node {
+            return None;
+        }
+        let key = KF::key(key, prefix);
+        match self.data.entry(key) {
+            Entry::Occupied(mut entry) => {
+                if entry.get().1 == 1 {
+                    let (value, _) = entry.remove();
+                    self.malloc_tracker.on_remove(&value);
+                    Some(value)
+                } else {
+                    entry.get_mut().1 -= 1;
+                    None
+                }
+            }
+            Entry::Vacant(entry) => {
+                let value = T::default();
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, -1));
+                None
+            }
+        }
+    }
+
+    /// Shrinks the capacity of the map as much as possible. It will drop
+    /// down as much as possible while maintaining the internal rules
+    /// and possibly leaving some space in accordance with the resize policy.
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {}
+}
+
+impl<H, KF, T, M> MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: for<'a> From<&'a [u8]> + Clone,
+    KF: KeyFunction<H>,
+    M: MemTracker<T> + Default,
+    KF::Key: Ord,
+{
+    /// Create a new `MemoryDB` from a given null key/data
+    pub fn from_null_node(null_key: &[u8], null_node_data: T) -> Self {
+        MemoryDB {
+            data: HashMap::default(),
+            hashed_null_node: H::hash(null_key),
+            null_node_data,
+            malloc_tracker: M::default(),
+            _kf: Default::default(),
+        }
+    }
+
+    /// Create a new `MemoryDB` from a given inner hash map.
+    pub fn from_inner(data: HashMap<KF::Key, (T, i32)>) -> Self {
+        MemoryDB {
+            data,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new instance of `Self`.
+    pub fn new(data: &[u8]) -> Self {
+        Self::from_null_node(data, data.into())
+    }
+
+    /// Create a new default instance of `Self` and returns `Self` and the root hash.
+    pub fn default_with_root() -> (Self, H::Out) {
+        let db = Self::default();
+        let root = db.hashed_null_node;
+
+        (db, root)
+    }
+
+    /// Clear all data from the database.
+    pub fn clear(&mut self) {
+        self.malloc_tracker.on_clear();
+        self.data.clear();
+    }
+
+    /// Purge all zero-referenced data from the database.
+    pub fn purge(&mut self) {
+        let malloc_tracker = &mut self.malloc_tracker;
+        self.data.retain(|_, (v, rc)| {
+            let keep = *rc != 0;
+            if !keep {
+                malloc_tracker.on_remove(v);
+            }
+            keep
+        });
+    }
+
+    /// Return the internal key-value HashMap, clearing the current state.
+    pub fn drain(&mut self) -> HashMap<KF::Key, (T, i32)> {
+        self.malloc_tracker.on_clear();
+        mem::take(&mut self.data)
+    }
+
+    /// Grab the raw information associated with a key. Returns None if the key
+    /// doesn't exist.
+    ///
+    /// Even when Some is returned, the data is only guaranteed to be useful
+    /// when the refs > 0.
+    pub fn raw(&self, key: &<H as KeyHasher>::Out, prefix: Prefix) -> Option<(&T, i32)> {
+        if key == &self.hashed_null_node {
+            return Some((&self.null_node_data, 1));
+        }
+        self.data
+            .get(&KF::key(key, prefix))
+            .map(|(value, count)| (value, *count))
+    }
+
+    /// Consolidate all the entries of `other` into `self`.
+    pub fn consolidate(&mut self, mut other: Self) {
+        for (key, (value, rc)) in other.drain() {
+            if rc == 0 {
+                continue;
+            }
+            match self.data.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    if entry.get().1 < 0 {
+                        self.malloc_tracker.on_insert(&value);
+                        self.malloc_tracker.on_remove(&entry.get().0);
+                        entry.get_mut().0 = value;
+                    }
+
+                    entry.get_mut().1 += rc;
+
+                    if entry.get().1 == 0 {
+                        let (value, _) = entry.remove();
+                        self.malloc_tracker.on_remove(&value);
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    self.malloc_tracker.on_insert(&value);
+                    entry.insert((value, rc));
+                }
+            }
+        }
+    }
+
+    /// Get the keys in the database together with number of underlying references.
+    pub fn keys(&self) -> HashMap<KF::Key, i32> {
+        self.data
+            .iter()
+            .filter_map(|(k, v)| {
+                if v.1 != 0 {
+                    Some((k.clone(), v.1))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+impl<H, KF, T, M> MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: for<'a> From<&'a [u8]> + Clone,
+    KF: KeyFunction<H>,
+    M: MemTracker<T> + Default,
+    T: serde::Serialize,
+{
+    pub fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+
+        let mut seq = serializer.serialize_seq(Some(self.data.len()))?;
+        for (_k, v) in self.data.iter() {
+            seq.serialize_element(&v)?;
+        }
+        seq.end()
+    }
+}
+
+impl<H, KF, T, M> MallocSizeOf for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    H::Out: MallocSizeOf,
+    T: MallocSizeOf,
+    KF: KeyFunction<H>,
+    KF::Key: MallocSizeOf,
+    M: MemTracker<T>,
+{
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        shallow_size_of_hashmap(&self.data, ops)
+            + self.malloc_tracker.get_size()
+            + self.null_node_data.size_of(ops)
+            + self.hashed_null_node.size_of(ops)
+    }
+}
+
+impl<H, KF, T, M> PlainDB<H::Out, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: Send + Sync + KeyFunction<H>,
+    KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    KF::Key: Ord,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out) -> Option<T> {
+        match self.data.get(key.as_ref()) {
+            Some(&(ref d, rc)) if rc > 0 => Some(d.clone()),
+            _ => None,
+        }
+    }
+
+    fn contains(&self, key: &H::Out) -> bool {
+        matches!(self.data.get(key.as_ref()), Some(&(_, x)) if x > 0)
+    }
+
+    fn emplace(&mut self, key: H::Out, value: T) {
+        match self.data.entry(key.as_ref().into()) {
+            Entry::Occupied(mut entry) => {
+                let &mut (ref mut old_value, ref mut rc) = entry.get_mut();
+                if *rc <= 0 {
+                    self.malloc_tracker.on_insert(&value);
+                    self.malloc_tracker.on_remove(old_value);
+                    *old_value = value;
+                }
+                *rc += 1;
+            }
+            Entry::Vacant(entry) => {
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, 1));
+            }
+        }
+    }
+
+    fn remove(&mut self, key: &H::Out) {
+        match self.data.entry(key.as_ref().into()) {
+            Entry::Occupied(mut entry) => {
+                let &mut (_, ref mut rc) = entry.get_mut();
+                *rc -= 1;
+                if *rc == 0 {
+                    let (value, _) = entry.remove();
+                    self.malloc_tracker.on_remove(&value);
+                }
+            }
+            Entry::Vacant(entry) => {
+                let value = T::default();
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, -1));
+            }
+        }
+    }
+}
+
+impl<H, KF, T, M> PlainDBRef<H::Out, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: Send + Sync + KeyFunction<H>,
+    KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    KF::Key: Ord,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out) -> Option<T> {
+        PlainDB::get(self, key)
+    }
+    fn contains(&self, key: &H::Out) -> bool {
+        PlainDB::contains(self, key)
+    }
+}
+
+impl<H, KF, T, M> HashDB<H, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    KF::Key: Ord,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
+        if key == &self.hashed_null_node {
+            return Some(self.null_node_data.clone());
+        }
+
+        let key = KF::key(key, prefix);
+        match self.data.get(&key) {
+            Some(&(ref d, rc)) if rc > 0 => Some(d.clone()),
+            _ => None,
+        }
+    }
+
+    fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
+        if key == &self.hashed_null_node {
+            return true;
+        }
+
+        let key = KF::key(key, prefix);
+        matches!(self.data.get(&key), Some(&(_, x)) if x > 0)
+    }
+
+    fn emplace(&mut self, key: H::Out, prefix: Prefix, value: T) {
+        if value == self.null_node_data {
+            return;
+        }
+
+        let key = KF::key(&key, prefix);
+        match self.data.entry(key) {
+            Entry::Occupied(mut entry) => {
+                let &mut (ref mut old_value, ref mut rc) = entry.get_mut();
+                if *rc <= 0 {
+                    self.malloc_tracker.on_insert(&value);
+                    self.malloc_tracker.on_remove(old_value);
+                    *old_value = value;
+                }
+                *rc += 1;
+            }
+            Entry::Vacant(entry) => {
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, 1));
+            }
+        }
+    }
+
+    fn insert(&mut self, prefix: Prefix, value: &[u8]) -> H::Out {
+        if T::from(value) == self.null_node_data {
+            return self.hashed_null_node;
+        }
+
+        let key = H::hash(value);
+        HashDB::emplace(self, key, prefix, value.into());
+        key
+    }
+
+    fn remove(&mut self, key: &H::Out, prefix: Prefix) {
+        if key == &self.hashed_null_node {
+            return;
+        }
+
+        let key = KF::key(key, prefix);
+        match self.data.entry(key) {
+            Entry::Occupied(mut entry) => {
+                let &mut (_, ref mut rc) = entry.get_mut();
+                *rc -= 1;
+                if *rc == 0 {
+                    let (value, _) = entry.remove();
+                    self.malloc_tracker.on_remove(&value);
+                }
+            }
+            Entry::Vacant(entry) => {
+                let value = T::default();
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, -1));
+            }
+        }
+    }
+}
+
+impl<H, KF, T, M> HashDBRef<H, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    KF::Key: Ord,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
+        HashDB::get(self, key, prefix)
+    }
+    fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
+        HashDB::contains(self, key, prefix)
+    }
+}
+
+impl<H, KF, T, M> AsPlainDB<H::Out, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    KF::Key: Ord,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn as_plain_db(&self) -> &dyn PlainDB<H::Out, T> {
+        self
+    }
+    fn as_plain_db_mut(&mut self) -> &mut dyn PlainDB<H::Out, T> {
+        self
+    }
+}
+
+impl<H, KF, T, M> AsHashDB<H, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    KF::Key: Ord,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn as_hash_db(&self) -> &dyn HashDB<H, T> {
+        self
+    }
+    fn as_hash_db_mut(&mut self) -> &mut dyn HashDB<H, T> {
+        self
+    }
+}
+
+/// Used to implement incremental evaluation of `MallocSizeOf` for a collection.
+pub trait MemTracker<T> {
+    /// Update `malloc_size_of` when a value is removed.
+    fn on_remove(&mut self, _value: &T) {}
+    /// Update `malloc_size_of` when a value is inserted.
+    fn on_insert(&mut self, _value: &T) {}
+    /// Reset `malloc_size_of` to zero.
+    fn on_clear(&mut self) {}
+    /// Get the allocated size of the values.
+    fn get_size(&self) -> usize {
+        0
+    }
+}
+
+/// `MemTracker` implementation for types
+/// which implement `MallocSizeOf`.
+#[derive(Eq, PartialEq)]
+pub struct MemCounter<T> {
+    malloc_size_of_values: usize,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> MemCounter<T> {
+    // Create a new instance of MemCounter<T>.
+    pub fn new() -> Self {
+        Self {
+            malloc_size_of_values: 0,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Default for MemCounter<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Clone for MemCounter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            malloc_size_of_values: self.malloc_size_of_values,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Copy for MemCounter<T> {}
+
+impl<T: MallocSizeOf> MemTracker<T> for MemCounter<T> {
+    fn on_remove(&mut self, value: &T) {
+        self.malloc_size_of_values -= malloc_size(value);
+    }
+    fn on_insert(&mut self, value: &T) {
+        self.malloc_size_of_values += malloc_size(value);
+    }
+    fn on_clear(&mut self) {
+        self.malloc_size_of_values = 0;
+    }
+    fn get_size(&self) -> usize {
+        self.malloc_size_of_values
+    }
+}
+
+/// No-op `MemTracker` implementation for when we want to
+/// construct a `MemoryDB` instance that does not track memory usage.
+#[derive(PartialEq, Eq)]
+pub struct NoopTracker<T>(PhantomData<T>);
+
+impl<T> Default for NoopTracker<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> Clone for NoopTracker<T> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl<T> Copy for NoopTracker<T> {}
+
+impl<T> MemTracker<T> for NoopTracker<T> {}
+
+fn shallow_size_of_hashmap<K, V>(map: &HashMap<K, V>, ops: &mut MallocSizeOfOps) -> usize {
+    // See the implementation for std::collections::HashSet for details.
+    if ops.has_malloc_enclosing_size_of() {
+        map.values()
+            .next()
+            .map_or(0, |v| unsafe { ops.malloc_enclosing_size_of(v) })
+    } else {
+        map.len() * (mem::size_of::<V>() + mem::size_of::<K>() + mem::size_of::<usize>())
+    }
+}
+
+#[cfg(test)]
+fn size_of_hash_map<K, V>(map: &HashMap<K, V>) -> usize
+where
+    K: MallocSizeOf,
+    V: MallocSizeOf,
+{
+    let ops = &mut parity_util_mem::allocators::new_malloc_size_ops();
+    let mut n = shallow_size_of_hashmap(map, ops);
+    if let (Some(k), Some(v)) = (K::constant_size(), V::constant_size()) {
+        n += map.len() * (k + v)
+    } else {
+        n = map
+            .iter()
+            .fold(n, |acc, (k, v)| acc + k.size_of(ops) + v.size_of(ops))
+    }
+    n
+}
+
+pub type GenericMemoryDB<H> = MemoryDB<H, HashKey<H>, DBValue, NoopTracker<DBValue>>;
+
+impl<H: KeyHasher> Consolidate for GenericMemoryDB<H>
+where
+    H::Out: Ord,
+{
+    fn consolidate(&mut self, other: Self) {
+        MemoryDB::consolidate(self, other)
+    }
+}
+
+impl<H: KeyHasher> TrieBackendStorage<H> for GenericMemoryDB<H>
+where
+    H::Out: Ord,
+{
+    type Overlay = Self;
+
+    fn get(
+        &self,
+        key: &<H as KeyHasher>::Out,
+        prefix: Prefix,
+    ) -> Result<Option<DBValue>, DefaultError> {
+        Ok(hash_db::HashDB::get(self, key, prefix))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HashDB, HashKey, KeyHasher, MemoryDB};
+    use hash_db::EMPTY_PREFIX;
+    use keccak_hasher::KeccakHasher;
+    use parity_util_mem::malloc_size;
+
+    #[test]
+    fn memorydb_remove_and_purge() {
+        let hello_bytes = b"Hello world!";
+        let hello_key = KeccakHasher::hash(hello_bytes);
+
+        let mut m = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        m.remove(&hello_key, EMPTY_PREFIX);
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, -1);
+        m.purge();
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, -1);
+        m.insert(EMPTY_PREFIX, hello_bytes);
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, 0);
+        m.purge();
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX), None);
+
+        let mut m = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        assert!(m.remove_and_purge(&hello_key, EMPTY_PREFIX).is_none());
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, -1);
+        m.insert(EMPTY_PREFIX, hello_bytes);
+        m.insert(EMPTY_PREFIX, hello_bytes);
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, 1);
+        assert_eq!(
+            &*m.remove_and_purge(&hello_key, EMPTY_PREFIX).unwrap(),
+            hello_bytes
+        );
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX), None);
+        assert!(m.remove_and_purge(&hello_key, EMPTY_PREFIX).is_none());
+    }
+
+    #[test]
+    fn consolidate() {
+        let mut main = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        let mut other = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        let remove_key = other.insert(EMPTY_PREFIX, b"doggo");
+        main.remove(&remove_key, EMPTY_PREFIX);
+
+        let insert_key = other.insert(EMPTY_PREFIX, b"arf");
+        main.emplace(insert_key, EMPTY_PREFIX, "arf".as_bytes().to_vec());
+
+        let negative_remove_key = other.insert(EMPTY_PREFIX, b"negative");
+        other.remove(&negative_remove_key, EMPTY_PREFIX); // ref cnt: 0
+        other.remove(&negative_remove_key, EMPTY_PREFIX); // ref cnt: -1
+        main.remove(&negative_remove_key, EMPTY_PREFIX); // ref cnt: -1
+
+        main.consolidate(other);
+
+        assert_eq!(main.raw(&remove_key, EMPTY_PREFIX), None);
+        assert_eq!(
+            main.raw(&insert_key, EMPTY_PREFIX).unwrap(),
+            (&"arf".as_bytes().to_vec(), 2)
+        );
+        assert_eq!(
+            main.raw(&negative_remove_key, EMPTY_PREFIX).unwrap(),
+            (&"".as_bytes().to_vec(), -2),
+        );
+    }
+
+    #[test]
+    fn default_works() {
+        let mut db = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        let hashed_null_node = KeccakHasher::hash(&[0u8][..]);
+        assert_eq!(db.insert(EMPTY_PREFIX, &[0u8][..]), hashed_null_node);
+
+        let (db2, root) = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default_with_root();
+        assert!(db2.contains(&root, EMPTY_PREFIX));
+        assert!(db.contains(&root, EMPTY_PREFIX));
+    }
+
+    #[test]
+    fn malloc_size_of() {
+        let mut db = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        for i in 0u32..1024 {
+            let bytes = i.to_be_bytes();
+            let prefix = (bytes.as_ref(), None);
+            db.insert(prefix, &bytes);
+        }
+        assert_eq!(
+            malloc_size(&db),
+            super::size_of_hash_map(&db.data)
+                + malloc_size(&db.null_node_data)
+                + malloc_size(&db.hashed_null_node)
+        );
+    }
+}

--- a/crates/phala-trie-storage/src/ser.rs
+++ b/crates/phala-trie-storage/src/ser.rs
@@ -1,18 +1,31 @@
 use alloc::vec::Vec;
+use hash_db::Hasher;
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use parity_scale_codec::{Encode, Decode};
 
 use super::{ChildStorageCollection, StorageCollection};
 
-#[derive(Serialize, Deserialize, Encode, Decode, Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, TypeInfo, Encode, Decode, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase", crate = "serde")]
 pub struct StorageChanges {
     pub main_storage_changes: StorageCollection,
     pub child_storage_changes: ChildStorageCollection,
 }
 
-#[derive(Serialize, Deserialize, Encode, Decode, Clone, Debug)]
+#[derive(Serialize, Deserialize, TypeInfo, Encode, Decode, Clone, Debug)]
 #[serde(crate = "serde")]
 pub struct StorageData {
     pub inner: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
+pub struct SerAsSeq<'a, H: Hasher>(pub &'a crate::MemoryDB<H>);
+
+impl<H: Hasher> Serialize for SerAsSeq<'_, H> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
 }

--- a/crates/pink/src/contract.rs
+++ b/crates/pink/src/contract.rs
@@ -9,8 +9,15 @@ use crate::{
 };
 
 use pallet_contracts_primitives::ContractExecResult;
+use phala_trie_storage::new_backend;
 
 pub type Storage = storage::Storage<storage::InMemoryBackend>;
+
+impl Storage {
+    pub fn new_empty() -> Self {
+        Self::new(new_backend())
+    }
+}
 
 #[derive(Debug)]
 pub struct ExecError {
@@ -31,7 +38,7 @@ pub struct Contract {
 
 impl Contract {
     pub fn new_storage() -> Storage {
-        Storage::new(Default::default())
+        Storage::new(new_backend())
     }
 
     pub fn from_address(address: AccountId) -> Self {

--- a/crates/sp-trie/Cargo.toml
+++ b/crates/sp-trie/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "sp-trie"
+version = "4.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "Patricia trie stuff using a parity-scale-codec node format"
+repository = "https://github.com/paritytech/substrate/"
+license = "Apache-2.0"
+edition = "2021"
+homepage = "https://substrate.io"
+documentation = "https://docs.rs/sp-trie"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
+scale-info = { version = "1.0", default-features = false, features = ["derive"] }
+sp-std = { default-features = false, path = "../../substrate/primitives/std" }
+hash-db = { version = "0.15.2", default-features = false }
+trie-db = { version = "0.23.0", default-features = false }
+trie-root = { version = "0.17.0", default-features = false }
+memory-db = { version = "0.27.0", default-features = false }
+sp-core = { default-features = false, path = "../../substrate/primitives/core" }
+
+[features]
+default = ["std"]
+std = [
+	"sp-std/std",
+	"codec/std",
+	"scale-info/std",
+	"hash-db/std",
+	"memory-db/std",
+	"trie-db/std",
+	"trie-root/std",
+	"sp-core/std",
+]
+memory-tracker = []

--- a/crates/sp-trie/README.md
+++ b/crates/sp-trie/README.md
@@ -1,0 +1,3 @@
+Utility functions to interact with Substrate's Base-16 Modified Merkle Patricia tree ("trie").
+
+License: Apache-2.0

--- a/crates/sp-trie/src/error.rs
+++ b/crates/sp-trie/src/error.rs
@@ -1,0 +1,56 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2015-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "std")]
+use std::error::Error as StdError;
+#[cfg(feature = "std")]
+use std::fmt;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+/// Error for trie node decoding.
+pub enum Error {
+	/// Bad format.
+	BadFormat,
+	/// Decoding error.
+	Decode(codec::Error),
+}
+
+impl From<codec::Error> for Error {
+	fn from(x: codec::Error) -> Self {
+		Error::Decode(x)
+	}
+}
+
+#[cfg(feature = "std")]
+impl StdError for Error {
+	fn description(&self) -> &str {
+		match self {
+			Error::BadFormat => "Bad format error",
+			Error::Decode(_) => "Decoding error",
+		}
+	}
+}
+
+#[cfg(feature = "std")]
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match self {
+			Error::Decode(e) => write!(f, "Decode error: {}", e),
+			Error::BadFormat => write!(f, "Bad format"),
+		}
+	}
+}

--- a/crates/sp-trie/src/lib.rs
+++ b/crates/sp-trie/src/lib.rs
@@ -1,0 +1,535 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2015-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utility functions to interact with Substrate's Base-16 Modified Merkle Patricia tree ("trie").
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+mod error;
+mod node_codec;
+mod node_header;
+mod storage_proof;
+mod trie_codec;
+mod trie_stream;
+
+/// Our `NodeCodec`-specific error.
+pub use error::Error;
+/// Various re-exports from the `hash-db` crate.
+pub use hash_db::{HashDB as HashDBT, EMPTY_PREFIX};
+use hash_db::{Hasher, Prefix};
+pub use memory_db::prefixed_key;
+/// Various re-exports from the `memory-db` crate.
+pub use memory_db::KeyFunction;
+/// The Substrate format implementation of `NodeCodec`.
+pub use node_codec::NodeCodec;
+use sp_std::{borrow::Borrow, boxed::Box, marker::PhantomData, vec::Vec};
+pub use storage_proof::{CompactProof, StorageProof};
+/// Trie codec reexport, mainly child trie support
+/// for trie compact proof.
+pub use trie_codec::{decode_compact, encode_compact, Error as CompactProofError};
+pub use trie_db::proof::VerifyError;
+use trie_db::proof::{generate_proof, verify_proof};
+/// Various re-exports from the `trie-db` crate.
+pub use trie_db::{
+    nibble_ops,
+    node::{NodePlan, ValuePlan},
+    CError, DBValue, Query, Recorder, Trie, TrieConfiguration, TrieDBIterator, TrieDBKeyIterator,
+    TrieLayout, TrieMut,
+};
+/// The Substrate format implementation of `TrieStream`.
+pub use trie_stream::TrieStream;
+
+/// substrate trie layout
+pub struct LayoutV0<H>(sp_std::marker::PhantomData<H>);
+
+/// substrate trie layout, with external value nodes.
+pub struct LayoutV1<H>(sp_std::marker::PhantomData<H>);
+
+impl<H> TrieLayout for LayoutV0<H>
+where
+    H: Hasher,
+{
+    const USE_EXTENSION: bool = false;
+    const ALLOW_EMPTY: bool = true;
+    const MAX_INLINE_VALUE: Option<u32> = None;
+
+    type Hash = H;
+    type Codec = NodeCodec<Self::Hash>;
+}
+
+impl<H> TrieConfiguration for LayoutV0<H>
+where
+    H: Hasher,
+{
+    fn trie_root<I, A, B>(input: I) -> <Self::Hash as Hasher>::Out
+    where
+        I: IntoIterator<Item = (A, B)>,
+        A: AsRef<[u8]> + Ord,
+        B: AsRef<[u8]>,
+    {
+        trie_root::trie_root_no_extension::<H, TrieStream, _, _, _>(input, Self::MAX_INLINE_VALUE)
+    }
+
+    fn trie_root_unhashed<I, A, B>(input: I) -> Vec<u8>
+    where
+        I: IntoIterator<Item = (A, B)>,
+        A: AsRef<[u8]> + Ord,
+        B: AsRef<[u8]>,
+    {
+        trie_root::unhashed_trie_no_extension::<H, TrieStream, _, _, _>(
+            input,
+            Self::MAX_INLINE_VALUE,
+        )
+    }
+
+    fn encode_index(input: u32) -> Vec<u8> {
+        codec::Encode::encode(&codec::Compact(input))
+    }
+}
+
+const TRIE_VALUE_NODE_THRESHOLD: u32 = 33;
+
+impl<H> TrieLayout for LayoutV1<H>
+where
+    H: Hasher,
+{
+    const USE_EXTENSION: bool = false;
+    const ALLOW_EMPTY: bool = true;
+    const MAX_INLINE_VALUE: Option<u32> = Some(TRIE_VALUE_NODE_THRESHOLD);
+
+    type Hash = H;
+    type Codec = NodeCodec<Self::Hash>;
+}
+
+impl<H> TrieConfiguration for LayoutV1<H>
+where
+    H: Hasher,
+{
+    fn trie_root<I, A, B>(input: I) -> <Self::Hash as Hasher>::Out
+    where
+        I: IntoIterator<Item = (A, B)>,
+        A: AsRef<[u8]> + Ord,
+        B: AsRef<[u8]>,
+    {
+        trie_root::trie_root_no_extension::<H, TrieStream, _, _, _>(input, Self::MAX_INLINE_VALUE)
+    }
+
+    fn trie_root_unhashed<I, A, B>(input: I) -> Vec<u8>
+    where
+        I: IntoIterator<Item = (A, B)>,
+        A: AsRef<[u8]> + Ord,
+        B: AsRef<[u8]>,
+    {
+        trie_root::unhashed_trie_no_extension::<H, TrieStream, _, _, _>(
+            input,
+            Self::MAX_INLINE_VALUE,
+        )
+    }
+
+    fn encode_index(input: u32) -> Vec<u8> {
+        codec::Encode::encode(&codec::Compact(input))
+    }
+}
+
+#[cfg(not(feature = "memory-tracker"))]
+type MemTracker = memory_db::NoopTracker<trie_db::DBValue>;
+#[cfg(feature = "memory-tracker")]
+type MemTracker = memory_db::MemCounter<trie_db::DBValue>;
+
+/// TrieDB error over `TrieConfiguration` trait.
+pub type TrieError<L> = trie_db::TrieError<TrieHash<L>, CError<L>>;
+/// Reexport from `hash_db`, with genericity set for `Hasher` trait.
+pub trait AsHashDB<H: Hasher>: hash_db::AsHashDB<H, trie_db::DBValue> {}
+impl<H: Hasher, T: hash_db::AsHashDB<H, trie_db::DBValue>> AsHashDB<H> for T {}
+/// Reexport from `hash_db`, with genericity set for `Hasher` trait.
+pub type HashDB<'a, H> = dyn hash_db::HashDB<H, trie_db::DBValue> + 'a;
+/// Reexport from `hash_db`, with genericity set for `Hasher` trait.
+/// This uses a `KeyFunction` for prefixing keys internally (avoiding
+/// key conflict for non random keys).
+pub type PrefixedMemoryDB<H> =
+    memory_db::MemoryDB<H, memory_db::PrefixedKey<H>, trie_db::DBValue, MemTracker>;
+/// Reexport from `hash_db`, with genericity set for `Hasher` trait.
+/// This uses a noops `KeyFunction` (key addressing must be hashed or using
+/// an encoding scheme that avoid key conflict).
+pub type MemoryDB<H> = memory_db::MemoryDB<H, memory_db::HashKey<H>, trie_db::DBValue, MemTracker>;
+/// Reexport from `hash_db`, with genericity set for `Hasher` trait.
+pub type GenericMemoryDB<H, KF> = memory_db::MemoryDB<H, KF, trie_db::DBValue, MemTracker>;
+
+/// Persistent trie database read-access interface for the a given hasher.
+pub type TrieDB<'a, L> = trie_db::TrieDB<'a, L>;
+/// Persistent trie database write-access interface for the a given hasher.
+pub type TrieDBMut<'a, L> = trie_db::TrieDBMut<'a, L>;
+/// Querying interface, as in `trie_db` but less generic.
+pub type Lookup<'a, L, Q> = trie_db::Lookup<'a, L, Q>;
+/// Hash type for a trie layout.
+pub type TrieHash<L> = <<L as TrieLayout>::Hash as Hasher>::Out;
+/// This module is for non generic definition of trie type.
+/// Only the `Hasher` trait is generic in this case.
+pub mod trie_types {
+    use super::*;
+
+    /// Persistent trie database read-access interface for the a given hasher.
+    /// Read only V1 and V0 are compatible, thus we always use V1.
+    pub type TrieDB<'a, H> = super::TrieDB<'a, LayoutV1<H>>;
+    /// Persistent trie database write-access interface for the a given hasher.
+    pub type TrieDBMutV0<'a, H> = super::TrieDBMut<'a, LayoutV0<H>>;
+    /// Persistent trie database write-access interface for the a given hasher.
+    pub type TrieDBMutV1<'a, H> = super::TrieDBMut<'a, LayoutV1<H>>;
+    /// Querying interface, as in `trie_db` but less generic.
+    pub type LookupV0<'a, H, Q> = trie_db::Lookup<'a, LayoutV0<H>, Q>;
+    /// Querying interface, as in `trie_db` but less generic.
+    pub type LookupV1<'a, H, Q> = trie_db::Lookup<'a, LayoutV1<H>, Q>;
+    /// As in `trie_db`, but less generic, error type for the crate.
+    pub type TrieError<H> = trie_db::TrieError<H, super::Error>;
+}
+
+/// Create a proof for a subset of keys in a trie.
+///
+/// The `keys` may contain any set of keys regardless of each one of them is included
+/// in the `db`.
+///
+/// For a key `K` that is included in the `db` a proof of inclusion is generated.
+/// For a key `K` that is not included in the `db` a proof of non-inclusion is generated.
+/// These can be later checked in `verify_trie_proof`.
+pub fn generate_trie_proof<'a, L, I, K, DB>(
+    db: &DB,
+    root: TrieHash<L>,
+    keys: I,
+) -> Result<Vec<Vec<u8>>, Box<TrieError<L>>>
+where
+    L: TrieConfiguration,
+    I: IntoIterator<Item = &'a K>,
+    K: 'a + AsRef<[u8]>,
+    DB: hash_db::HashDBRef<L::Hash, trie_db::DBValue>,
+{
+    // Can use default layout (read only).
+    let trie = TrieDB::<L>::new(db, &root)?;
+    generate_proof(&trie, keys)
+}
+
+/// Verify a set of key-value pairs against a trie root and a proof.
+///
+/// Checks a set of keys with optional values for inclusion in the proof that was generated by
+/// `generate_trie_proof`.
+/// If the value in the pair is supplied (`(key, Some(value))`), this key-value pair will be
+/// checked for inclusion in the proof.
+/// If the value is omitted (`(key, None)`), this key will be checked for non-inclusion in the
+/// proof.
+pub fn verify_trie_proof<'a, L, I, K, V>(
+    root: &TrieHash<L>,
+    proof: &[Vec<u8>],
+    items: I,
+) -> Result<(), VerifyError<TrieHash<L>, CError<L>>>
+where
+    L: TrieConfiguration,
+    I: IntoIterator<Item = &'a (K, Option<V>)>,
+    K: 'a + AsRef<[u8]>,
+    V: 'a + AsRef<[u8]>,
+{
+    verify_proof::<L, _, _, _>(root, proof, items)
+}
+
+/// Determine a trie root given a hash DB and delta values.
+pub fn delta_trie_root<L: TrieConfiguration, I, A, B, DB, V>(
+    db: &mut DB,
+    mut root: TrieHash<L>,
+    delta: I,
+) -> Result<TrieHash<L>, Box<TrieError<L>>>
+where
+    I: IntoIterator<Item = (A, B)>,
+    A: Borrow<[u8]>,
+    B: Borrow<Option<V>>,
+    V: Borrow<[u8]>,
+    DB: hash_db::HashDB<L::Hash, trie_db::DBValue>,
+{
+    {
+        let mut trie = TrieDBMut::<L>::from_existing(db, &mut root)?;
+
+        let mut delta = delta.into_iter().collect::<Vec<_>>();
+        delta.sort_by(|l, r| l.0.borrow().cmp(r.0.borrow()));
+
+        for (key, change) in delta {
+            match change.borrow() {
+                Some(val) => trie.insert(key.borrow(), val.borrow())?,
+                None => trie.remove(key.borrow())?,
+            };
+        }
+    }
+
+    Ok(root)
+}
+
+/// Read a value from the trie.
+pub fn read_trie_value<L, DB>(
+    db: &DB,
+    root: &TrieHash<L>,
+    key: &[u8],
+) -> Result<Option<Vec<u8>>, Box<TrieError<L>>>
+where
+    L: TrieConfiguration,
+    DB: hash_db::HashDBRef<L::Hash, trie_db::DBValue>,
+{
+    TrieDB::<L>::new(&*db, root)?
+        .get(key)
+        .map(|x| x.map(|val| val.to_vec()))
+}
+
+/// Read a value from the trie with given Query.
+pub fn read_trie_value_with<L, Q, DB>(
+    db: &DB,
+    root: &TrieHash<L>,
+    key: &[u8],
+    query: Q,
+) -> Result<Option<Vec<u8>>, Box<TrieError<L>>>
+where
+    L: TrieConfiguration,
+    Q: Query<L::Hash, Item = DBValue>,
+    DB: hash_db::HashDBRef<L::Hash, trie_db::DBValue>,
+{
+    TrieDB::<L>::new(&*db, root)?
+        .get_with(key, query)
+        .map(|x| x.map(|val| val.to_vec()))
+}
+
+/// Determine the empty trie root.
+pub fn empty_trie_root<L: TrieConfiguration>() -> <L::Hash as Hasher>::Out {
+    L::trie_root::<_, Vec<u8>, Vec<u8>>(core::iter::empty())
+}
+
+/// Determine the empty child trie root.
+pub fn empty_child_trie_root<L: TrieConfiguration>() -> <L::Hash as Hasher>::Out {
+    L::trie_root::<_, Vec<u8>, Vec<u8>>(core::iter::empty())
+}
+
+/// Determine a child trie root given its ordered contents, closed form. H is the default hasher,
+/// but a generic implementation may ignore this type parameter and use other hashers.
+pub fn child_trie_root<L: TrieConfiguration, I, A, B>(input: I) -> <L::Hash as Hasher>::Out
+where
+    I: IntoIterator<Item = (A, B)>,
+    A: AsRef<[u8]> + Ord,
+    B: AsRef<[u8]>,
+{
+    L::trie_root(input)
+}
+
+/// Determine a child trie root given a hash DB and delta values. H is the default hasher,
+/// but a generic implementation may ignore this type parameter and use other hashers.
+pub fn child_delta_trie_root<L: TrieConfiguration, I, A, B, DB, RD, V>(
+    keyspace: &[u8],
+    db: &mut DB,
+    root_data: RD,
+    delta: I,
+) -> Result<<L::Hash as Hasher>::Out, Box<TrieError<L>>>
+where
+    I: IntoIterator<Item = (A, B)>,
+    A: Borrow<[u8]>,
+    B: Borrow<Option<V>>,
+    V: Borrow<[u8]>,
+    RD: AsRef<[u8]>,
+    DB: hash_db::HashDB<L::Hash, trie_db::DBValue>,
+{
+    let mut root = TrieHash::<L>::default();
+    // root is fetched from DB, not writable by runtime, so it's always valid.
+    root.as_mut().copy_from_slice(root_data.as_ref());
+
+    let mut db = KeySpacedDBMut::new(&mut *db, keyspace);
+    delta_trie_root::<L, _, _, _, _, _>(&mut db, root, delta)
+}
+
+/// Record all keys for a given root.
+pub fn record_all_keys<L: TrieConfiguration, DB>(
+    db: &DB,
+    root: &TrieHash<L>,
+    recorder: &mut Recorder<TrieHash<L>>,
+) -> Result<(), Box<TrieError<L>>>
+where
+    DB: hash_db::HashDBRef<L::Hash, trie_db::DBValue>,
+{
+    let trie = TrieDB::<L>::new(&*db, root)?;
+    let iter = trie.iter()?;
+
+    for x in iter {
+        let (key, _) = x?;
+
+        // there's currently no API like iter_with()
+        // => use iter to enumerate all keys AND lookup each
+        // key using get_with
+        trie.get_with(&key, &mut *recorder)?;
+    }
+
+    Ok(())
+}
+
+/// Read a value from the child trie.
+pub fn read_child_trie_value<L: TrieConfiguration, DB>(
+    keyspace: &[u8],
+    db: &DB,
+    root_slice: &[u8],
+    key: &[u8],
+) -> Result<Option<Vec<u8>>, Box<TrieError<L>>>
+where
+    DB: hash_db::HashDBRef<L::Hash, trie_db::DBValue>,
+{
+    let mut root = TrieHash::<L>::default();
+    // root is fetched from DB, not writable by runtime, so it's always valid.
+    root.as_mut().copy_from_slice(root_slice);
+
+    let db = KeySpacedDB::new(&*db, keyspace);
+    TrieDB::<L>::new(&db, &root)?
+        .get(key)
+        .map(|x| x.map(|val| val.to_vec()))
+}
+
+/// Read a value from the child trie with given query.
+pub fn read_child_trie_value_with<L, Q, DB>(
+    keyspace: &[u8],
+    db: &DB,
+    root_slice: &[u8],
+    key: &[u8],
+    query: Q,
+) -> Result<Option<Vec<u8>>, Box<TrieError<L>>>
+where
+    L: TrieConfiguration,
+    Q: Query<L::Hash, Item = DBValue>,
+    DB: hash_db::HashDBRef<L::Hash, trie_db::DBValue>,
+{
+    let mut root = TrieHash::<L>::default();
+    // root is fetched from DB, not writable by runtime, so it's always valid.
+    root.as_mut().copy_from_slice(root_slice);
+
+    let db = KeySpacedDB::new(&*db, keyspace);
+    TrieDB::<L>::new(&db, &root)?
+        .get_with(key, query)
+        .map(|x| x.map(|val| val.to_vec()))
+}
+
+/// `HashDB` implementation that append a encoded prefix (unique id bytes) in addition to the
+/// prefix of every key value.
+pub struct KeySpacedDB<'a, DB, H>(&'a DB, &'a [u8], PhantomData<H>);
+
+/// `HashDBMut` implementation that append a encoded prefix (unique id bytes) in addition to the
+/// prefix of every key value.
+///
+/// Mutable variant of `KeySpacedDB`, see [`KeySpacedDB`].
+pub struct KeySpacedDBMut<'a, DB, H>(&'a mut DB, &'a [u8], PhantomData<H>);
+
+/// Utility function used to merge some byte data (keyspace) and `prefix` data
+/// before calling key value database primitives.
+fn keyspace_as_prefix_alloc(ks: &[u8], prefix: Prefix) -> (Vec<u8>, Option<u8>) {
+    let mut result = sp_std::vec![0; ks.len() + prefix.0.len()];
+    result[..ks.len()].copy_from_slice(ks);
+    result[ks.len()..].copy_from_slice(prefix.0);
+    (result, prefix.1)
+}
+
+impl<'a, DB, H> KeySpacedDB<'a, DB, H>
+where
+    H: Hasher,
+{
+    /// instantiate new keyspaced db
+    pub fn new(db: &'a DB, ks: &'a [u8]) -> Self {
+        KeySpacedDB(db, ks, PhantomData)
+    }
+}
+
+impl<'a, DB, H> KeySpacedDBMut<'a, DB, H>
+where
+    H: Hasher,
+{
+    /// instantiate new keyspaced db
+    pub fn new(db: &'a mut DB, ks: &'a [u8]) -> Self {
+        KeySpacedDBMut(db, ks, PhantomData)
+    }
+}
+
+impl<'a, DB, H, T> hash_db::HashDBRef<H, T> for KeySpacedDB<'a, DB, H>
+where
+    DB: hash_db::HashDBRef<H, T>,
+    H: Hasher,
+    T: From<&'static [u8]>,
+{
+    fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
+        let derived_prefix = keyspace_as_prefix_alloc(self.1, prefix);
+        self.0.get(key, (&derived_prefix.0, derived_prefix.1))
+    }
+
+    fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
+        let derived_prefix = keyspace_as_prefix_alloc(self.1, prefix);
+        self.0.contains(key, (&derived_prefix.0, derived_prefix.1))
+    }
+}
+
+impl<'a, DB, H, T> hash_db::HashDB<H, T> for KeySpacedDBMut<'a, DB, H>
+where
+    DB: hash_db::HashDB<H, T>,
+    H: Hasher,
+    T: Default + PartialEq<T> + for<'b> From<&'b [u8]> + Clone + Send + Sync,
+{
+    fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
+        let derived_prefix = keyspace_as_prefix_alloc(self.1, prefix);
+        self.0.get(key, (&derived_prefix.0, derived_prefix.1))
+    }
+
+    fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
+        let derived_prefix = keyspace_as_prefix_alloc(self.1, prefix);
+        self.0.contains(key, (&derived_prefix.0, derived_prefix.1))
+    }
+
+    fn insert(&mut self, prefix: Prefix, value: &[u8]) -> H::Out {
+        let derived_prefix = keyspace_as_prefix_alloc(self.1, prefix);
+        self.0.insert((&derived_prefix.0, derived_prefix.1), value)
+    }
+
+    fn emplace(&mut self, key: H::Out, prefix: Prefix, value: T) {
+        let derived_prefix = keyspace_as_prefix_alloc(self.1, prefix);
+        self.0
+            .emplace(key, (&derived_prefix.0, derived_prefix.1), value)
+    }
+
+    fn remove(&mut self, key: &H::Out, prefix: Prefix) {
+        let derived_prefix = keyspace_as_prefix_alloc(self.1, prefix);
+        self.0.remove(key, (&derived_prefix.0, derived_prefix.1))
+    }
+}
+
+impl<'a, DB, H, T> hash_db::AsHashDB<H, T> for KeySpacedDBMut<'a, DB, H>
+where
+    DB: hash_db::HashDB<H, T>,
+    H: Hasher,
+    T: Default + PartialEq<T> + for<'b> From<&'b [u8]> + Clone + Send + Sync,
+{
+    fn as_hash_db(&self) -> &dyn hash_db::HashDB<H, T> {
+        &*self
+    }
+
+    fn as_hash_db_mut<'b>(&'b mut self) -> &'b mut (dyn hash_db::HashDB<H, T> + 'b) {
+        &mut *self
+    }
+}
+
+/// Constants used into trie simplification codec.
+mod trie_constants {
+    const FIRST_PREFIX: u8 = 0b_00 << 6;
+    pub const NIBBLE_SIZE_BOUND: usize = u16::max_value() as usize;
+    pub const LEAF_PREFIX_MASK: u8 = 0b_01 << 6;
+    pub const BRANCH_WITHOUT_MASK: u8 = 0b_10 << 6;
+    pub const BRANCH_WITH_MASK: u8 = 0b_11 << 6;
+    pub const EMPTY_TRIE: u8 = FIRST_PREFIX | (0b_00 << 4);
+    pub const ALT_HASHING_LEAF_PREFIX_MASK: u8 = FIRST_PREFIX | (0b_1 << 5);
+    pub const ALT_HASHING_BRANCH_WITH_MASK: u8 = FIRST_PREFIX | (0b_01 << 4);
+    pub const ESCAPE_COMPACT_HEADER: u8 = EMPTY_TRIE | 0b_00_01;
+}

--- a/crates/sp-trie/src/node_codec.rs
+++ b/crates/sp-trie/src/node_codec.rs
@@ -1,0 +1,352 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2015-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `NodeCodec` implementation for Substrate's trie format.
+
+use super::node_header::{NodeHeader, NodeKind};
+use crate::{error::Error, trie_constants};
+use codec::{Compact, Decode, Encode, Input};
+use hash_db::Hasher;
+use sp_std::{borrow::Borrow, marker::PhantomData, ops::Range, vec::Vec};
+use trie_db::{
+	self, nibble_ops,
+	node::{NibbleSlicePlan, NodeHandlePlan, NodePlan, Value, ValuePlan},
+	ChildReference, NodeCodec as NodeCodecT, Partial,
+};
+
+/// Helper struct for trie node decoder. This implements `codec::Input` on a byte slice, while
+/// tracking the absolute position. This is similar to `std::io::Cursor` but does not implement
+/// `Read` and `io` is not in `sp-std`.
+struct ByteSliceInput<'a> {
+	data: &'a [u8],
+	offset: usize,
+}
+
+impl<'a> ByteSliceInput<'a> {
+	fn new(data: &'a [u8]) -> Self {
+		ByteSliceInput { data, offset: 0 }
+	}
+
+	fn take(&mut self, count: usize) -> Result<Range<usize>, codec::Error> {
+		if self.offset + count > self.data.len() {
+			return Err("out of data".into())
+		}
+
+		let range = self.offset..(self.offset + count);
+		self.offset += count;
+		Ok(range)
+	}
+}
+
+impl<'a> Input for ByteSliceInput<'a> {
+	fn remaining_len(&mut self) -> Result<Option<usize>, codec::Error> {
+		let remaining =
+			if self.offset <= self.data.len() { Some(self.data.len() - self.offset) } else { None };
+		Ok(remaining)
+	}
+
+	fn read(&mut self, into: &mut [u8]) -> Result<(), codec::Error> {
+		let range = self.take(into.len())?;
+		into.copy_from_slice(&self.data[range]);
+		Ok(())
+	}
+
+	fn read_byte(&mut self) -> Result<u8, codec::Error> {
+		if self.offset + 1 > self.data.len() {
+			return Err("out of data".into())
+		}
+
+		let byte = self.data[self.offset];
+		self.offset += 1;
+		Ok(byte)
+	}
+}
+
+/// Concrete implementation of a `NodeCodec` with Parity Codec encoding, generic over the `Hasher`
+#[derive(Default, Clone)]
+pub struct NodeCodec<H>(PhantomData<H>);
+
+impl<H> NodeCodecT for NodeCodec<H>
+where
+	H: Hasher,
+{
+	const ESCAPE_HEADER: Option<u8> = Some(trie_constants::ESCAPE_COMPACT_HEADER);
+	type Error = Error;
+	type HashOut = H::Out;
+
+	fn hashed_null_node() -> <H as Hasher>::Out {
+		H::hash(<Self as NodeCodecT>::empty_node())
+	}
+
+	fn decode_plan(data: &[u8]) -> Result<NodePlan, Self::Error> {
+		let mut input = ByteSliceInput::new(data);
+
+		let header = NodeHeader::decode(&mut input)?;
+		let contains_hash = header.contains_hash_of_value();
+
+		let branch_has_value = if let NodeHeader::Branch(has_value, _) = &header {
+			*has_value
+		} else {
+			// hashed_value_branch
+			true
+		};
+
+		match header {
+			NodeHeader::Null => Ok(NodePlan::Empty),
+			NodeHeader::HashedValueBranch(nibble_count) | NodeHeader::Branch(_, nibble_count) => {
+				let padding = nibble_count % nibble_ops::NIBBLE_PER_BYTE != 0;
+				// check that the padding is valid (if any)
+				if padding && nibble_ops::pad_left(data[input.offset]) != 0 {
+					return Err(Error::BadFormat)
+				}
+				let partial = input.take(
+					(nibble_count + (nibble_ops::NIBBLE_PER_BYTE - 1)) /
+						nibble_ops::NIBBLE_PER_BYTE,
+				)?;
+				let partial_padding = nibble_ops::number_padding(nibble_count);
+				let bitmap_range = input.take(BITMAP_LENGTH)?;
+				let bitmap = Bitmap::decode(&data[bitmap_range])?;
+				let value = if branch_has_value {
+					Some(if contains_hash {
+						ValuePlan::Node(input.take(H::LENGTH)?)
+					} else {
+						let count = <Compact<u32>>::decode(&mut input)?.0 as usize;
+						ValuePlan::Inline(input.take(count)?)
+					})
+				} else {
+					None
+				};
+				let mut children = [
+					None, None, None, None, None, None, None, None, None, None, None, None, None,
+					None, None, None,
+				];
+				for i in 0..nibble_ops::NIBBLE_LENGTH {
+					if bitmap.value_at(i) {
+						let count = <Compact<u32>>::decode(&mut input)?.0 as usize;
+						let range = input.take(count)?;
+						children[i] = Some(if count == H::LENGTH {
+							NodeHandlePlan::Hash(range)
+						} else {
+							NodeHandlePlan::Inline(range)
+						});
+					}
+				}
+				Ok(NodePlan::NibbledBranch {
+					partial: NibbleSlicePlan::new(partial, partial_padding),
+					value,
+					children,
+				})
+			},
+			NodeHeader::HashedValueLeaf(nibble_count) | NodeHeader::Leaf(nibble_count) => {
+				let padding = nibble_count % nibble_ops::NIBBLE_PER_BYTE != 0;
+				// check that the padding is valid (if any)
+				if padding && nibble_ops::pad_left(data[input.offset]) != 0 {
+					return Err(Error::BadFormat)
+				}
+				let partial = input.take(
+					(nibble_count + (nibble_ops::NIBBLE_PER_BYTE - 1)) /
+						nibble_ops::NIBBLE_PER_BYTE,
+				)?;
+				let partial_padding = nibble_ops::number_padding(nibble_count);
+				let value = if contains_hash {
+					ValuePlan::Node(input.take(H::LENGTH)?)
+				} else {
+					let count = <Compact<u32>>::decode(&mut input)?.0 as usize;
+					ValuePlan::Inline(input.take(count)?)
+				};
+
+				Ok(NodePlan::Leaf {
+					partial: NibbleSlicePlan::new(partial, partial_padding),
+					value,
+				})
+			},
+		}
+	}
+
+	fn is_empty_node(data: &[u8]) -> bool {
+		data == <Self as NodeCodecT>::empty_node()
+	}
+
+	fn empty_node() -> &'static [u8] {
+		&[trie_constants::EMPTY_TRIE]
+	}
+
+	fn leaf_node(partial: Partial, value: Value) -> Vec<u8> {
+		let contains_hash = matches!(&value, Value::Node(..));
+		let mut output = if contains_hash {
+			partial_encode(partial, NodeKind::HashedValueLeaf)
+		} else {
+			partial_encode(partial, NodeKind::Leaf)
+		};
+		match value {
+			Value::Inline(value) => {
+				Compact(value.len() as u32).encode_to(&mut output);
+				output.extend_from_slice(value);
+			},
+			Value::Node(hash, _) => {
+				debug_assert!(hash.len() == H::LENGTH);
+				output.extend_from_slice(hash);
+			},
+		}
+		output
+	}
+
+	fn extension_node(
+		_partial: impl Iterator<Item = u8>,
+		_nbnibble: usize,
+		_child: ChildReference<<H as Hasher>::Out>,
+	) -> Vec<u8> {
+		unreachable!("No extension codec.")
+	}
+
+	fn branch_node(
+		_children: impl Iterator<Item = impl Borrow<Option<ChildReference<<H as Hasher>::Out>>>>,
+		_maybe_value: Option<Value>,
+	) -> Vec<u8> {
+		unreachable!("No extension codec.")
+	}
+
+	fn branch_node_nibbled(
+		partial: impl Iterator<Item = u8>,
+		number_nibble: usize,
+		children: impl Iterator<Item = impl Borrow<Option<ChildReference<<H as Hasher>::Out>>>>,
+		value: Option<Value>,
+	) -> Vec<u8> {
+		let contains_hash = matches!(&value, Some(Value::Node(..)));
+		let mut output = match (&value, contains_hash) {
+			(&None, _) =>
+				partial_from_iterator_encode(partial, number_nibble, NodeKind::BranchNoValue),
+			(_, false) =>
+				partial_from_iterator_encode(partial, number_nibble, NodeKind::BranchWithValue),
+			(_, true) =>
+				partial_from_iterator_encode(partial, number_nibble, NodeKind::HashedValueBranch),
+		};
+
+		let bitmap_index = output.len();
+		let mut bitmap: [u8; BITMAP_LENGTH] = [0; BITMAP_LENGTH];
+		(0..BITMAP_LENGTH).for_each(|_| output.push(0));
+		match value {
+			Some(Value::Inline(value)) => {
+				Compact(value.len() as u32).encode_to(&mut output);
+				output.extend_from_slice(value);
+			},
+			Some(Value::Node(hash, _)) => {
+				debug_assert!(hash.len() == H::LENGTH);
+				output.extend_from_slice(hash);
+			},
+			None => (),
+		}
+		Bitmap::encode(
+			children.map(|maybe_child| match maybe_child.borrow() {
+				Some(ChildReference::Hash(h)) => {
+					h.as_ref().encode_to(&mut output);
+					true
+				},
+				&Some(ChildReference::Inline(inline_data, len)) => {
+					inline_data.as_ref()[..len].encode_to(&mut output);
+					true
+				},
+				None => false,
+			}),
+			bitmap.as_mut(),
+		);
+		output[bitmap_index..bitmap_index + BITMAP_LENGTH]
+			.copy_from_slice(&bitmap[..BITMAP_LENGTH]);
+		output
+	}
+}
+
+// utils
+
+/// Encode and allocate node type header (type and size), and partial value.
+/// It uses an iterator over encoded partial bytes as input.
+fn partial_from_iterator_encode<I: Iterator<Item = u8>>(
+	partial: I,
+	nibble_count: usize,
+	node_kind: NodeKind,
+) -> Vec<u8> {
+	let nibble_count = sp_std::cmp::min(trie_constants::NIBBLE_SIZE_BOUND, nibble_count);
+
+	let mut output = Vec::with_capacity(4 + (nibble_count / nibble_ops::NIBBLE_PER_BYTE));
+	match node_kind {
+		NodeKind::Leaf => NodeHeader::Leaf(nibble_count).encode_to(&mut output),
+		NodeKind::BranchWithValue => NodeHeader::Branch(true, nibble_count).encode_to(&mut output),
+		NodeKind::BranchNoValue => NodeHeader::Branch(false, nibble_count).encode_to(&mut output),
+		NodeKind::HashedValueLeaf =>
+			NodeHeader::HashedValueLeaf(nibble_count).encode_to(&mut output),
+		NodeKind::HashedValueBranch =>
+			NodeHeader::HashedValueBranch(nibble_count).encode_to(&mut output),
+	};
+	output.extend(partial);
+	output
+}
+
+/// Encode and allocate node type header (type and size), and partial value.
+/// Same as `partial_from_iterator_encode` but uses non encoded `Partial` as input.
+fn partial_encode(partial: Partial, node_kind: NodeKind) -> Vec<u8> {
+	let number_nibble_encoded = (partial.0).0 as usize;
+	let nibble_count = partial.1.len() * nibble_ops::NIBBLE_PER_BYTE + number_nibble_encoded;
+
+	let nibble_count = sp_std::cmp::min(trie_constants::NIBBLE_SIZE_BOUND, nibble_count);
+
+	let mut output = Vec::with_capacity(4 + partial.1.len());
+	match node_kind {
+		NodeKind::Leaf => NodeHeader::Leaf(nibble_count).encode_to(&mut output),
+		NodeKind::BranchWithValue => NodeHeader::Branch(true, nibble_count).encode_to(&mut output),
+		NodeKind::BranchNoValue => NodeHeader::Branch(false, nibble_count).encode_to(&mut output),
+		NodeKind::HashedValueLeaf =>
+			NodeHeader::HashedValueLeaf(nibble_count).encode_to(&mut output),
+		NodeKind::HashedValueBranch =>
+			NodeHeader::HashedValueBranch(nibble_count).encode_to(&mut output),
+	};
+	if number_nibble_encoded > 0 {
+		output.push(nibble_ops::pad_right((partial.0).1));
+	}
+	output.extend_from_slice(partial.1);
+	output
+}
+
+const BITMAP_LENGTH: usize = 2;
+
+/// Radix 16 trie, bitmap encoding implementation,
+/// it contains children mapping information for a branch
+/// (children presence only), it encodes into
+/// a compact bitmap encoding representation.
+pub(crate) struct Bitmap(u16);
+
+impl Bitmap {
+	pub fn decode(mut data: &[u8]) -> Result<Self, Error> {
+		Ok(Bitmap(u16::decode(&mut data)?))
+	}
+
+	pub fn value_at(&self, i: usize) -> bool {
+		self.0 & (1u16 << i) != 0
+	}
+
+	pub fn encode<I: Iterator<Item = bool>>(has_children: I, dest: &mut [u8]) {
+		let mut bitmap: u16 = 0;
+		let mut cursor: u16 = 1;
+		for v in has_children {
+			if v {
+				bitmap |= cursor
+			}
+			cursor <<= 1;
+		}
+		dest[0] = (bitmap % 256) as u8;
+		dest[1] = (bitmap / 256) as u8;
+	}
+}

--- a/crates/sp-trie/src/node_header.rs
+++ b/crates/sp-trie/src/node_header.rs
@@ -1,0 +1,176 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2015-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The node header.
+
+use crate::trie_constants;
+use codec::{Decode, Encode, Input, Output};
+use sp_std::iter::once;
+
+/// A node header
+#[derive(Copy, Clone, PartialEq, Eq, sp_core::RuntimeDebug)]
+pub(crate) enum NodeHeader {
+	Null,
+	// contains wether there is a value and nibble count
+	Branch(bool, usize),
+	// contains nibble count
+	Leaf(usize),
+	// contains nibble count.
+	HashedValueBranch(usize),
+	// contains nibble count.
+	HashedValueLeaf(usize),
+}
+
+impl NodeHeader {
+	pub(crate) fn contains_hash_of_value(&self) -> bool {
+		matches!(self, NodeHeader::HashedValueBranch(_) | NodeHeader::HashedValueLeaf(_))
+	}
+}
+
+/// NodeHeader without content
+pub(crate) enum NodeKind {
+	Leaf,
+	BranchNoValue,
+	BranchWithValue,
+	HashedValueLeaf,
+	HashedValueBranch,
+}
+
+impl Encode for NodeHeader {
+	fn encode_to<T: Output + ?Sized>(&self, output: &mut T) {
+		match self {
+			NodeHeader::Null => output.push_byte(trie_constants::EMPTY_TRIE),
+			NodeHeader::Branch(true, nibble_count) =>
+				encode_size_and_prefix(*nibble_count, trie_constants::BRANCH_WITH_MASK, 2, output),
+			NodeHeader::Branch(false, nibble_count) => encode_size_and_prefix(
+				*nibble_count,
+				trie_constants::BRANCH_WITHOUT_MASK,
+				2,
+				output,
+			),
+			NodeHeader::Leaf(nibble_count) =>
+				encode_size_and_prefix(*nibble_count, trie_constants::LEAF_PREFIX_MASK, 2, output),
+			NodeHeader::HashedValueBranch(nibble_count) => encode_size_and_prefix(
+				*nibble_count,
+				trie_constants::ALT_HASHING_BRANCH_WITH_MASK,
+				4,
+				output,
+			),
+			NodeHeader::HashedValueLeaf(nibble_count) => encode_size_and_prefix(
+				*nibble_count,
+				trie_constants::ALT_HASHING_LEAF_PREFIX_MASK,
+				3,
+				output,
+			),
+		}
+	}
+}
+
+impl codec::EncodeLike for NodeHeader {}
+
+impl Decode for NodeHeader {
+	fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
+		let i = input.read_byte()?;
+		if i == trie_constants::EMPTY_TRIE {
+			return Ok(NodeHeader::Null)
+		}
+		match i & (0b11 << 6) {
+			trie_constants::LEAF_PREFIX_MASK => Ok(NodeHeader::Leaf(decode_size(i, input, 2)?)),
+			trie_constants::BRANCH_WITH_MASK =>
+				Ok(NodeHeader::Branch(true, decode_size(i, input, 2)?)),
+			trie_constants::BRANCH_WITHOUT_MASK =>
+				Ok(NodeHeader::Branch(false, decode_size(i, input, 2)?)),
+			trie_constants::EMPTY_TRIE => {
+				if i & (0b111 << 5) == trie_constants::ALT_HASHING_LEAF_PREFIX_MASK {
+					Ok(NodeHeader::HashedValueLeaf(decode_size(i, input, 3)?))
+				} else if i & (0b1111 << 4) == trie_constants::ALT_HASHING_BRANCH_WITH_MASK {
+					Ok(NodeHeader::HashedValueBranch(decode_size(i, input, 4)?))
+				} else {
+					// do not allow any special encoding
+					Err("Unallowed encoding".into())
+				}
+			},
+			_ => unreachable!(),
+		}
+	}
+}
+
+/// Returns an iterator over encoded bytes for node header and size.
+/// Size encoding allows unlimited, length inefficient, representation, but
+/// is bounded to 16 bit maximum value to avoid possible DOS.
+pub(crate) fn size_and_prefix_iterator(
+	size: usize,
+	prefix: u8,
+	prefix_mask: usize,
+) -> impl Iterator<Item = u8> {
+	let size = sp_std::cmp::min(trie_constants::NIBBLE_SIZE_BOUND, size);
+
+	let max_value = 255u8 >> prefix_mask;
+	let l1 = sp_std::cmp::min((max_value as usize).saturating_sub(1), size);
+	let (first_byte, mut rem) = if size == l1 {
+		(once(prefix + l1 as u8), 0)
+	} else {
+		(once(prefix + max_value as u8), size - l1)
+	};
+	let next_bytes = move || {
+		if rem > 0 {
+			if rem < 256 {
+				let result = rem - 1;
+				rem = 0;
+				Some(result as u8)
+			} else {
+				rem = rem.saturating_sub(255);
+				Some(255)
+			}
+		} else {
+			None
+		}
+	};
+	first_byte.chain(sp_std::iter::from_fn(next_bytes))
+}
+
+/// Encodes size and prefix to a stream output.
+fn encode_size_and_prefix<W>(size: usize, prefix: u8, prefix_mask: usize, out: &mut W)
+where
+	W: Output + ?Sized,
+{
+	for b in size_and_prefix_iterator(size, prefix, prefix_mask) {
+		out.push_byte(b)
+	}
+}
+
+/// Decode size only from stream input and header byte.
+fn decode_size(
+	first: u8,
+	input: &mut impl Input,
+	prefix_mask: usize,
+) -> Result<usize, codec::Error> {
+	let max_value = 255u8 >> prefix_mask;
+	let mut result = (first & max_value) as usize;
+	if result < max_value as usize {
+		return Ok(result)
+	}
+	result -= 1;
+	while result <= trie_constants::NIBBLE_SIZE_BOUND {
+		let n = input.read_byte()? as usize;
+		if n < 255 {
+			return Ok(result + n + 1)
+		}
+		result += 255;
+	}
+	Ok(trie_constants::NIBBLE_SIZE_BOUND)
+}

--- a/crates/sp-trie/src/storage_proof.rs
+++ b/crates/sp-trie/src/storage_proof.rs
@@ -1,0 +1,178 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codec::{Decode, Encode};
+use hash_db::{HashDB, Hasher};
+use scale_info::TypeInfo;
+use sp_std::{collections::btree_set::BTreeSet, iter::IntoIterator, vec::Vec};
+// Note that `LayoutV1` usage here (proof compaction) is compatible
+// with `LayoutV0`.
+use crate::LayoutV1 as Layout;
+
+/// A proof that some set of key-value pairs are included in the storage trie. The proof contains
+/// the storage values so that the partial storage backend can be reconstructed by a verifier that
+/// does not already have access to the key-value pairs.
+///
+/// The proof consists of the set of serialized nodes in the storage trie accessed when looking up
+/// the keys covered by the proof. Verifying the proof requires constructing the partial trie from
+/// the serialized nodes and performing the key lookups.
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
+pub struct StorageProof {
+	trie_nodes: BTreeSet<Vec<u8>>,
+}
+
+/// Storage proof in compact form.
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
+pub struct CompactProof {
+	pub encoded_nodes: Vec<Vec<u8>>,
+}
+
+impl StorageProof {
+	/// Constructs a storage proof from a subset of encoded trie nodes in a storage backend.
+	pub fn new(trie_nodes: impl IntoIterator<Item = Vec<u8>>) -> Self {
+		StorageProof { trie_nodes: BTreeSet::from_iter(trie_nodes) }
+	}
+
+	/// Returns a new empty proof.
+	///
+	/// An empty proof is capable of only proving trivial statements (ie. that an empty set of
+	/// key-value pairs exist in storage).
+	pub fn empty() -> Self {
+		StorageProof { trie_nodes: BTreeSet::new() }
+	}
+
+	/// Returns whether this is an empty proof.
+	pub fn is_empty(&self) -> bool {
+		self.trie_nodes.is_empty()
+	}
+
+	/// Create an iterator over encoded trie nodes in lexicographical order constructed
+	/// from the proof.
+	pub fn iter_nodes(self) -> StorageProofNodeIterator {
+		StorageProofNodeIterator::new(self)
+	}
+
+	/// Convert into plain node vector.
+	pub fn into_nodes(self) -> BTreeSet<Vec<u8>> {
+		self.trie_nodes
+	}
+
+	/// Creates a `MemoryDB` from `Self`.
+	pub fn into_memory_db<H: Hasher>(self) -> crate::MemoryDB<H> {
+		self.into()
+	}
+
+	/// Merges multiple storage proofs covering potentially different sets of keys into one proof
+	/// covering all keys. The merged proof output may be smaller than the aggregate size of the
+	/// input proofs due to deduplication of trie nodes.
+	pub fn merge<I>(proofs: I) -> Self
+	where
+		I: IntoIterator<Item = Self>,
+	{
+		let trie_nodes = proofs
+			.into_iter()
+			.flat_map(|proof| proof.iter_nodes())
+			.collect::<sp_std::collections::btree_set::BTreeSet<_>>()
+			.into_iter()
+			.collect();
+
+		Self { trie_nodes }
+	}
+
+	/// Encode as a compact proof with default
+	/// trie layout.
+	pub fn into_compact_proof<H: Hasher>(
+		self,
+		root: H::Out,
+	) -> Result<CompactProof, crate::CompactProofError<Layout<H>>> {
+		crate::encode_compact::<Layout<H>>(self, root)
+	}
+
+	/// Returns the estimated encoded size of the compact proof.
+	///
+	/// Running this operation is a slow operation (build the whole compact proof) and should only
+	/// be in non sensitive path.
+	///
+	/// Return `None` on error.
+	pub fn encoded_compact_size<H: Hasher>(self, root: H::Out) -> Option<usize> {
+		let compact_proof = self.into_compact_proof::<H>(root);
+		compact_proof.ok().map(|p| p.encoded_size())
+	}
+}
+
+impl CompactProof {
+	/// Return an iterator on the compact encoded nodes.
+	pub fn iter_compact_encoded_nodes(&self) -> impl Iterator<Item = &[u8]> {
+		self.encoded_nodes.iter().map(Vec::as_slice)
+	}
+
+	/// Decode to a full storage_proof.
+	///
+	/// Method use a temporary `HashDB`, and `sp_trie::decode_compact`
+	/// is often better.
+	pub fn to_storage_proof<H: Hasher>(
+		&self,
+		expected_root: Option<&H::Out>,
+	) -> Result<(StorageProof, H::Out), crate::CompactProofError<Layout<H>>> {
+		let mut db = crate::MemoryDB::<H>::new(&[]);
+		let root = crate::decode_compact::<Layout<H>, _, _>(
+			&mut db,
+			self.iter_compact_encoded_nodes(),
+			expected_root,
+		)?;
+		Ok((
+			StorageProof::new(db.drain().into_iter().filter_map(|kv| {
+				if (kv.1).1 > 0 {
+					Some((kv.1).0)
+				} else {
+					None
+				}
+			})),
+			root,
+		))
+	}
+}
+
+/// An iterator over trie nodes constructed from a storage proof. The nodes are not guaranteed to
+/// be traversed in any particular order.
+pub struct StorageProofNodeIterator {
+	inner: <BTreeSet<Vec<u8>> as IntoIterator>::IntoIter,
+}
+
+impl StorageProofNodeIterator {
+	fn new(proof: StorageProof) -> Self {
+		StorageProofNodeIterator { inner: proof.trie_nodes.into_iter() }
+	}
+}
+
+impl Iterator for StorageProofNodeIterator {
+	type Item = Vec<u8>;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		self.inner.next()
+	}
+}
+
+impl<H: Hasher> From<StorageProof> for crate::MemoryDB<H> {
+	fn from(proof: StorageProof) -> Self {
+		let mut db = crate::MemoryDB::default();
+		for item in proof.iter_nodes() {
+			db.insert(crate::EMPTY_PREFIX, &item);
+		}
+		db
+	}
+}

--- a/crates/sp-trie/src/trie_codec.rs
+++ b/crates/sp-trie/src/trie_codec.rs
@@ -1,0 +1,250 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2021-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compact proof support.
+//!
+//! This uses compact proof from trie crate and extends
+//! it to substrate specific layout and child trie system.
+
+use crate::{
+	CompactProof, HashDBT, StorageProof, TrieConfiguration, TrieError, TrieHash, EMPTY_PREFIX,
+};
+use sp_std::{boxed::Box, vec::Vec};
+#[cfg(feature = "std")]
+use std::error::Error as StdError;
+#[cfg(feature = "std")]
+use std::fmt;
+use trie_db::Trie;
+
+/// Error for trie node decoding.
+pub enum Error<L: TrieConfiguration> {
+	/// Verification failed due to root mismatch.
+	RootMismatch(TrieHash<L>, TrieHash<L>),
+	/// Missing nodes in proof.
+	IncompleteProof,
+	/// Compact node is not needed.
+	ExtraneousChildNode,
+	/// Child content with root not in proof.
+	ExtraneousChildProof(TrieHash<L>),
+	/// Bad child trie root.
+	InvalidChildRoot(Vec<u8>, Vec<u8>),
+	/// Errors from trie crate.
+	TrieError(Box<TrieError<L>>),
+}
+
+impl<L: TrieConfiguration> From<Box<TrieError<L>>> for Error<L> {
+	fn from(error: Box<TrieError<L>>) -> Self {
+		Error::TrieError(error)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<L: TrieConfiguration> StdError for Error<L> {
+	fn description(&self) -> &str {
+		match self {
+			Error::InvalidChildRoot(..) => "Invalid child root error",
+			Error::TrieError(..) => "Trie db error",
+			Error::RootMismatch(..) => "Trie db error",
+			Error::IncompleteProof => "Incomplete proof",
+			Error::ExtraneousChildNode => "Extraneous child node",
+			Error::ExtraneousChildProof(..) => "Extraneous child proof",
+		}
+	}
+}
+
+#[cfg(feature = "std")]
+impl<L: TrieConfiguration> fmt::Debug for Error<L> {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		<Self as fmt::Display>::fmt(&self, f)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<L: TrieConfiguration> fmt::Display for Error<L> {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match self {
+			Error::InvalidChildRoot(k, v) => write!(f, "InvalidChildRoot at {:x?}: {:x?}", k, v),
+			Error::TrieError(e) => write!(f, "Trie error: {}", e),
+			Error::IncompleteProof => write!(f, "Incomplete proof"),
+			Error::ExtraneousChildNode => write!(f, "Child node content with no root in proof"),
+			Error::ExtraneousChildProof(root) => {
+				write!(f, "Proof of child trie {:x?} not in parent proof", root.as_ref())
+			},
+			Error::RootMismatch(root, expected) => write!(
+				f,
+				"Verification error, root is {:x?}, expected: {:x?}",
+				root.as_ref(),
+				expected.as_ref(),
+			),
+		}
+	}
+}
+
+/// Decode a compact proof.
+///
+/// Takes as input a destination `db` for decoded node and `encoded`
+/// an iterator of compact encoded nodes.
+///
+/// Child trie are decoded in order of child trie root present
+/// in the top trie.
+pub fn decode_compact<'a, L, DB, I>(
+	db: &mut DB,
+	encoded: I,
+	expected_root: Option<&TrieHash<L>>,
+) -> Result<TrieHash<L>, Error<L>>
+where
+	L: TrieConfiguration,
+	DB: HashDBT<L::Hash, trie_db::DBValue> + hash_db::HashDBRef<L::Hash, trie_db::DBValue>,
+	I: IntoIterator<Item = &'a [u8]>,
+{
+	let mut nodes_iter = encoded.into_iter();
+	let (top_root, _nb_used) = trie_db::decode_compact_from_iter::<L, _, _>(db, &mut nodes_iter)?;
+
+	// Only check root if expected root is passed as argument.
+	if let Some(expected_root) = expected_root {
+		if expected_root != &top_root {
+			return Err(Error::RootMismatch(top_root.clone(), expected_root.clone()))
+		}
+	}
+
+	let mut child_tries = Vec::new();
+	{
+		// fetch child trie roots
+		let trie = crate::TrieDB::<L>::new(db, &top_root)?;
+
+		let mut iter = trie.iter()?;
+
+		let childtrie_roots = sp_core::storage::well_known_keys::DEFAULT_CHILD_STORAGE_KEY_PREFIX;
+		if iter.seek(childtrie_roots).is_ok() {
+			loop {
+				match iter.next() {
+					Some(Ok((key, value))) if key.starts_with(childtrie_roots) => {
+						// we expect all default child trie root to be correctly encoded.
+						// see other child trie functions.
+						let mut root = TrieHash::<L>::default();
+						// still in a proof so prevent panic
+						if root.as_mut().len() != value.as_slice().len() {
+							return Err(Error::InvalidChildRoot(key, value))
+						}
+						root.as_mut().copy_from_slice(value.as_ref());
+						child_tries.push(root);
+					},
+					// allow incomplete database error: we only
+					// require access to data in the proof.
+					Some(Err(error)) => match *error {
+						trie_db::TrieError::IncompleteDatabase(..) => (),
+						e => return Err(Box::new(e).into()),
+					},
+					_ => break,
+				}
+			}
+		}
+	}
+
+	if !HashDBT::<L::Hash, _>::contains(db, &top_root, EMPTY_PREFIX) {
+		return Err(Error::IncompleteProof)
+	}
+
+	let mut previous_extracted_child_trie = None;
+	let mut nodes_iter = nodes_iter.peekable();
+	for child_root in child_tries.into_iter() {
+		if previous_extracted_child_trie.is_none() && nodes_iter.peek().is_some() {
+			let (top_root, _) = trie_db::decode_compact_from_iter::<L, _, _>(db, &mut nodes_iter)?;
+			previous_extracted_child_trie = Some(top_root);
+		}
+
+		// we do not early exit on root mismatch but try the
+		// other read from proof (some child root may be
+		// in proof without actual child content).
+		if Some(child_root) == previous_extracted_child_trie {
+			previous_extracted_child_trie = None;
+		}
+	}
+
+	if let Some(child_root) = previous_extracted_child_trie {
+		// A child root was read from proof but is not present
+		// in top trie.
+		return Err(Error::ExtraneousChildProof(child_root))
+	}
+
+	if nodes_iter.next().is_some() {
+		return Err(Error::ExtraneousChildNode)
+	}
+
+	Ok(top_root)
+}
+
+/// Encode a compact proof.
+///
+/// Takes as input all full encoded node from the proof, and
+/// the root.
+/// Then parse all child trie root and compress main trie content first
+/// then all child trie contents.
+/// Child trie are ordered by the order of their roots in the top trie.
+pub fn encode_compact<L>(proof: StorageProof, root: TrieHash<L>) -> Result<CompactProof, Error<L>>
+where
+	L: TrieConfiguration,
+{
+	let mut child_tries = Vec::new();
+	let partial_db = proof.into_memory_db();
+	let mut compact_proof = {
+		let trie = crate::TrieDB::<L>::new(&partial_db, &root)?;
+
+		let mut iter = trie.iter()?;
+
+		let childtrie_roots = sp_core::storage::well_known_keys::DEFAULT_CHILD_STORAGE_KEY_PREFIX;
+		if iter.seek(childtrie_roots).is_ok() {
+			loop {
+				match iter.next() {
+					Some(Ok((key, value))) if key.starts_with(childtrie_roots) => {
+						let mut root = TrieHash::<L>::default();
+						if root.as_mut().len() != value.as_slice().len() {
+							// some child trie root in top trie are not an encoded hash.
+							return Err(Error::InvalidChildRoot(key.to_vec(), value.to_vec()))
+						}
+						root.as_mut().copy_from_slice(value.as_ref());
+						child_tries.push(root);
+					},
+					// allow incomplete database error: we only
+					// require access to data in the proof.
+					Some(Err(error)) => match *error {
+						trie_db::TrieError::IncompleteDatabase(..) => (),
+						e => return Err(Box::new(e).into()),
+					},
+					_ => break,
+				}
+			}
+		}
+
+		trie_db::encode_compact::<L>(&trie)?
+	};
+
+	for child_root in child_tries {
+		if !HashDBT::<L::Hash, _>::contains(&partial_db, &child_root, EMPTY_PREFIX) {
+			// child proof are allowed to be missing (unused root can be included
+			// due to trie structure modification).
+			continue
+		}
+
+		let trie = crate::TrieDB::<L>::new(&partial_db, &child_root)?;
+		let child_proof = trie_db::encode_compact::<L>(&trie)?;
+
+		compact_proof.extend(child_proof);
+	}
+
+	Ok(CompactProof { encoded_nodes: compact_proof })
+}

--- a/crates/sp-trie/src/trie_stream.rs
+++ b/crates/sp-trie/src/trie_stream.rs
@@ -1,0 +1,148 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2015-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `TrieStream` implementation for Substrate's trie format.
+
+use crate::{
+	node_header::{size_and_prefix_iterator, NodeKind},
+	trie_constants,
+};
+use codec::{Compact, Encode};
+use hash_db::Hasher;
+use sp_std::vec::Vec;
+use trie_root;
+
+/// Codec-flavored TrieStream.
+#[derive(Default, Clone)]
+pub struct TrieStream {
+	/// Current node buffer.
+	buffer: Vec<u8>,
+}
+
+impl TrieStream {
+	// useful for debugging but not used otherwise
+	pub fn as_raw(&self) -> &[u8] {
+		&self.buffer
+	}
+}
+
+fn branch_node_bit_mask(has_children: impl Iterator<Item = bool>) -> (u8, u8) {
+	let mut bitmap: u16 = 0;
+	let mut cursor: u16 = 1;
+	for v in has_children {
+		if v {
+			bitmap |= cursor
+		}
+		cursor <<= 1;
+	}
+	((bitmap % 256) as u8, (bitmap / 256) as u8)
+}
+
+/// Create a leaf/branch node, encoding a number of nibbles.
+fn fuse_nibbles_node<'a>(nibbles: &'a [u8], kind: NodeKind) -> impl Iterator<Item = u8> + 'a {
+	let size = sp_std::cmp::min(trie_constants::NIBBLE_SIZE_BOUND, nibbles.len());
+
+	let iter_start = match kind {
+		NodeKind::Leaf => size_and_prefix_iterator(size, trie_constants::LEAF_PREFIX_MASK, 2),
+		NodeKind::BranchNoValue =>
+			size_and_prefix_iterator(size, trie_constants::BRANCH_WITHOUT_MASK, 2),
+		NodeKind::BranchWithValue =>
+			size_and_prefix_iterator(size, trie_constants::BRANCH_WITH_MASK, 2),
+		NodeKind::HashedValueLeaf =>
+			size_and_prefix_iterator(size, trie_constants::ALT_HASHING_LEAF_PREFIX_MASK, 3),
+		NodeKind::HashedValueBranch =>
+			size_and_prefix_iterator(size, trie_constants::ALT_HASHING_BRANCH_WITH_MASK, 4),
+	};
+	iter_start
+		.chain(if nibbles.len() % 2 == 1 { Some(nibbles[0]) } else { None })
+		.chain(nibbles[nibbles.len() % 2..].chunks(2).map(|ch| ch[0] << 4 | ch[1]))
+}
+
+use trie_root::Value as TrieStreamValue;
+impl trie_root::TrieStream for TrieStream {
+	fn new() -> Self {
+		Self { buffer: Vec::new() }
+	}
+
+	fn append_empty_data(&mut self) {
+		self.buffer.push(trie_constants::EMPTY_TRIE);
+	}
+
+	fn append_leaf(&mut self, key: &[u8], value: TrieStreamValue) {
+		let kind = match &value {
+			TrieStreamValue::Inline(..) => NodeKind::Leaf,
+			TrieStreamValue::Node(..) => NodeKind::HashedValueLeaf,
+		};
+		self.buffer.extend(fuse_nibbles_node(key, kind));
+		match &value {
+			TrieStreamValue::Inline(value) => {
+				Compact(value.len() as u32).encode_to(&mut self.buffer);
+				self.buffer.extend_from_slice(value);
+			},
+			TrieStreamValue::Node(hash) => {
+				self.buffer.extend_from_slice(hash.as_slice());
+			},
+		};
+	}
+
+	fn begin_branch(
+		&mut self,
+		maybe_partial: Option<&[u8]>,
+		maybe_value: Option<TrieStreamValue>,
+		has_children: impl Iterator<Item = bool>,
+	) {
+		if let Some(partial) = maybe_partial {
+			let kind = match &maybe_value {
+				None => NodeKind::BranchNoValue,
+				Some(TrieStreamValue::Inline(..)) => NodeKind::BranchWithValue,
+				Some(TrieStreamValue::Node(..)) => NodeKind::HashedValueBranch,
+			};
+
+			self.buffer.extend(fuse_nibbles_node(partial, kind));
+			let bm = branch_node_bit_mask(has_children);
+			self.buffer.extend([bm.0, bm.1].iter());
+		} else {
+			unreachable!("trie stream codec only for no extension trie");
+		}
+		match maybe_value {
+			None => (),
+			Some(TrieStreamValue::Inline(value)) => {
+				Compact(value.len() as u32).encode_to(&mut self.buffer);
+				self.buffer.extend_from_slice(value);
+			},
+			Some(TrieStreamValue::Node(hash)) => {
+				self.buffer.extend_from_slice(hash.as_slice());
+			},
+		}
+	}
+
+	fn append_extension(&mut self, _key: &[u8]) {
+		debug_assert!(false, "trie stream codec only for no extension trie");
+	}
+
+	fn append_substream<H: Hasher>(&mut self, other: Self) {
+		let data = other.out();
+		match data.len() {
+			0..=31 => data.encode_to(&mut self.buffer),
+			_ => H::hash(&data).as_ref().encode_to(&mut self.buffer),
+		}
+	}
+
+	fn out(self) -> Vec<u8> {
+		self.buffer
+	}
+}

--- a/standalone/pruntime/app/Cargo.lock
+++ b/standalone/pruntime/app/Cargo.lock
@@ -722,6 +722,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
+name = "ethbloom"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,7 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
  "serde",
 ]
 
@@ -1617,6 +1662,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
+dependencies = [
+ "hashbrown 0.11.2",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,7 +1722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de006e09d04fc301a5f7e817b75aa49801c4479a8af753764416b085337ddcc5"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.11.2",
  "parity-util-mem",
 ]
 
@@ -2524,11 +2578,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "ethereum-types",
+ "hashbrown 0.11.2",
  "impl-trait-for-tuples",
+ "lru",
  "parity-util-mem-derive",
  "parking_lot",
  "primitive-types",
+ "smallvec",
  "winapi",
 ]
 
@@ -2871,12 +2928,16 @@ dependencies = [
 name = "phala-trie-storage"
 version = "0.1.0"
 dependencies = [
+ "hash-db",
  "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
  "serde",
  "sp-core",
  "sp-io",
  "sp-state-machine",
  "sp-trie",
+ "trie-db 0.23.1",
 ]
 
 [[package]]
@@ -2957,6 +3018,7 @@ checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -3383,6 +3445,16 @@ dependencies = [
  "opaque-debug 0.3.0",
  "ring 0.16.20",
  "zeroize",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -4250,7 +4322,7 @@ dependencies = [
  "sp-trie",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.22.6",
  "trie-root",
 ]
 
@@ -4314,7 +4386,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-std",
- "trie-db",
+ "trie-db 0.22.6",
  "trie-root",
 ]
 
@@ -4942,7 +5014,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eac131e334e81b6b3be07399482042838adcd7957aa0010231d0813e39e02fa"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.11.2",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.12.3",
  "log",
  "rustc-hex",
  "smallvec",

--- a/standalone/pruntime/enclave/Cargo.lock
+++ b/standalone/pruntime/enclave/Cargo.lock
@@ -1772,6 +1772,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hashbrown_tstd"
 version = "0.11.2"
 
@@ -1994,7 +2003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2427,7 +2436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de006e09d04fc301a5f7e817b75aa49801c4479a8af753764416b085337ddcc5"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.11.2",
  "parity-util-mem",
 ]
 
@@ -3123,7 +3132,7 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-std",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
 ]
 
 [[package]]
@@ -3316,7 +3325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.11.2",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot",
@@ -3541,7 +3550,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-trie",
+ "sp-trie 4.0.0",
  "surf",
  "thiserror",
  "webpki 0.21.4",
@@ -3750,7 +3759,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-state-machine",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
 ]
 
 [[package]]
@@ -5241,7 +5250,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-tracing",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "sp-wasm-interface",
  "tracing",
  "tracing-core",
@@ -5420,11 +5429,11 @@ dependencies = [
  "sp-externalities",
  "sp-panic-handler",
  "sp-std",
- "sp-trie",
+ "sp-trie 4.0.0-dev",
  "thiserror",
  "tracing",
- "trie-db",
- "trie-root",
+ "trie-db 0.22.6",
+ "trie-root 0.16.0",
 ]
 
 [[package]]
@@ -5487,8 +5496,22 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-std",
- "trie-db",
- "trie-root",
+ "trie-db 0.22.6",
+ "trie-root 0.16.0",
+]
+
+[[package]]
+name = "sp-trie"
+version = "4.0.0"
+dependencies = [
+ "hash-db",
+ "memory-db",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-std",
+ "trie-db 0.23.1",
+ "trie-root 0.17.0",
 ]
 
 [[package]]
@@ -6040,7 +6063,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eac131e334e81b6b3be07399482042838adcd7957aa0010231d0813e39e02fa"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.11.2",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.12.3",
  "log",
  "rustc-hex",
  "smallvec",
@@ -6051,6 +6087,15 @@ name = "trie-root"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "652931506d2c1244d7217a70b99f56718a7b4161b37f04e7cd868072a99f68cd"
+dependencies = [
+ "hash-db",
+]
+
+[[package]]
+name = "trie-root"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a36c5ca3911ed3c9a5416ee6c679042064b93fc637ded67e25f92e68d783891"
 dependencies = [
  "hash-db",
 ]

--- a/standalone/pruntime/enclave/Cargo.lock
+++ b/standalone/pruntime/enclave/Cargo.lock
@@ -1197,6 +1197,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
+name = "ethbloom"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "git+https://github.com/Phala-Network/event-listener-sgx.git?branch=phala#b2aceade7a2f395ae59969696a6f64423618467c"
@@ -1977,6 +2004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2408,15 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
  "value-bag",
+]
+
+[[package]]
+name = "lru"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
+dependencies = [
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -3325,11 +3370,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if",
+ "ethereum-types",
  "hashbrown 0.11.2",
  "impl-trait-for-tuples",
+ "lru",
  "parity-util-mem-derive",
  "parking_lot",
  "primitive-types",
+ "smallvec",
  "winapi",
 ]
 
@@ -3754,12 +3802,16 @@ dependencies = [
 name = "phala-trie-storage"
 version = "0.1.0"
 dependencies = [
+ "hash-db",
  "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
  "serde",
  "sp-core",
  "sp-io",
  "sp-state-machine",
  "sp-trie 4.0.0-dev",
+ "trie-db 0.23.1",
 ]
 
 [[package]]
@@ -3993,6 +4045,7 @@ checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -4452,6 +4505,16 @@ dependencies = [
  "sgx_tstd",
  "spin 0.5.2",
  "untrusted",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]


### PR DESCRIPTION
I've tried to upgrade the entire substrate in #1118, but encountered a bunch of troubles difficult to resolve.

Instead, this PR backports the sp-trie that supports TrieLayoutV1 to pruntime-v0.

There are tens of commits modifying `sp-trie` in the substrate from the version pruntime-v0 uses to polkadot-v0.9.36:
```
* fafc8e0ba8 - Remove `mem_info` and references to `parity-util-mem` (#12795) (6 weeks ago) <Marcin S>
* 108d8eed88 - (tag: sp-runtime-v7.0.0, tag: sp-core-v7.0.0) release `sp-core 7.0.0` and `sp-runtime 7.0.0` (#12599) (9 weeks ago) <Niklas Adolfsson>
* c460f4be08 - Update some dependencies to prune duplicated crates with different version (#12560) (10 weeks ago) <Qinxuan Chen>
* a1dee7ecd2 - Remove partial key size limit from trie codec (#12566) (10 weeks ago) <cheme>
* 14c3ef3898 - `sp_trie::Recorder`: Fix recording the same key for different tries (#12636) (2 months ago) <Bastian Köcher>
* cafbb668d2 - Guard some invalid node for proof decoding. (#12417) (2 months ago) <cheme>
* f2bc08a307 - feat: generalize some functions in sp-trie (#12376) (3 months ago) <yjh>
* 4c45673d92 - Prepare for latest clippy (nightly 09-10-2022) (#12466) (3 months ago) <Bastian Köcher>
* fc67cbb66d - update kvdb & co (#12312) (3 months ago) <Andronik>
* 409167ef42 - Use `array-bytes` for All Array/Bytes/Hex Operations (#12190) (4 months ago) <Xavier Lau>
* 3db5c9512c - Fix flaky trie-db cache test (#12139) (5 months ago) <Bastian Köcher>
* 4262c63fec - Bump parking_lot from 0.12.0 to 0.12.1 (#12098) (5 months ago) <dependabot[bot]>
* 40703f4116 - Print bootnode mismatch message as `warning` (#12075) (5 months ago) <Bastian Köcher>
* 00cc5f1041 - Introduce trie level cache and remove state cache (#11407) (5 months ago) <Bastian Köcher>
* 9428b0ea49 - Prepare for rust 1.62.1 (#11903) (6 months ago) <Sebastian Kunert>
* 4fe4fc471b - InMemoryBackend: Make it generic over the key hasher (#11488) (8 months ago) <Bastian Köcher>
* e8e6833213 - Bump scale-info from 2.0.1 to 2.1.1 (#11420) (8 months ago) <dependabot[bot]>
* f367d9062a - Basic TOML Lint (#11348) (9 months ago) <Shawn Tabrizi>
* 0ba251c938 - Apply some clippy lints (#11154) (9 months ago) <Falco Hirschenberger>
* 32a4fe01f1 - Fix the undeterministic storage proof recorded for the same execution (#10915) (11 months ago) <Liu-Cheng Xu>
* 7a742c6f77 - Bump scale-info from 2.0.0 to 2.0.1 (#10965) (11 months ago) <dependabot[bot]>
* 0063f74287 - sp-trie: Switch to thiserror and some other small cleanups (#10954) (11 months ago) <Bastian Köcher>
* d14784fee8 - Release primitive crates (#10937) (11 months ago) <Andrew Jones>
* c22fce5a31 - Upgrading parity-scale-codec to v3 (#10825) (11 months ago) <wigy>
* 542d587c3d - state-machine: Move all functionality from trie backend to the essence (#10904) (11 months ago) <Bastian Köcher>
* 6611740479 - Release `pallet-contracts-primitives` (#10772) (12 months ago) <Alexander Theißen>
* 823c253361 - Relax types on `DigestItemRef`, such that byte slices can be used in addition to vector references (#10536) (12 months ago) <Nazar Mokrynskyi>
* a2ae8a5702 - Make clippy _a little_ more annoying (#10570) (1 year ago) <Squirrel>
* ded44948e2 - Happy new year 2022 (#10573) (1 year ago) <Bastian Köcher>
* b03e8bcf15 - Inner hashing of value in state trie (runtime versioning). (#9732) (1 year, 1 month ago) <cheme>
* 50ab759f7a - (tag: publish-sp-runtime-v4.0.0) Prepare `sp-runtime` for publication (#10451) (1 year, 1 month ago) <David>
* a991b0aecb - `inspect-key`: Adds support for `expect-public` (#10430) (1 year, 1 month ago) <Bastian Köcher>
* 25e636bcbf - (tag: publish-sp-core-v4.0.0) Release sp-core 4.0.0 (#10447) (1 year, 1 month ago) <David>
* 6d09a45caf - allow try-runtime and `TestExternalities` to report PoV size (#10372) (1 year, 1 month ago) <Kian Paimani>
```
The `b03e8bcf15` is the commit introducing `TrieLayoutV1`.
I extracted the later a2ae8a5702 and patch it with `32a4fe01f1` by the following commands:
```bash
git checkout a2ae8a5702  # Make clippy _a little_ more annoying (#10570) 
git cherry-pick 32a4fe01f1  # Fix the undeterministic storage proof recorded for the same execution (#10915)
```
**Then put the sp-trie at `crates/sp-trie` and use it in the light validation client in pruntime to handle the relay chain proof.
We still use trie layout v0 for the trie to store the parachain state.**

