### PR TITLE
TrieDB: use im::OrdMap to reduce memory consumption

### DIFF
--- a/crates/phala-trie-storage/src/memdb.rs
+++ b/crates/phala-trie-storage/src/memdb.rs
@@ -17,7 +17,7 @@
 use hash_db::{
     AsHashDB, AsPlainDB, HashDB, HashDBRef, Hasher as KeyHasher, PlainDB, PlainDBRef, Prefix,
 };
-use im::{hashmap::Entry, HashMap};
+pub(crate) use im::ordmap::{Entry, OrdMap as Map};
 use std::{borrow::Borrow, cmp::Eq, hash, marker::PhantomData, mem};
 
 use sp_state_machine::{backend::Consolidate, DefaultError, TrieBackendStorage};
@@ -28,13 +28,19 @@ impl<T: std::fmt::Debug> MaybeDebug for T {}
 
 pub type GenericMemoryDB<H> = MemoryDB<H, HashKey<H>, trie_db::DBValue>;
 
-impl<H: KeyHasher> Consolidate for GenericMemoryDB<H> {
+impl<H: KeyHasher> Consolidate for GenericMemoryDB<H>
+where
+    H::Out: Ord,
+{
     fn consolidate(&mut self, other: Self) {
         MemoryDB::consolidate(self, other)
     }
 }
 
-impl<H: KeyHasher> TrieBackendStorage<H> for GenericMemoryDB<H> {
+impl<H: KeyHasher> TrieBackendStorage<H> for GenericMemoryDB<H>
+where
+    H::Out: Ord,
+{
     type Overlay = Self;
 
     fn get(
@@ -58,7 +64,7 @@ where
     H: KeyHasher,
     KF: KeyFunction<H>,
 {
-    data: HashMap<KF::Key, (T, i32)>,
+    data: Map<KF::Key, (T, i32)>,
     hashed_null_node: H::Out,
     null_node_data: T,
     _kf: PhantomData<KF>,
@@ -78,34 +84,6 @@ where
             _kf: Default::default(),
         }
     }
-}
-
-impl<H, KF, T> PartialEq<MemoryDB<H, KF, T>> for MemoryDB<H, KF, T>
-where
-    H: KeyHasher,
-    KF: KeyFunction<H>,
-    <KF as KeyFunction<H>>::Key: Eq + MaybeDebug,
-    T: Eq + MaybeDebug,
-{
-    fn eq(&self, other: &MemoryDB<H, KF, T>) -> bool {
-        for a in self.data.iter() {
-            match other.data.get(a.0) {
-                Some(v) if v != a.1 => return false,
-                None => return false,
-                _ => (),
-            }
-        }
-        true
-    }
-}
-
-impl<H, KF, T> Eq for MemoryDB<H, KF, T>
-where
-    H: KeyHasher,
-    KF: KeyFunction<H>,
-    <KF as KeyFunction<H>>::Key: Eq + MaybeDebug,
-    T: Eq + MaybeDebug,
-{
 }
 
 pub trait KeyFunction<H: KeyHasher> {
@@ -181,6 +159,7 @@ where
     H: KeyHasher,
     T: for<'a> From<&'a [u8]> + Clone,
     KF: KeyFunction<H>,
+    KF::Key: Ord,
 {
     fn default() -> Self {
         Self::from_null_node(&[0u8][..], [0u8][..].into())
@@ -193,6 +172,7 @@ where
     H: KeyHasher,
     T: Default + Clone,
     KF: KeyFunction<H>,
+    KF::Key: Ord,
 {
     /// Remove an element and delete it from storage if reference count reaches zero.
     /// If the value was purged, return the old value.
@@ -233,11 +213,12 @@ where
     H: KeyHasher,
     T: for<'a> From<&'a [u8]> + Clone,
     KF: KeyFunction<H>,
+    KF::Key: Ord,
 {
     /// Create a new `MemoryDB` from a given null key/data
     pub fn from_null_node(null_key: &[u8], null_node_data: T) -> Self {
         MemoryDB {
-            data: HashMap::default(),
+            data: Map::default(),
             hashed_null_node: H::hash(null_key),
             null_node_data,
             _kf: Default::default(),
@@ -245,7 +226,7 @@ where
     }
 
     /// Create a new `MemoryDB` from a given inner hash map.
-    pub fn from_inner(data: HashMap<KF::Key, (T, i32)>) -> Self {
+    pub fn from_inner(data: Map<KF::Key, (T, i32)>) -> Self {
         MemoryDB {
             data,
             ..Default::default()
@@ -271,13 +252,8 @@ where
         self.data.clear();
     }
 
-    /// Purge all zero-referenced data from the database.
-    pub fn purge(&mut self) {
-        self.data.retain(|_, (_, rc)| *rc != 0);
-    }
-
-    /// Return the internal key-value HashMap, clearing the current state.
-    pub fn drain(&mut self) -> HashMap<KF::Key, (T, i32)> {
+    /// Return the internal key-value Map, clearing the current state.
+    pub fn drain(&mut self) -> Map<KF::Key, (T, i32)> {
         mem::take(&mut self.data)
     }
 
@@ -317,7 +293,7 @@ where
     }
 
     /// Get the keys in the database together with number of underlying references.
-    pub fn keys(&self) -> HashMap<KF::Key, i32> {
+    pub fn keys(&self) -> Map<KF::Key, i32> {
         self.data
             .iter()
             .filter_map(|(k, v)| {
@@ -331,12 +307,35 @@ where
     }
 }
 
+impl<H, KF, T> MemoryDB<H, KF, T>
+where
+    H: KeyHasher,
+    T: for<'a> From<&'a [u8]> + Clone,
+    KF: KeyFunction<H>,
+    KF::Key: Ord,
+    T: serde::Serialize,
+{
+    pub fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+
+        let mut seq = serializer.serialize_seq(Some(self.data.len()))?;
+        for (_k, v) in self.data.iter() {
+            seq.serialize_element(&v)?;
+        }
+        seq.end()
+    }
+}
+
 impl<H, KF, T> PlainDB<H::Out, T> for MemoryDB<H, KF, T>
 where
     H: KeyHasher,
     T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
     KF: Send + Sync + KeyFunction<H>,
     KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    KF::Key: Ord,
 {
     fn get(&self, key: &H::Out) -> Option<T> {
         match self.data.get(key.as_ref()) {
@@ -390,6 +389,7 @@ where
     T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
     KF: Send + Sync + KeyFunction<H>,
     KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    KF::Key: Ord,
 {
     fn get(&self, key: &H::Out) -> Option<T> {
         PlainDB::get(self, key)
@@ -404,6 +404,7 @@ where
     H: KeyHasher,
     T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
     KF: KeyFunction<H> + Send + Sync,
+    KF::Key: Ord,
 {
     fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
         if key == &self.hashed_null_node {
@@ -486,6 +487,7 @@ where
     H: KeyHasher,
     T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
     KF: KeyFunction<H> + Send + Sync,
+    KF::Key: Ord,
 {
     fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
         HashDB::get(self, key, prefix)
@@ -501,6 +503,7 @@ where
     T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
     KF: KeyFunction<H> + Send + Sync,
     KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
+    KF::Key: Ord,
 {
     fn as_plain_db(&self) -> &dyn PlainDB<H::Out, T> {
         self
@@ -515,6 +518,7 @@ where
     H: KeyHasher,
     T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
     KF: KeyFunction<H> + Send + Sync,
+    KF::Key: Ord,
 {
     fn as_hash_db(&self) -> &dyn HashDB<H, T> {
         self

--- a/crates/phala-trie-storage/src/ser.rs
+++ b/crates/phala-trie-storage/src/ser.rs
@@ -1,6 +1,7 @@
-use serde::{Deserialize, Serialize};
-use parity_scale_codec::{Encode, Decode};
+use hash_db::Hasher;
+use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
 
 use super::{ChildStorageCollection, StorageCollection};
 
@@ -15,4 +16,20 @@ pub struct StorageChanges {
 #[serde(crate = "serde")]
 pub struct StorageData {
     pub inner: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
+pub struct SerAsSeq<'a, H: Hasher>(pub &'a crate::MemoryDB<H>)
+where
+    H::Out: Ord;
+
+impl<H: Hasher> Serialize for SerAsSeq<'_, H>
+where
+    H::Out: Ord,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
 }


### PR DESCRIPTION
The `im::HashMap` has a really heavy memory overhead. Let's use `im::OrdMap` to reduce memory usage.
<img width="919" alt="image" src="https://user-images.githubusercontent.com/6442159/215664460-776f0259-975a-479d-b98f-bc9406335e70.png">

## Drawback
`im::OrdMap` is a bit slower than `im::HashMap`. It took about `57 minutes` to sync from block height 0 to 900000 vs `52 minutes` for `im::HashMap`.
