### PR TITLE
Starting serve and --grab without pre-imported headers

### DIFF
--- a/standalone/headers-cache/src/grab.rs
+++ b/standalone/headers-cache/src/grab.rs
@@ -12,14 +12,10 @@ pub async fn run(
     para_node_uri: &str,
     check_interval: u64,
     justification_interval: BlockNumber,
+    genesis_block: BlockNumber,
 ) -> anyhow::Result<()> {
-    let Some(mut metadata) = db.get_metadata()? else {
-        anyhow::bail!("No metadata in the DB, can not grab");
-    };
-    let Some(highest) = metadata.recent_imported.header else {
-        anyhow::bail!("There aren't any headers in the DB, can not grab");
-    };
-
+    let mut metadata = db.get_metadata()?.unwrap_or_default();
+    let highest = metadata.recent_imported.header.unwrap_or(genesis_block);
     let mut next_block = highest + 1;
 
     loop {

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -370,6 +370,7 @@ async fn main() -> anyhow::Result<()> {
                         &para_node_uri,
                         interval,
                         justification_interval,
+                        genesis_block,
                     )
                     .await;
                     if let Err(err) = result {


### PR DESCRIPTION
This allows to start `headers-cache serve --grab` without the pre-requirement of `grab and import` steps.
For example:
```
./target/release/headers-cache serve --grab --node-uri wss://miner-node.phala.network:443/kusama/ws --para-node-uri wss://miner-node.phala.network:443/khala/ws
```