### PR TITLE
Remove attestation_provider from the WorkerEvent::Registered

### DIFF
--- a/crates/phactory/src/system/gk.rs
+++ b/crates/phactory/src/system/gk.rs
@@ -1721,7 +1721,6 @@ pub mod tests {
         with_block(1, |block| {
             let mut worker0 = r.for_worker(0);
             worker0.pallet_say(msg::WorkerEvent::Registered(msg::WorkerInfo {
-                attestation_provider: None,
                 confidence_level: 2,
             }));
             r.gk.test_process_messages(block);
@@ -1755,7 +1754,6 @@ pub mod tests {
         with_block(1, |block| {
             let mut worker0 = r.for_worker(0);
             worker0.pallet_say(msg::WorkerEvent::Registered(msg::WorkerInfo {
-                attestation_provider: None,
                 confidence_level: 2,
             }));
             r.gk.test_process_messages(block);
@@ -1853,7 +1851,6 @@ pub mod tests {
         with_block(block_number, |block| {
             let mut worker0 = r.for_worker(0);
             worker0.pallet_say(msg::WorkerEvent::Registered(msg::WorkerInfo {
-                attestation_provider: None,
                 confidence_level: 2,
             }));
             r.gk.test_process_messages(block);
@@ -1919,7 +1916,6 @@ pub mod tests {
         with_block(block_number, |block| {
             let mut worker0 = r.for_worker(0);
             worker0.pallet_say(msg::WorkerEvent::Registered(msg::WorkerInfo {
-                attestation_provider: None,
                 confidence_level: 2,
             }));
             r.gk.test_process_messages(block);
@@ -1974,7 +1970,6 @@ pub mod tests {
         with_block(block_number, |block| {
             let mut worker0 = r.for_worker(0);
             worker0.pallet_say(msg::WorkerEvent::Registered(msg::WorkerInfo {
-                attestation_provider: None,
                 confidence_level: 2,
             }));
             r.gk.test_process_messages(block);
@@ -2056,7 +2051,6 @@ pub mod tests {
         with_block(block_number, |block| {
             let mut worker0 = r.for_worker(0);
             worker0.pallet_say(msg::WorkerEvent::Registered(msg::WorkerInfo {
-                attestation_provider: None,
                 confidence_level: 2,
             }));
             r.gk.test_process_messages(block);
@@ -2130,7 +2124,6 @@ pub mod tests {
         with_block(block_number, |block| {
             let mut worker0 = r.for_worker(0);
             worker0.pallet_say(msg::WorkerEvent::Registered(msg::WorkerInfo {
-                attestation_provider: None,
                 confidence_level: 2,
             }));
             r.gk.test_process_messages(block);
@@ -2201,7 +2194,6 @@ pub mod tests {
         with_block(block_number, |block| {
             let mut worker0 = r.for_worker(0);
             worker0.pallet_say(msg::WorkerEvent::Registered(msg::WorkerInfo {
-                attestation_provider: None,
                 confidence_level: 2,
             }));
             r.gk.test_process_messages(block);
@@ -2289,7 +2281,6 @@ pub mod tests {
         with_block(block_number, |block| {
             let mut worker0 = r.for_worker(0);
             worker0.pallet_say(msg::WorkerEvent::Registered(msg::WorkerInfo {
-                attestation_provider: None,
                 confidence_level: 2,
             }));
             r.gk.test_process_messages(block);
@@ -2363,7 +2354,6 @@ pub mod tests {
             for i in 0..=1 {
                 let mut worker = r.for_worker(i);
                 worker.pallet_say(msg::WorkerEvent::Registered(msg::WorkerInfo {
-                    attestation_provider: None,
                     confidence_level: 2,
                 }));
             }

--- a/crates/phala-mq/src/dispatcher.rs
+++ b/crates/phala-mq/src/dispatcher.rs
@@ -139,7 +139,8 @@ impl<T: Decode> TypedReceiver<T> {
             Err(err) => {
                 if msg.sender.always_well_formed() {
                     panic!(
-                        "Failed to decode critical mq message, please upgrade the pRuntime client"
+                        "Failed to decode critical mq message (dest={:?}), please upgrade the pRuntime client",
+                        msg.destination
                     );
                 } else {
                     return Err(TypedReceiveError::CodecError(err));

--- a/crates/phala-types/src/lib.rs
+++ b/crates/phala-types/src/lib.rs
@@ -28,7 +28,7 @@ pub mod messaging {
     use serde::{Deserialize, Serialize};
 
     use super::{
-        EcdhPublicKey, MasterPublicKey, WorkerIdentity, WorkerPublicKey, AttestationProvider,
+        EcdhPublicKey, MasterPublicKey, WorkerIdentity, WorkerPublicKey,
     };
 
     pub use phala_mq::bind_topic;
@@ -62,7 +62,6 @@ pub mod messaging {
 
     #[derive(Encode, Decode, Debug, TypeInfo)]
     pub struct WorkerInfo {
-        pub attestation_provider: Option<AttestationProvider>,
         pub confidence_level: u8,
     }
 

--- a/pallets/phala/src/registry.rs
+++ b/pallets/phala/src/registry.rs
@@ -325,7 +325,6 @@ pub mod pallet {
 			Self::push_message(SystemEvent::new_worker_event(
 				pubkey,
 				WorkerEvent::Registered(messaging::WorkerInfo {
-					attestation_provider: Some(AttestationProvider::Root),
 					confidence_level: worker_info.confidence_level,
 				}),
 			));
@@ -515,7 +514,6 @@ pub mod pallet {
 						Self::push_message(SystemEvent::new_worker_event(
 							pubkey,
 							WorkerEvent::Registered(messaging::WorkerInfo {
-								attestation_provider: Some(AttestationProvider::Ias),
 								confidence_level: fields.confidence_level,
 							}),
 						));
@@ -541,7 +539,6 @@ pub mod pallet {
 						Self::push_message(SystemEvent::new_worker_event(
 							pubkey,
 							WorkerEvent::Registered(messaging::WorkerInfo {
-								attestation_provider: Some(AttestationProvider::Ias),
 								confidence_level: fields.confidence_level,
 							}),
 						));
@@ -632,7 +629,6 @@ pub mod pallet {
 						Self::push_message(SystemEvent::new_worker_event(
 							pubkey,
 							WorkerEvent::Registered(messaging::WorkerInfo {
-								attestation_provider: attestation_report.provider,
 								confidence_level: attestation_report.confidence_level,
 							}),
 						));
@@ -658,7 +654,6 @@ pub mod pallet {
 						Self::push_message(SystemEvent::new_worker_event(
 							pubkey,
 							WorkerEvent::Registered(messaging::WorkerInfo {
-								attestation_provider: attestation_report.provider,
 								confidence_level: attestation_report.confidence_level,
 							}),
 						));
@@ -1046,7 +1041,6 @@ pub mod pallet {
 				Pallet::<T>::queue_message(SystemEvent::new_worker_event(
 					*pubkey,
 					WorkerEvent::Registered(messaging::WorkerInfo {
-						attestation_provider: Some(AttestationProvider::Root),
 						confidence_level: 128u8,
 					}),
 				));


### PR DESCRIPTION
It was added in #768. The WorkerInfo is an mq message sent from the chain to pRuntime. If we change the codec layout, pRuntime would fail to decode the history message and abort.

We can add a `WorkerEvent::RegisteredV2` if we want to add more information to the structure in the future.