### PR TITLE
Bump grandpa to 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22349c6a11563a202d95772a68e0fcf56119e74ea8a2a19cf2301460fcd0df5"
+checksum = "e24e6c429951433ccb7c87fd528c60084834dcd14763182c1f83291bcde24c34"
 dependencies = [
  "either",
  "futures",

--- a/crates/phactory/Cargo.toml
+++ b/crates/phactory/Cargo.toml
@@ -53,7 +53,7 @@ phactory-pal = { path = "./pal", default-features = false }
 derive_more = "0.99.0"
 hash-db = { version = "0.15.2", default-features = false }
 num = { package = "num-traits", version = "0.2", default-features = false }
-finality-grandpa = { version = "0.16.0", default-features = false, features = ["derive-codec"] }
+finality-grandpa = { version = "0.16.1", default-features = false, features = ["derive-codec"] }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.34" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.34" }
 sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.34" }

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -1665,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22349c6a11563a202d95772a68e0fcf56119e74ea8a2a19cf2301460fcd0df5"
+checksum = "e24e6c429951433ccb7c87fd528c60084834dcd14763182c1f83291bcde24c34"
 dependencies = [
  "either",
  "futures",


### PR DESCRIPTION
It's a trivial update though. Only logs or code style changed from `0.16.0` to `0.16.1`: https://github.com/paritytech/finality-grandpa/compare/eb26b0c86dbb6949435b627f85eceb026f96ebe9..218cdc68568cf30c536070a92336686f3df67a9c