### PR TITLE
kv-session: loosen rollup() KvSnapshot to ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8030,7 +8030,7 @@ dependencies = [
 
 [[package]]
 name = "pink-kv-session"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "parity-scale-codec",
 ]

--- a/crates/pink-libs/kv-session/Cargo.toml
+++ b/crates/pink-libs/kv-session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pink-kv-session"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://phala.network/"

--- a/crates/pink-libs/kv-session/src/rollup.rs
+++ b/crates/pink-libs/kv-session/src/rollup.rs
@@ -30,7 +30,7 @@ impl RollUpTransaction {
 }
 
 /// Rollup version conditions and updates with given R/W tracking data and user updates
-pub fn rollup<DB>(kvdb: DB, tx: KvTransaction, layout: VersionLayout) -> Result<RollUpTransaction>
+pub fn rollup<DB>(kvdb: &DB, tx: KvTransaction, layout: VersionLayout) -> Result<RollUpTransaction>
 where
     DB: KvSnapshot + BumpVersion,
 {
@@ -189,7 +189,7 @@ mod tests {
         };
 
         let rollup = rollup(
-            kvdb,
+            &kvdb,
             tx,
             VersionLayout::Standalone {
                 key_postfix: "_ver".into(),
@@ -224,7 +224,7 @@ mod tests {
         let (tx, kvdb) = queue.commit();
 
         let tx = rollup(
-            kvdb,
+            &kvdb,
             tx,
             VersionLayout::Standalone {
                 key_postfix: "_ver".into(),
@@ -256,7 +256,7 @@ mod tests {
         let final_head = queue.queue_head();
         let (tx, kvdb) = queue.commit();
         let tx = rollup(
-            kvdb,
+            &kvdb,
             tx,
             VersionLayout::Standalone {
                 key_postfix: "_ver".into(),

--- a/crates/pink-libs/kv-session/src/session.rs
+++ b/crates/pink-libs/kv-session/src/session.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use alloc::vec::Vec;
 use alloc::{borrow::ToOwned, collections::BTreeMap};
 
-use crate::traits::{QueueIndex, QueueSession, QueueIndexCodec};
+use crate::traits::{QueueIndex, QueueIndexCodec, QueueSession};
 use crate::{
     traits::{AccessTracking, KvSession, KvSnapshot, KvTransaction},
     Result,

--- a/pallets/offchain-rollup/src/anchor.rs
+++ b/pallets/offchain-rollup/src/anchor.rs
@@ -593,7 +593,7 @@ pub mod pallet {
 				kvdb: ChainStorage,
 			) -> Option<RollupTx> {
 				let tx = kv_session::rollup::rollup(
-					kvdb,
+					&kvdb,
 					tx,
 					kv_session::rollup::VersionLayout::Standalone {
 						key_postfix: "_ver".into(),


### PR DESCRIPTION
Bump kv-session to v0.2.0 as API is changed.

When working with pink-web3 (EVM), I've created a contract object in the KvSnapshot impl. When committing, the object will be passed to `rollup()`, and its lifecycle ends. Since the contract object is heavy, it's ideal to reuse the object to submit transactions after calling `rollup()`. So in this PR, I propose to make the argument a reference for easier object reuse.