### PR TITLE
Backport custom MemoryDB to pruntime v0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,15 +966,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3630,20 +3621,6 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.3",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -7274,7 +7251,6 @@ dependencies = [
  "hash-db",
  "hash256-std-hasher",
  "hex",
- "im",
  "impl-serde",
  "parity-scale-codec",
  "parity-util-mem",
@@ -8130,15 +8106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -10031,16 +9998,6 @@ name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,6 +2377,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethbloom"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3597,12 +3633,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.3",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
 ]
 
 [[package]]
@@ -6572,8 +6631,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if 1.0.0",
+ "ethereum-types",
  "hashbrown 0.11.2",
  "impl-trait-for-tuples",
+ "lru 0.6.6",
  "parity-util-mem-derive",
  "parking_lot",
  "primitive-types",
@@ -7210,10 +7271,14 @@ dependencies = [
 name = "phala-trie-storage"
 version = "0.1.0"
 dependencies = [
+ "hash-db",
  "hash256-std-hasher",
  "hex",
+ "im",
  "impl-serde",
  "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
  "serde",
  "serde_json",
  "sp-application-crypto",
@@ -7222,6 +7287,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie 4.0.0-dev",
+ "trie-db 0.23.1",
 ]
 
 [[package]]
@@ -7616,6 +7682,7 @@ checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -8066,6 +8133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8319,6 +8395,16 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes 1.1.0",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -9945,6 +10031,16 @@ name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "slab"

--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -211,7 +211,7 @@ pub mod cluster {
                 .clusters
                 .entry(cluster_id.clone())
                 .or_insert_with(|| Cluster {
-                    storage: Default::default(),
+                    storage: pink::Storage::new_empty(),
                     contracts: Default::default(),
                     key: contract_key.clone(),
                 });

--- a/crates/phala-trie-storage/Cargo.toml
+++ b/crates/phala-trie-storage/Cargo.toml
@@ -18,7 +18,6 @@ sp-state-machine = { path = "../../substrate/primitives/state-machine", default-
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 hash-db = "0.15.2"
 trie-db = "0.23.0"
-im = "15.1.0"
 parity-util-mem = "0.10"
 
 [dev-dependencies]

--- a/crates/phala-trie-storage/Cargo.toml
+++ b/crates/phala-trie-storage/Cargo.toml
@@ -8,13 +8,18 @@ homepage = "https://phala.network/"
 repository = "https://github.com/Phala-Network/phala-blockchain"
 
 [dependencies]
-parity-scale-codec = { version = "2.0.0", default-features = false }
+parity-scale-codec = { version = "2", default-features = false }
+scale-info = { version = "1", default-features = false }
 sp-core = { path = "../../substrate/primitives/core", default-features = false, features = ["full_crypto"] }
 sp-trie = { path = "../../substrate/primitives/trie", default-features = false }
 sp-io   = { path = "../../substrate/primitives/io", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
 sp-state-machine = { path = "../../substrate/primitives/state-machine", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
+hash-db = "0.15.2"
+trie-db = "0.23.0"
+im = "15.1.0"
+parity-util-mem = "0.10"
 
 [dev-dependencies]
 sp-runtime = { path = "../../substrate/primitives/runtime", default-features = false }

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -80,7 +80,7 @@ where
     S: Serializer,
 {
     let root = trie.root();
-    let kvs = trie.backend_storage().clone().drain();
+    let kvs = trie.backend_storage();
     (root, ser::SerAsSeq(kvs)).serialize(serializer)
 }
 

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -33,18 +33,20 @@ pub type StorageCollection = Vec<(StorageKey, Option<StorageValue>)>;
 pub type ChildStorageCollection = Vec<(StorageKey, StorageCollection)>;
 
 pub type InMemoryBackend<H> = TrieBackend<MemoryDB<H>, H>;
-pub struct TrieStorage<H: Hasher>(InMemoryBackend<H>);
+pub struct TrieStorage<H: Hasher>(InMemoryBackend<H>)
+where
+    H::Out: Ord;
 
 pub fn new_backend<H: Hasher>() -> InMemoryBackend<H>
 where
-    H::Out: Codec,
+    H::Out: Codec + Ord,
 {
     TrieBackend::new(Default::default(), Default::default())
 }
 
 impl<H: Hasher> Default for TrieStorage<H>
 where
-    H::Out: Codec,
+    H::Out: Codec + Ord,
 {
     fn default() -> Self {
         Self(new_backend())
@@ -55,7 +57,7 @@ pub fn load_trie_backend<H: Hasher>(
     pairs: impl Iterator<Item = (impl AsRef<[u8]>, impl AsRef<[u8]>)>,
 ) -> TrieBackend<MemoryDB<H>, H>
 where
-    H::Out: Codec,
+    H::Out: Codec + Ord,
 {
     let mut root = Default::default();
     let mut mdb = Default::default();
@@ -76,7 +78,7 @@ pub fn serialize_trie_backend<H: Hasher, S>(
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
-    H::Out: Codec + Serialize,
+    H::Out: Codec + Serialize + Ord,
     S: Serializer,
 {
     let root = trie.root();
@@ -89,7 +91,7 @@ pub fn deserialize_trie_backend<'de, H: Hasher, De>(
     deserializer: De,
 ) -> Result<TrieBackend<MemoryDB<H>, H>, De::Error>
 where
-    H::Out: Codec + Deserialize<'de>,
+    H::Out: Codec + Deserialize<'de> + Ord,
     De: Deserializer<'de>,
 {
     let (root, kvs): (H::Out, Vec<(Vec<u8>, i32)>) = Deserialize::deserialize(deserializer)?;
@@ -106,7 +108,7 @@ pub fn clone_trie_backend<H: Hasher>(
     trie: &TrieBackend<MemoryDB<H>, H>,
 ) -> TrieBackend<MemoryDB<H>, H>
 where
-    H::Out: Codec,
+    H::Out: Codec + Ord,
 {
     let root = trie.root();
     let mdb = trie.backend_storage().clone();

--- a/crates/phala-trie-storage/src/memdb.rs
+++ b/crates/phala-trie-storage/src/memdb.rs
@@ -1,0 +1,735 @@
+//! Reference-counted memory-based `HashDB` implementation.
+use hash_db::{
+    AsHashDB, AsPlainDB, HashDB, HashDBRef, Hasher as KeyHasher, PlainDB, PlainDBRef, Prefix,
+};
+use im::{hashmap::Entry, HashMap};
+use parity_util_mem::{malloc_size, MallocSizeOf, MallocSizeOfOps};
+use std::{borrow::Borrow, cmp::Eq, hash, marker::PhantomData, mem};
+
+use sp_state_machine::{backend::Consolidate, DefaultError, TrieBackendStorage};
+use trie_db::DBValue;
+
+pub trait MaybeDebug: std::fmt::Debug {}
+impl<T: std::fmt::Debug> MaybeDebug for T {}
+
+pub type DefaultMemTracker<T> = MemCounter<T>;
+
+pub struct MemoryDB<H, KF, T, M = DefaultMemTracker<T>>
+where
+    H: KeyHasher,
+    KF: KeyFunction<H>,
+    M: MemTracker<T>,
+{
+    data: HashMap<KF::Key, (T, i32)>,
+    malloc_tracker: M,
+    hashed_null_node: H::Out,
+    null_node_data: T,
+    _kf: PhantomData<KF>,
+}
+
+impl<H, KF, T, M> Clone for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    KF: KeyFunction<H>,
+    T: Clone,
+    M: MemTracker<T> + Copy,
+{
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            hashed_null_node: self.hashed_null_node,
+            null_node_data: self.null_node_data.clone(),
+            malloc_tracker: self.malloc_tracker,
+            _kf: Default::default(),
+        }
+    }
+}
+
+pub trait KeyFunction<H: KeyHasher> {
+    type Key: Send + Sync + Clone + hash::Hash + Eq;
+
+    fn key(hash: &H::Out, prefix: Prefix) -> Self::Key;
+}
+
+/// Key function that only uses the hash
+pub struct HashKey<H>(PhantomData<H>);
+
+impl<H> Clone for HashKey<H> {
+    fn clone(&self) -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<H> core::fmt::Debug for HashKey<H> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::write!(f, "HashKey")
+    }
+}
+
+impl<H: KeyHasher> KeyFunction<H> for HashKey<H> {
+    type Key = H::Out;
+
+    fn key(hash: &H::Out, prefix: Prefix) -> H::Out {
+        hash_key::<H>(hash, prefix)
+    }
+}
+
+/// Make database key from hash only.
+pub fn hash_key<H: KeyHasher>(key: &H::Out, _prefix: Prefix) -> H::Out {
+    *key
+}
+
+/// Key function that concatenates prefix and hash.
+pub struct PrefixedKey<H>(PhantomData<H>);
+
+impl<H> Clone for PrefixedKey<H> {
+    fn clone(&self) -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<H> core::fmt::Debug for PrefixedKey<H> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::write!(f, "PrefixedKey")
+    }
+}
+
+impl<H: KeyHasher> KeyFunction<H> for PrefixedKey<H> {
+    type Key = Vec<u8>;
+
+    fn key(hash: &H::Out, prefix: Prefix) -> Vec<u8> {
+        prefixed_key::<H>(hash, prefix)
+    }
+}
+
+/// Derive a database key from hash value of the node (key) and  the node prefix.
+pub fn prefixed_key<H: KeyHasher>(key: &H::Out, prefix: Prefix) -> Vec<u8> {
+    let mut prefixed_key = Vec::with_capacity(key.as_ref().len() + prefix.0.len() + 1);
+    prefixed_key.extend_from_slice(prefix.0);
+    if let Some(last) = prefix.1 {
+        prefixed_key.push(last);
+    }
+    prefixed_key.extend_from_slice(key.as_ref());
+    prefixed_key
+}
+
+impl<H, KF, T, M> Default for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: for<'a> From<&'a [u8]> + Clone,
+    KF: KeyFunction<H>,
+    M: MemTracker<T> + Default,
+{
+    fn default() -> Self {
+        Self::from_null_node(&[0u8][..], [0u8][..].into())
+    }
+}
+
+/// Create a new `MemoryDB` from a given null key/data
+impl<H, KF, T, M> MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + Clone,
+    KF: KeyFunction<H>,
+    M: MemTracker<T>,
+{
+    /// Remove an element and delete it from storage if reference count reaches zero.
+    /// If the value was purged, return the old value.
+    pub fn remove_and_purge(&mut self, key: &<H as KeyHasher>::Out, prefix: Prefix) -> Option<T> {
+        if key == &self.hashed_null_node {
+            return None;
+        }
+        let key = KF::key(key, prefix);
+        match self.data.entry(key) {
+            Entry::Occupied(mut entry) => {
+                if entry.get().1 == 1 {
+                    let (value, _) = entry.remove();
+                    self.malloc_tracker.on_remove(&value);
+                    Some(value)
+                } else {
+                    entry.get_mut().1 -= 1;
+                    None
+                }
+            }
+            Entry::Vacant(entry) => {
+                let value = T::default();
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, -1));
+                None
+            }
+        }
+    }
+
+    /// Shrinks the capacity of the map as much as possible. It will drop
+    /// down as much as possible while maintaining the internal rules
+    /// and possibly leaving some space in accordance with the resize policy.
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {}
+}
+
+impl<H, KF, T, M> MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: for<'a> From<&'a [u8]> + Clone,
+    KF: KeyFunction<H>,
+    M: MemTracker<T> + Default,
+{
+    /// Create a new `MemoryDB` from a given null key/data
+    pub fn from_null_node(null_key: &[u8], null_node_data: T) -> Self {
+        MemoryDB {
+            data: HashMap::default(),
+            hashed_null_node: H::hash(null_key),
+            null_node_data,
+            malloc_tracker: M::default(),
+            _kf: Default::default(),
+        }
+    }
+
+    /// Create a new `MemoryDB` from a given inner hash map.
+    pub fn from_inner(data: HashMap<KF::Key, (T, i32)>) -> Self {
+        MemoryDB {
+            data,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new instance of `Self`.
+    pub fn new(data: &[u8]) -> Self {
+        Self::from_null_node(data, data.into())
+    }
+
+    /// Create a new default instance of `Self` and returns `Self` and the root hash.
+    pub fn default_with_root() -> (Self, H::Out) {
+        let db = Self::default();
+        let root = db.hashed_null_node;
+
+        (db, root)
+    }
+
+    /// Clear all data from the database.
+    pub fn clear(&mut self) {
+        self.malloc_tracker.on_clear();
+        self.data.clear();
+    }
+
+    /// Purge all zero-referenced data from the database.
+    pub fn purge(&mut self) {
+        let malloc_tracker = &mut self.malloc_tracker;
+        self.data.retain(|_, (v, rc)| {
+            let keep = *rc != 0;
+            if !keep {
+                malloc_tracker.on_remove(v);
+            }
+            keep
+        });
+    }
+
+    /// Return the internal key-value HashMap, clearing the current state.
+    pub fn drain(&mut self) -> HashMap<KF::Key, (T, i32)> {
+        self.malloc_tracker.on_clear();
+        mem::take(&mut self.data)
+    }
+
+    /// Grab the raw information associated with a key. Returns None if the key
+    /// doesn't exist.
+    ///
+    /// Even when Some is returned, the data is only guaranteed to be useful
+    /// when the refs > 0.
+    pub fn raw(&self, key: &<H as KeyHasher>::Out, prefix: Prefix) -> Option<(&T, i32)> {
+        if key == &self.hashed_null_node {
+            return Some((&self.null_node_data, 1));
+        }
+        self.data
+            .get(&KF::key(key, prefix))
+            .map(|(value, count)| (value, *count))
+    }
+
+    /// Consolidate all the entries of `other` into `self`.
+    pub fn consolidate(&mut self, mut other: Self) {
+        for (key, (value, rc)) in other.drain() {
+            if rc == 0 {
+                continue;
+            }
+            match self.data.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    if entry.get().1 < 0 {
+                        self.malloc_tracker.on_insert(&value);
+                        self.malloc_tracker.on_remove(&entry.get().0);
+                        entry.get_mut().0 = value;
+                    }
+
+                    entry.get_mut().1 += rc;
+
+                    if entry.get().1 == 0 {
+                        let (value, _) = entry.remove();
+                        self.malloc_tracker.on_remove(&value);
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    self.malloc_tracker.on_insert(&value);
+                    entry.insert((value, rc));
+                }
+            }
+        }
+    }
+
+    /// Get the keys in the database together with number of underlying references.
+    pub fn keys(&self) -> HashMap<KF::Key, i32> {
+        self.data
+            .iter()
+            .filter_map(|(k, v)| {
+                if v.1 != 0 {
+                    Some((k.clone(), v.1))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+impl<H, KF, T, M> MallocSizeOf for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    H::Out: MallocSizeOf,
+    T: MallocSizeOf,
+    KF: KeyFunction<H>,
+    KF::Key: MallocSizeOf,
+    M: MemTracker<T>,
+{
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        shallow_size_of_hashmap(&self.data, ops)
+            + self.malloc_tracker.get_size()
+            + self.null_node_data.size_of(ops)
+            + self.hashed_null_node.size_of(ops)
+    }
+}
+
+impl<H, KF, T, M> PlainDB<H::Out, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: Send + Sync + KeyFunction<H>,
+    KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out) -> Option<T> {
+        match self.data.get(key.as_ref()) {
+            Some(&(ref d, rc)) if rc > 0 => Some(d.clone()),
+            _ => None,
+        }
+    }
+
+    fn contains(&self, key: &H::Out) -> bool {
+        matches!(self.data.get(key.as_ref()), Some(&(_, x)) if x > 0)
+    }
+
+    fn emplace(&mut self, key: H::Out, value: T) {
+        match self.data.entry(key.as_ref().into()) {
+            Entry::Occupied(mut entry) => {
+                let &mut (ref mut old_value, ref mut rc) = entry.get_mut();
+                if *rc <= 0 {
+                    self.malloc_tracker.on_insert(&value);
+                    self.malloc_tracker.on_remove(old_value);
+                    *old_value = value;
+                }
+                *rc += 1;
+            }
+            Entry::Vacant(entry) => {
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, 1));
+            }
+        }
+    }
+
+    fn remove(&mut self, key: &H::Out) {
+        match self.data.entry(key.as_ref().into()) {
+            Entry::Occupied(mut entry) => {
+                let &mut (_, ref mut rc) = entry.get_mut();
+                *rc -= 1;
+                if *rc == 0 {
+                    let (value, _) = entry.remove();
+                    self.malloc_tracker.on_remove(&value);
+                }
+            }
+            Entry::Vacant(entry) => {
+                let value = T::default();
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, -1));
+            }
+        }
+    }
+}
+
+impl<H, KF, T, M> PlainDBRef<H::Out, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: Send + Sync + KeyFunction<H>,
+    KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out) -> Option<T> {
+        PlainDB::get(self, key)
+    }
+    fn contains(&self, key: &H::Out) -> bool {
+        PlainDB::contains(self, key)
+    }
+}
+
+impl<H, KF, T, M> HashDB<H, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
+        if key == &self.hashed_null_node {
+            return Some(self.null_node_data.clone());
+        }
+
+        let key = KF::key(key, prefix);
+        match self.data.get(&key) {
+            Some(&(ref d, rc)) if rc > 0 => Some(d.clone()),
+            _ => None,
+        }
+    }
+
+    fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
+        if key == &self.hashed_null_node {
+            return true;
+        }
+
+        let key = KF::key(key, prefix);
+        matches!(self.data.get(&key), Some(&(_, x)) if x > 0)
+    }
+
+    fn emplace(&mut self, key: H::Out, prefix: Prefix, value: T) {
+        if value == self.null_node_data {
+            return;
+        }
+
+        let key = KF::key(&key, prefix);
+        match self.data.entry(key) {
+            Entry::Occupied(mut entry) => {
+                let &mut (ref mut old_value, ref mut rc) = entry.get_mut();
+                if *rc <= 0 {
+                    self.malloc_tracker.on_insert(&value);
+                    self.malloc_tracker.on_remove(old_value);
+                    *old_value = value;
+                }
+                *rc += 1;
+            }
+            Entry::Vacant(entry) => {
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, 1));
+            }
+        }
+    }
+
+    fn insert(&mut self, prefix: Prefix, value: &[u8]) -> H::Out {
+        if T::from(value) == self.null_node_data {
+            return self.hashed_null_node;
+        }
+
+        let key = H::hash(value);
+        HashDB::emplace(self, key, prefix, value.into());
+        key
+    }
+
+    fn remove(&mut self, key: &H::Out, prefix: Prefix) {
+        if key == &self.hashed_null_node {
+            return;
+        }
+
+        let key = KF::key(key, prefix);
+        match self.data.entry(key) {
+            Entry::Occupied(mut entry) => {
+                let &mut (_, ref mut rc) = entry.get_mut();
+                *rc -= 1;
+                if *rc == 0 {
+                    let (value, _) = entry.remove();
+                    self.malloc_tracker.on_remove(&value);
+                }
+            }
+            Entry::Vacant(entry) => {
+                let value = T::default();
+                self.malloc_tracker.on_insert(&value);
+                entry.insert((value, -1));
+            }
+        }
+    }
+}
+
+impl<H, KF, T, M> HashDBRef<H, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
+        HashDB::get(self, key, prefix)
+    }
+    fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
+        HashDB::contains(self, key, prefix)
+    }
+}
+
+impl<H, KF, T, M> AsPlainDB<H::Out, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn as_plain_db(&self) -> &dyn PlainDB<H::Out, T> {
+        self
+    }
+    fn as_plain_db_mut(&mut self) -> &mut dyn PlainDB<H::Out, T> {
+        self
+    }
+}
+
+impl<H, KF, T, M> AsHashDB<H, T> for MemoryDB<H, KF, T, M>
+where
+    H: KeyHasher,
+    T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+    KF: KeyFunction<H> + Send + Sync,
+    M: MemTracker<T> + Send + Sync,
+{
+    fn as_hash_db(&self) -> &dyn HashDB<H, T> {
+        self
+    }
+    fn as_hash_db_mut(&mut self) -> &mut dyn HashDB<H, T> {
+        self
+    }
+}
+
+/// Used to implement incremental evaluation of `MallocSizeOf` for a collection.
+pub trait MemTracker<T> {
+    /// Update `malloc_size_of` when a value is removed.
+    fn on_remove(&mut self, _value: &T) {}
+    /// Update `malloc_size_of` when a value is inserted.
+    fn on_insert(&mut self, _value: &T) {}
+    /// Reset `malloc_size_of` to zero.
+    fn on_clear(&mut self) {}
+    /// Get the allocated size of the values.
+    fn get_size(&self) -> usize {
+        0
+    }
+}
+
+/// `MemTracker` implementation for types
+/// which implement `MallocSizeOf`.
+#[derive(Eq, PartialEq)]
+pub struct MemCounter<T> {
+    malloc_size_of_values: usize,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> MemCounter<T> {
+    // Create a new instance of MemCounter<T>.
+    pub fn new() -> Self {
+        Self {
+            malloc_size_of_values: 0,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Default for MemCounter<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Clone for MemCounter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            malloc_size_of_values: self.malloc_size_of_values,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Copy for MemCounter<T> {}
+
+impl<T: MallocSizeOf> MemTracker<T> for MemCounter<T> {
+    fn on_remove(&mut self, value: &T) {
+        self.malloc_size_of_values -= malloc_size(value);
+    }
+    fn on_insert(&mut self, value: &T) {
+        self.malloc_size_of_values += malloc_size(value);
+    }
+    fn on_clear(&mut self) {
+        self.malloc_size_of_values = 0;
+    }
+    fn get_size(&self) -> usize {
+        self.malloc_size_of_values
+    }
+}
+
+/// No-op `MemTracker` implementation for when we want to
+/// construct a `MemoryDB` instance that does not track memory usage.
+#[derive(PartialEq, Eq)]
+pub struct NoopTracker<T>(PhantomData<T>);
+
+impl<T> Default for NoopTracker<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> Clone for NoopTracker<T> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl<T> Copy for NoopTracker<T> {}
+
+impl<T> MemTracker<T> for NoopTracker<T> {}
+
+fn shallow_size_of_hashmap<K, V, S>(map: &HashMap<K, V, S>, ops: &mut MallocSizeOfOps) -> usize {
+    // See the implementation for std::collections::HashSet for details.
+    if ops.has_malloc_enclosing_size_of() {
+        map.values()
+            .next()
+            .map_or(0, |v| unsafe { ops.malloc_enclosing_size_of(v) })
+    } else {
+        map.len() * (mem::size_of::<V>() + mem::size_of::<K>() + mem::size_of::<usize>())
+    }
+}
+
+#[cfg(test)]
+fn size_of_hash_map<K, V, S>(map: &HashMap<K, V, S>) -> usize
+where
+    K: MallocSizeOf,
+    V: MallocSizeOf,
+{
+    let ops = &mut parity_util_mem::allocators::new_malloc_size_ops();
+    let mut n = shallow_size_of_hashmap(map, ops);
+    if let (Some(k), Some(v)) = (K::constant_size(), V::constant_size()) {
+        n += map.len() * (k + v)
+    } else {
+        n = map
+            .iter()
+            .fold(n, |acc, (k, v)| acc + k.size_of(ops) + v.size_of(ops))
+    }
+    n
+}
+
+pub type GenericMemoryDB<H> = MemoryDB<H, HashKey<H>, DBValue, NoopTracker<DBValue>>;
+
+impl<H: KeyHasher> Consolidate for GenericMemoryDB<H> {
+    fn consolidate(&mut self, other: Self) {
+        MemoryDB::consolidate(self, other)
+    }
+}
+
+impl<H: KeyHasher> TrieBackendStorage<H> for GenericMemoryDB<H> {
+    type Overlay = Self;
+
+    fn get(
+        &self,
+        key: &<H as KeyHasher>::Out,
+        prefix: Prefix,
+    ) -> Result<Option<DBValue>, DefaultError> {
+        Ok(hash_db::HashDB::get(self, key, prefix))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HashDB, HashKey, KeyHasher, MemoryDB};
+    use hash_db::EMPTY_PREFIX;
+    use keccak_hasher::KeccakHasher;
+    use parity_util_mem::malloc_size;
+
+    #[test]
+    fn memorydb_remove_and_purge() {
+        let hello_bytes = b"Hello world!";
+        let hello_key = KeccakHasher::hash(hello_bytes);
+
+        let mut m = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        m.remove(&hello_key, EMPTY_PREFIX);
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, -1);
+        m.purge();
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, -1);
+        m.insert(EMPTY_PREFIX, hello_bytes);
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, 0);
+        m.purge();
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX), None);
+
+        let mut m = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        assert!(m.remove_and_purge(&hello_key, EMPTY_PREFIX).is_none());
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, -1);
+        m.insert(EMPTY_PREFIX, hello_bytes);
+        m.insert(EMPTY_PREFIX, hello_bytes);
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX).unwrap().1, 1);
+        assert_eq!(
+            &*m.remove_and_purge(&hello_key, EMPTY_PREFIX).unwrap(),
+            hello_bytes
+        );
+        assert_eq!(m.raw(&hello_key, EMPTY_PREFIX), None);
+        assert!(m.remove_and_purge(&hello_key, EMPTY_PREFIX).is_none());
+    }
+
+    #[test]
+    fn consolidate() {
+        let mut main = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        let mut other = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        let remove_key = other.insert(EMPTY_PREFIX, b"doggo");
+        main.remove(&remove_key, EMPTY_PREFIX);
+
+        let insert_key = other.insert(EMPTY_PREFIX, b"arf");
+        main.emplace(insert_key, EMPTY_PREFIX, "arf".as_bytes().to_vec());
+
+        let negative_remove_key = other.insert(EMPTY_PREFIX, b"negative");
+        other.remove(&negative_remove_key, EMPTY_PREFIX); // ref cnt: 0
+        other.remove(&negative_remove_key, EMPTY_PREFIX); // ref cnt: -1
+        main.remove(&negative_remove_key, EMPTY_PREFIX); // ref cnt: -1
+
+        main.consolidate(other);
+
+        assert_eq!(main.raw(&remove_key, EMPTY_PREFIX), None);
+        assert_eq!(
+            main.raw(&insert_key, EMPTY_PREFIX).unwrap(),
+            (&"arf".as_bytes().to_vec(), 2)
+        );
+        assert_eq!(
+            main.raw(&negative_remove_key, EMPTY_PREFIX).unwrap(),
+            (&"".as_bytes().to_vec(), -2),
+        );
+    }
+
+    #[test]
+    fn default_works() {
+        let mut db = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        let hashed_null_node = KeccakHasher::hash(&[0u8][..]);
+        assert_eq!(db.insert(EMPTY_PREFIX, &[0u8][..]), hashed_null_node);
+
+        let (db2, root) = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default_with_root();
+        assert!(db2.contains(&root, EMPTY_PREFIX));
+        assert!(db.contains(&root, EMPTY_PREFIX));
+    }
+
+    #[test]
+    fn malloc_size_of() {
+        let mut db = MemoryDB::<KeccakHasher, HashKey<_>, Vec<u8>>::default();
+        for i in 0u32..1024 {
+            let bytes = i.to_be_bytes();
+            let prefix = (bytes.as_ref(), None);
+            db.insert(prefix, &bytes);
+        }
+        assert_eq!(
+            malloc_size(&db),
+            super::size_of_hash_map(&db.data)
+                + malloc_size(&db.null_node_data)
+                + malloc_size(&db.hashed_null_node)
+        );
+    }
+}

--- a/crates/phala-trie-storage/src/ser.rs
+++ b/crates/phala-trie-storage/src/ser.rs
@@ -32,8 +32,8 @@ where
         use serde::ser::SerializeSeq;
 
         let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-        for e in self.0.iter() {
-            seq.serialize_element(&e)?;
+        for (_k, v) in self.0.iter() {
+            seq.serialize_element(&v)?;
         }
         seq.end()
     }

--- a/crates/phala-trie-storage/src/ser.rs
+++ b/crates/phala-trie-storage/src/ser.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use hash_db::Hasher;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
@@ -18,23 +19,13 @@ pub struct StorageData {
     pub inner: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
-pub struct SerAsSeq<K, V>(pub im::HashMap<K, V>);
+pub struct SerAsSeq<'a, H: Hasher>(pub &'a crate::MemoryDB<H>);
 
-impl<K, V> Serialize for SerAsSeq<K, V>
-where
-    K: Serialize,
-    V: Serialize,
-{
+impl<H: Hasher> Serialize for SerAsSeq<'_, H> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        use serde::ser::SerializeSeq;
-
-        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-        for (_k, v) in self.0.iter() {
-            seq.serialize_element(&v)?;
-        }
-        seq.end()
+        self.0.serialize(serializer)
     }
 }

--- a/crates/phala-trie-storage/src/ser.rs
+++ b/crates/phala-trie-storage/src/ser.rs
@@ -1,18 +1,40 @@
 use alloc::vec::Vec;
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use parity_scale_codec::{Encode, Decode};
 
 use super::{ChildStorageCollection, StorageCollection};
 
-#[derive(Serialize, Deserialize, Encode, Decode, Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, TypeInfo, Encode, Decode, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase", crate = "serde")]
 pub struct StorageChanges {
     pub main_storage_changes: StorageCollection,
     pub child_storage_changes: ChildStorageCollection,
 }
 
-#[derive(Serialize, Deserialize, Encode, Decode, Clone, Debug)]
+#[derive(Serialize, Deserialize, TypeInfo, Encode, Decode, Clone, Debug)]
 #[serde(crate = "serde")]
 pub struct StorageData {
     pub inner: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
+pub struct SerAsSeq<K, V>(pub im::HashMap<K, V>);
+
+impl<K, V> Serialize for SerAsSeq<K, V>
+where
+    K: Serialize,
+    V: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for e in self.0.iter() {
+            seq.serialize_element(&e)?;
+        }
+        seq.end()
+    }
 }

--- a/crates/pink/src/contract.rs
+++ b/crates/pink/src/contract.rs
@@ -9,8 +9,15 @@ use crate::{
 };
 
 use pallet_contracts_primitives::ContractExecResult;
+use phala_trie_storage::new_backend;
 
 pub type Storage = storage::Storage<storage::InMemoryBackend>;
+
+impl Storage {
+    pub fn new_empty() -> Self {
+        Self::new(new_backend())
+    }
+}
 
 #[derive(Debug)]
 pub struct ExecError {
@@ -31,7 +38,7 @@ pub struct Contract {
 
 impl Contract {
     pub fn new_storage() -> Storage {
-        Storage::new(Default::default())
+        Storage::new(new_backend())
     }
 
     pub fn from_address(address: AccountId) -> Self {

--- a/standalone/pruntime/app/Cargo.lock
+++ b/standalone/pruntime/app/Cargo.lock
@@ -257,15 +257,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,20 +1441,6 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.3",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -2952,7 +2929,6 @@ name = "phala-trie-storage"
 version = "0.1.0"
 dependencies = [
  "hash-db",
- "im",
  "parity-scale-codec",
  "parity-util-mem",
  "scale-info",
@@ -3350,15 +3326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3877,16 +3844,6 @@ name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"

--- a/standalone/pruntime/app/Cargo.lock
+++ b/standalone/pruntime/app/Cargo.lock
@@ -257,6 +257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +729,33 @@ name = "environmental"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+
+[[package]]
+name = "ethbloom"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
 
 [[package]]
 name = "fake-simd"
@@ -1248,6 +1284,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,12 +1453,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.3",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
 ]
 
 [[package]]
@@ -1443,7 +1511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
  "serde",
 ]
 
@@ -1617,6 +1685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
+dependencies = [
+ "hashbrown 0.11.2",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,7 +1745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de006e09d04fc301a5f7e817b75aa49801c4479a8af753764416b085337ddcc5"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.11.2",
  "parity-util-mem",
 ]
 
@@ -2524,11 +2601,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "ethereum-types",
+ "hashbrown 0.11.2",
  "impl-trait-for-tuples",
+ "lru",
  "parity-util-mem-derive",
  "parking_lot",
  "primitive-types",
+ "smallvec",
  "winapi",
 ]
 
@@ -2871,12 +2951,17 @@ dependencies = [
 name = "phala-trie-storage"
 version = "0.1.0"
 dependencies = [
+ "hash-db",
+ "im",
  "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
  "serde",
  "sp-core",
  "sp-io",
  "sp-state-machine",
  "sp-trie",
+ "trie-db 0.23.1",
 ]
 
 [[package]]
@@ -2957,6 +3042,7 @@ checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -3267,6 +3353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,6 +3478,16 @@ dependencies = [
  "opaque-debug 0.3.0",
  "ring 0.16.20",
  "zeroize",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -3772,6 +3877,16 @@ name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "slab"
@@ -4250,7 +4365,7 @@ dependencies = [
  "sp-trie",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.22.6",
  "trie-root",
 ]
 
@@ -4314,7 +4429,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-std",
- "trie-db",
+ "trie-db 0.22.6",
  "trie-root",
 ]
 
@@ -4942,7 +5057,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eac131e334e81b6b3be07399482042838adcd7957aa0010231d0813e39e02fa"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.11.2",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.12.3",
  "log",
  "rustc-hex",
  "smallvec",

--- a/standalone/pruntime/enclave/Cargo.lock
+++ b/standalone/pruntime/enclave/Cargo.lock
@@ -474,6 +474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1204,33 @@ name = "environmental"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+
+[[package]]
+name = "ethbloom"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
 
 [[package]]
 name = "event-listener"
@@ -1968,12 +2004,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.3",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
 ]
 
 [[package]]
@@ -2372,6 +2431,15 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
  "value-bag",
+]
+
+[[package]]
+name = "lru"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
+dependencies = [
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -3325,11 +3393,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if",
+ "ethereum-types",
  "hashbrown 0.11.2",
  "impl-trait-for-tuples",
+ "lru",
  "parity-util-mem-derive",
  "parking_lot",
  "primitive-types",
+ "smallvec",
  "winapi",
 ]
 
@@ -3754,12 +3825,17 @@ dependencies = [
 name = "phala-trie-storage"
 version = "0.1.0"
 dependencies = [
+ "hash-db",
+ "im",
  "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
  "serde",
  "sp-core",
  "sp-io",
  "sp-state-machine",
  "sp-trie 4.0.0-dev",
+ "trie-db 0.23.1",
 ]
 
 [[package]]
@@ -3993,6 +4069,7 @@ checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "scale-info",
  "uint",
@@ -4328,6 +4405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,6 +4538,16 @@ dependencies = [
  "sgx_tstd",
  "spin 0.5.2",
  "untrusted",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -4934,6 +5030,16 @@ name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "slab"

--- a/standalone/pruntime/enclave/Cargo.lock
+++ b/standalone/pruntime/enclave/Cargo.lock
@@ -474,15 +474,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,20 +1992,6 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.3",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -3826,7 +3803,6 @@ name = "phala-trie-storage"
 version = "0.1.0"
 dependencies = [
  "hash-db",
- "im",
  "parity-scale-codec",
  "parity-util-mem",
  "scale-info",
@@ -4402,15 +4378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -5030,16 +4997,6 @@ name = "siphasher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"


### PR DESCRIPTION
For the pruntime v0, we use the MemoryDB from Substrate as the backend of the TrieDB.
Because the MemoryDB neither implements serde traits nor supplies a cheap API to get the inner KV store. So we did have to clone the entire TrieDB to take checkpoints. **That causes peak memory usage to be twice the KV store**.

In purntime-v2, we implemented a custom MemoryDB based on `im::HashMap` to support cheap snapshots for queries. As a side effect, it also makes taking checkpoints cheaper(Doesn't need to clone the entire TrieDB).

This PR backports the implementation so that taking checkpoints won't require much more memory. However, there is also an overhead: the memory cost of `im::HashMap` is larger (not much) than `std::_::HashMap`.
For example, here is a sample from about 2 months ago:
```
pruntime v0:
{"current": 143614176, "peak": 303069955 }
pruntime v2:
{"current": 241041536, "peak": 261140152 }
```
Since pruntime 2.0 already uses it, I think the overhead is acceptable.
