### PR TITLE
pruntime: Builtin handover coordinator

### DIFF
--- a/crates/phactory/api/Cargo.toml
+++ b/crates/phactory/api/Cargo.toml
@@ -14,7 +14,7 @@ prost = { version = "0.11.2", default-features = false }
 
 phala-trie-storage = { path = "../../../crates/phala-trie-storage", default-features = false, features = ["serde"] }
 phala-types = { path = "../../../crates/phala-types", default-features = false, features = ["enable_serde", "sgx"] }
-prpc = { path = "../../../crates/prpc" }
+prpc = { path = "../../../crates/prpc", default-features = false }
 phala-crypto = { path = "../../../crates/phala-crypto" }
 phala-mq = { path = "../../../crates/phala-mq" }
 chain = { path = "../../../standalone/runtime", default-features = false, package = "phala-node-runtime" }
@@ -52,6 +52,7 @@ std = [
     "sp-application-crypto/std",
     "frame-system/std",
     "chain/std",
+    "prpc/std",
 ]
 
 sgx = []

--- a/crates/prpc/Cargo.toml
+++ b/crates/prpc/Cargo.toml
@@ -9,3 +9,7 @@ derive_more = "0.99.16"
 prost = { version = "0.11.2", default-features = false, features = ["prost-derive"] }
 anyhow = { version = "1.0.42", default-features = false }
 parity-scale-codec = { version = "3.1", default-features = false }
+
+[features]
+default = ["std"]
+std = []

--- a/crates/prpc/src/lib.rs
+++ b/crates/prpc/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
 use alloc::boxed::Box;
@@ -35,6 +35,10 @@ pub mod server {
         }
     }
 
+    #[cfg(feature = "std")]
+    impl std::error::Error for Error {}
+
+    #[cfg(not(feature = "std"))]
     impl From<Error> for anyhow::Error {
         fn from(error: Error) -> Self {
             Self::msg(error)
@@ -84,6 +88,10 @@ pub mod client {
         }
     }
 
+    #[cfg(feature = "std")]
+    impl std::error::Error for Error {}
+
+    #[cfg(not(feature = "std"))]
     impl From<Error> for anyhow::Error {
         fn from(error: Error) -> Self {
             Self::msg(error)

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -884,6 +884,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1772,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2540,19 @@ dependencies = [
  "rustls 0.20.6",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -3292,6 +3330,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "node-primitives"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.34#1cc97dd30537997ff4c9827beb2ef0cac9c49063"
@@ -3452,6 +3508,51 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -4587,6 +4688,7 @@ dependencies = [
 name = "phactory-api"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.13.0",
  "derive_more",
@@ -4602,6 +4704,7 @@ dependencies = [
  "prost 0.11.2",
  "prpc",
  "prpc-build",
+ "reqwest",
  "scale-info",
  "serde",
  "sp-application-crypto",
@@ -5031,6 +5134,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
@@ -5677,11 +5786,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.6",
@@ -5690,6 +5801,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-socks",
  "tower-service",
@@ -6040,6 +6152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "schnorrkel"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6136,6 +6257,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -7581,6 +7725,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-proxy"
 version = "0.1.0"
 source = "git+https://github.com/Phala-Network/tokio-proxy#e98d21a0ff7bf7a3bea413b2ee336b0d4da1e213"
@@ -8013,6 +8167,12 @@ dependencies = [
  "ctor",
  "version_check",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version"

--- a/standalone/pruntime/Cargo.toml
+++ b/standalone/pruntime/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 urlencoding = "2.1.0"
 
 phactory = { path = "../../crates/phactory" }
-phactory-api = { path = "../../crates/phactory/api" }
+phactory-api = { path = "../../crates/phactory/api", features = ["pruntime-client"] }
 phactory-pal = { path = "../../crates/phactory/pal" }
 phala-allocator = { path = "../../crates/phala-allocator" }
 phala-rocket-middleware = { path = "../../crates/phala-rocket-middleware" }

--- a/standalone/pruntime/src/handover.rs
+++ b/standalone/pruntime/src/handover.rs
@@ -1,0 +1,30 @@
+use crate::pal_gramine::GraminePlatform;
+use anyhow::{Context, Result};
+use phactory::RpcService;
+use phactory_api::{
+    ecall_args::InitArgs, prpc::phactory_api_server::PhactoryApi,
+    pruntime_client::new_pruntime_client,
+};
+
+pub(crate) async fn handover_from(url: &str, args: InitArgs) -> Result<()> {
+    let mut this = RpcService::new(GraminePlatform);
+    this.lock_phactory().init(args);
+
+    let from_pruntime = new_pruntime_client(url.into());
+    let challenge = from_pruntime
+        .handover_create_challenge(())
+        .await
+        .context("Failed to create challenge")?;
+    let response = this
+        .handover_accept_challenge(challenge)
+        .await
+        .context("Failed to accept challenge")?;
+    let encrypted_key = from_pruntime
+        .handover_start(response)
+        .await
+        .context("Failed to start handover")?;
+    this.handover_receive(encrypted_key)
+        .await
+        .context("Failed to receive handover result")?;
+    Ok(())
+}

--- a/standalone/pruntime/src/handover.rs
+++ b/standalone/pruntime/src/handover.rs
@@ -5,24 +5,29 @@ use phactory_api::{
     ecall_args::InitArgs, prpc::phactory_api_server::PhactoryApi,
     pruntime_client::new_pruntime_client,
 };
+use log::info;
 
 pub(crate) async fn handover_from(url: &str, args: InitArgs) -> Result<()> {
     let mut this = RpcService::new(GraminePlatform);
     this.lock_phactory().init(args);
 
     let from_pruntime = new_pruntime_client(url.into());
+    info!("Requesting for challenge");
     let challenge = from_pruntime
         .handover_create_challenge(())
         .await
         .context("Failed to create challenge")?;
+    info!("Challenge received");
     let response = this
         .handover_accept_challenge(challenge)
         .await
         .context("Failed to accept challenge")?;
+    info!("Requesting for key");
     let encrypted_key = from_pruntime
         .handover_start(response)
         .await
         .context("Failed to start handover")?;
+    info!("Key received");
     this.handover_receive(encrypted_key)
         .await
         .context("Failed to receive handover result")?;

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -142,6 +142,7 @@ async fn main() -> Result<(), rocket::Error> {
     };
     info!("init_args: {:#?}", init_args);
     if let Some(handover_from) = args.request_handover_from {
+        info!("Starting handover from {handover_from}");
         handover::handover_from(&handover_from, init_args)
             .await
             .expect("Handover failed");


### PR DESCRIPTION
This PR adds a new argument `--request-handover-from` to pruntime. Which allows doing handover without a third program.
Another benefit is the new pruntime doesn't require listening on any TCP port while doing handover.
Usage:
```bash
./pruntime --request-handover-from http://localhost:8000
```
Codes are copied from:
https://github.com/Phala-Network/phala-blockchain/blob/29f046e0d49bba0af405c2c617be414a9a339711/standalone/pherry/src/lib.rs#L1526-L1532