### PR TITLE
pruntime: Add safe mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8007,6 +8007,7 @@ dependencies = [
  "im",
  "impl-serde",
  "keccak-hasher",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/crates/phactory/api/src/ecall_args.rs
+++ b/crates/phactory/api/src/ecall_args.rs
@@ -40,6 +40,9 @@ pub struct InitArgs {
 
     /// The public rpc port with acl enabled
     pub public_port: Option<u16>,
+
+    /// Only sync blocks into pruntime without dispatching messages.
+    pub safe_mode: bool,
 }
 
 pub fn git_revision() -> String {

--- a/crates/phactory/api/src/ecall_args.rs
+++ b/crates/phactory/api/src/ecall_args.rs
@@ -42,7 +42,7 @@ pub struct InitArgs {
     pub public_port: Option<u16>,
 
     /// Only sync blocks into pruntime without dispatching messages.
-    pub safe_mode: bool,
+    pub safe_mode_level: u8,
 }
 
 pub fn git_revision() -> String {

--- a/crates/phactory/api/src/pruntime_client.rs
+++ b/crates/phactory/api/src/pruntime_client.rs
@@ -43,7 +43,7 @@ impl RequestClient for RpcRequest {
             .await
             .map_err(from_display)?;
 
-        info!("Response: {}", res.status());
+        info!("{path}: {}", res.status());
         let status = res.status();
         let body = res.bytes().await.map_err(from_display)?;
         if status.is_success() {

--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -88,7 +88,12 @@ pub trait StorageSynchronizer {
     ) -> Result<chain::BlockNumber>;
 
     /// Feed in a block of storage changes
-    fn feed_block(&mut self, block: &BlockHeaderWithChanges, storage: &mut Storage) -> Result<()>;
+    fn feed_block(
+        &mut self,
+        block: &BlockHeaderWithChanges,
+        storage: &mut Storage,
+        no_store: bool,
+    ) -> Result<()>;
 
     /// Assume synced to given block.
     fn assume_at_block(&mut self, block_number: chain::BlockNumber) -> Result<()>;
@@ -204,9 +209,16 @@ where
         block: &BlockHeaderWithChanges,
         state_roots: &mut VecDeque<Hash>,
         storage: &mut Storage,
+        no_store: bool,
     ) -> Result<()> {
         if block.block_header.number != self.block_number_next {
             return Err(Error::BlockNumberMismatch);
+        }
+        if no_store {
+            self.block_number_next += 1;
+            let root = state_roots.pop_front().ok_or(Error::NoStateRoot)?;
+            storage.set_root(root);
+            return Ok(());
         }
 
         if !self.genesis_state_validated {
@@ -301,9 +313,14 @@ impl<Validator: BlockValidator> StorageSynchronizer for SolochainSynchronizer<Va
         )
     }
 
-    fn feed_block(&mut self, block: &BlockHeaderWithChanges, storage: &mut Storage) -> Result<()> {
+    fn feed_block(
+        &mut self,
+        block: &BlockHeaderWithChanges,
+        storage: &mut Storage,
+        no_store: bool,
+    ) -> Result<()> {
         self.sync_state
-            .feed_block(block, &mut self.state_roots, storage)
+            .feed_block(block, &mut self.state_roots, storage, no_store)
     }
 
     fn sync_parachain_header(
@@ -432,9 +449,14 @@ impl<Validator: BlockValidator> StorageSynchronizer for ParachainSynchronizer<Va
     }
 
     /// Feed in a block of storage changes
-    fn feed_block(&mut self, block: &BlockHeaderWithChanges, storage: &mut Storage) -> Result<()> {
+    fn feed_block(
+        &mut self,
+        block: &BlockHeaderWithChanges,
+        storage: &mut Storage,
+        no_store: bool,
+    ) -> Result<()> {
         self.sync_state
-            .feed_block(block, &mut self.para_state_roots, storage)
+            .feed_block(block, &mut self.para_state_roots, storage, no_store)
     }
 
     fn assume_at_block(&mut self, block_number: chain::BlockNumber) -> Result<()> {
@@ -514,8 +536,13 @@ impl<Validator: BlockValidator> StorageSynchronizer for Synchronizer<Validator> 
             .sync_parachain_header(headers, proof, storage_key)
     }
 
-    fn feed_block(&mut self, block: &BlockHeaderWithChanges, storage: &mut Storage) -> Result<()> {
-        self.as_dyn_mut().feed_block(block, storage)
+    fn feed_block(
+        &mut self,
+        block: &BlockHeaderWithChanges,
+        storage: &mut Storage,
+        no_store: bool,
+    ) -> Result<()> {
+        self.as_dyn_mut().feed_block(block, storage, no_store)
     }
 
     fn assume_at_block(&mut self, block_number: chain::BlockNumber) -> Result<()> {

--- a/crates/phactory/api/src/storage_sync.rs
+++ b/crates/phactory/api/src/storage_sync.rs
@@ -92,7 +92,7 @@ pub trait StorageSynchronizer {
         &mut self,
         block: &BlockHeaderWithChanges,
         storage: &mut Storage,
-        no_store: bool,
+        drop_proofs: bool,
     ) -> Result<()>;
 
     /// Assume synced to given block.
@@ -209,12 +209,12 @@ where
         block: &BlockHeaderWithChanges,
         state_roots: &mut VecDeque<Hash>,
         storage: &mut Storage,
-        no_store: bool,
+        drop_proofs: bool,
     ) -> Result<()> {
         if block.block_header.number != self.block_number_next {
             return Err(Error::BlockNumberMismatch);
         }
-        if no_store {
+        if drop_proofs {
             self.block_number_next += 1;
             let root = state_roots.pop_front().ok_or(Error::NoStateRoot)?;
             storage.set_root(root);
@@ -317,10 +317,10 @@ impl<Validator: BlockValidator> StorageSynchronizer for SolochainSynchronizer<Va
         &mut self,
         block: &BlockHeaderWithChanges,
         storage: &mut Storage,
-        no_store: bool,
+        drop_proofs: bool,
     ) -> Result<()> {
         self.sync_state
-            .feed_block(block, &mut self.state_roots, storage, no_store)
+            .feed_block(block, &mut self.state_roots, storage, drop_proofs)
     }
 
     fn sync_parachain_header(
@@ -453,10 +453,10 @@ impl<Validator: BlockValidator> StorageSynchronizer for ParachainSynchronizer<Va
         &mut self,
         block: &BlockHeaderWithChanges,
         storage: &mut Storage,
-        no_store: bool,
+        drop_proofs: bool,
     ) -> Result<()> {
         self.sync_state
-            .feed_block(block, &mut self.para_state_roots, storage, no_store)
+            .feed_block(block, &mut self.para_state_roots, storage, drop_proofs)
     }
 
     fn assume_at_block(&mut self, block_number: chain::BlockNumber) -> Result<()> {
@@ -540,9 +540,9 @@ impl<Validator: BlockValidator> StorageSynchronizer for Synchronizer<Validator> 
         &mut self,
         block: &BlockHeaderWithChanges,
         storage: &mut Storage,
-        no_store: bool,
+        drop_proofs: bool,
     ) -> Result<()> {
-        self.as_dyn_mut().feed_block(block, storage, no_store)
+        self.as_dyn_mut().feed_block(block, storage, drop_proofs)
     }
 
     fn assume_at_block(&mut self, block_number: chain::BlockNumber) -> Result<()> {

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -236,9 +236,10 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         for block in blocks.into_iter() {
             info!("Dispatching block: {}", block.block_header.number);
             let state = self.runtime_state()?;
+            let drop_proofs = safe_mode_level > 1;
             state
                 .storage_synchronizer
-                .feed_block(&block, state.chain_storage.inner_mut(), safe_mode_level > 1)
+                .feed_block(&block, state.chain_storage.inner_mut(), drop_proofs)
                 .map_err(from_display)?;
             if safe_mode_level > 0 {
                 continue;

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -525,6 +525,9 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         request: pb::ContractQueryRequest,
         effects_queue: Sender<(ContractClusterId, ExecSideEffects)>,
     ) -> RpcResult<impl Future<Output = RpcResult<pb::ContractQueryResponse>>> {
+        if self.args.safe_mode {
+            return Err(from_display("Query is unavailable in safe mode"));
+        }
         // Validate signature
         let origin = if let Some(sig) = &request.signature {
             let current_block = self.get_info().blocknum - 1;

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -128,6 +128,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             }),
             system: system_info,
             can_load_chain_state: self.can_load_chain_state,
+            safe_mode_level: self.args.safe_mode_level as _,
         };
         info!("Got info: {:?}", info);
         info
@@ -541,9 +542,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
                     }
                 },
                 Err(err) => {
-                    return Err(from_display(format!(
-                        "Verifying signature failed: {err:?}"
-                    )));
+                    return Err(from_display(format!("Verifying signature failed: {err:?}")));
                 }
             }
         } else {

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -1652,8 +1652,11 @@ impl<Platform: pal::Platform> System<Platform> {
 }
 
 impl<P: pal::Platform> System<P> {
-    pub fn on_restored(&mut self) -> Result<()> {
+    pub fn on_restored(&mut self, safe_mode: bool) -> Result<()> {
         ::pink::runtime::set_worker_pubkey(self.ecdh_key.public());
+        if safe_mode {
+            return Ok(());
+        }
         self.contracts.try_restart_sidevms(&self.sidevm_spawner);
         self.contracts.apply_local_cache_quotas();
         Ok(())

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -1652,9 +1652,9 @@ impl<Platform: pal::Platform> System<Platform> {
 }
 
 impl<P: pal::Platform> System<P> {
-    pub fn on_restored(&mut self, safe_mode: bool) -> Result<()> {
+    pub fn on_restored(&mut self, safe_mode_level: u8) -> Result<()> {
         ::pink::runtime::set_worker_pubkey(self.ecdh_key.public());
-        if safe_mode {
+        if safe_mode_level > 0 {
             return Ok(());
         }
         self.contracts.try_restart_sidevms(&self.sidevm_spawner);

--- a/crates/phala-trie-storage/Cargo.toml
+++ b/crates/phala-trie-storage/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 hash-db = "0.15.2"
 trie-db = "0.24.0"
 im = { version = "15", features = ["serde"] }
+log = "0.4"
 
 [dev-dependencies]
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -176,6 +176,21 @@ where
     pub fn as_trie_backend(&self) -> &InMemoryBackend<H> {
         &self.0
     }
+
+    pub fn set_root(&mut self, root: H::Out) {
+        let storage = core::mem::take(self).0.into_storage();
+        let _ = core::mem::replace(&mut self.0, TrieBackendBuilder::new(storage, root).build());
+    }
+
+    pub fn load_proof(&mut self, proof: Vec<Vec<u8>>) {
+        use hash_db::HashDB as _;
+        let root = *self.root();
+        let mut storage = MemoryDB::default();
+        for value in proof {
+            storage.insert(hash_db::EMPTY_PREFIX, &value);
+        }
+        let _ = core::mem::replace(&mut self.0, TrieBackendBuilder::new(storage, root).build());
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/crates/phala-trie-storage/src/lib.rs
+++ b/crates/phala-trie-storage/src/lib.rs
@@ -187,7 +187,8 @@ where
         let root = *self.root();
         let mut storage = MemoryDB::default();
         for value in proof {
-            storage.insert(hash_db::EMPTY_PREFIX, &value);
+            let hash = storage.insert(hash_db::EMPTY_PREFIX, &value);
+            log::debug!("Loaded proof {:?}", hash);
         }
         let _ = core::mem::replace(&mut self.0, TrieBackendBuilder::new(storage, root).build());
     }

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "pruntime"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -4806,6 +4806,7 @@ version = "0.1.0"
 dependencies = [
  "hash-db",
  "im",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/standalone/pruntime/src/api_server.rs
+++ b/standalone/pruntime/src/api_server.rs
@@ -200,6 +200,7 @@ fn rpc_type(method: &str) -> RpcType {
             GetNetworkConfig => Private,
             LoadChainState => Private,
             Stop => Private,
+            LoadStorageProof => Private,
             // Public RPCs
             GetInfo => Public,
             ContractQuery => Public,
@@ -244,6 +245,7 @@ fn default_payload_limit_for_method(method: PhactoryAPIMethod) -> ByteUnit {
         GetNetworkConfig => 1.kibibytes(),
         LoadChainState => 500.mebibytes(),
         Stop => 1.kibibytes(),
+        LoadStorageProof => 10.mebibytes(),
     }
 }
 

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -75,6 +75,10 @@ struct Args {
     /// Handover key from another running pruntime instance
     #[arg(long)]
     request_handover_from: Option<String>,
+
+    /// Sync blocks without dispatching messages.
+    #[arg(long)]
+    safe_mode: bool,
 }
 
 #[rocket::main]
@@ -138,6 +142,7 @@ async fn main() -> Result<(), rocket::Error> {
             gc_interval: args.gc_interval,
             cores,
             public_port: args.public_port,
+            safe_mode: args.safe_mode,
         }
     };
     info!("init_args: {:#?}", init_args);

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -76,9 +76,16 @@ struct Args {
     #[arg(long)]
     request_handover_from: Option<String>,
 
-    /// Sync blocks without dispatching messages.
+    /// Safe mode level
+    ///
+    /// - 0, All features enabled.
+    /// - 1, Sync blocks without dispatching messages.
+    /// - 2, Sync blocks without storing the trie proofs and dispatching messages.
+    ///     In this mode, it is needed to invoke prpc.LoadStorageProof to load the necessary values
+    ///     before accepting key handover request.
     #[arg(long)]
-    safe_mode: bool,
+    #[arg(default_value_t = 0)]
+    safe_mode_level: u8,
 }
 
 #[rocket::main]
@@ -142,7 +149,7 @@ async fn main() -> Result<(), rocket::Error> {
             gc_interval: args.gc_interval,
             cores,
             public_port: args.public_port,
-            safe_mode: args.safe_mode,
+            safe_mode_level: args.safe_mode_level,
         }
     };
     info!("init_args: {:#?}", init_args);

--- a/standalone/pruntime/src/runtime.rs
+++ b/standalone/pruntime/src/runtime.rs
@@ -58,15 +58,10 @@ pub fn ecall_init(args: phactory_api::ecall_args::InitArgs) -> Result<()> {
     if args.enable_checkpoint {
         match Phactory::restore_from_checkpoint(
             &GraminePlatform,
-            &args.sealing_path,
-            &args.storage_path,
-            args.remove_corrupted_checkpoint,
-            args.cores as _,
-            args.safe_mode_level,
+            &args,
         ) {
-            Ok(Some(mut factory)) => {
+            Ok(Some(factory)) => {
                 info!("Loaded checkpoint");
-                factory.set_args(args.clone());
                 *APPLICATION.lock_phactory() = factory;
                 return Ok(());
             }

--- a/standalone/pruntime/src/runtime.rs
+++ b/standalone/pruntime/src/runtime.rs
@@ -62,7 +62,7 @@ pub fn ecall_init(args: phactory_api::ecall_args::InitArgs) -> Result<()> {
             &args.storage_path,
             args.remove_corrupted_checkpoint,
             args.cores as _,
-            args.safe_mode,
+            args.safe_mode_level,
         ) {
             Ok(Some(mut factory)) => {
                 info!("Loaded checkpoint");

--- a/standalone/pruntime/src/runtime.rs
+++ b/standalone/pruntime/src/runtime.rs
@@ -62,6 +62,7 @@ pub fn ecall_init(args: phactory_api::ecall_args::InitArgs) -> Result<()> {
             &args.storage_path,
             args.remove_corrupted_checkpoint,
             args.cores as _,
+            args.safe_mode,
         ) {
             Ok(Some(mut factory)) => {
                 info!("Loaded checkpoint");


### PR DESCRIPTION
This PR adds `--safe-mode-level` to prevent bricking the whole system by some unexpected fault in pruntime.

# About safe mode level
- 0, All features enabled.
- 1, Sync blocks without dispatching messages. Sidevm and contract query are disabled.
- 2,  In addition to level 1, this level neither stores the trie proofs to reduce memory usage.
     In this mode, it is needed to invoke `prpc.LoadStorageProof` to load the necessary values
     before accepting key handover requests.