### PR TITLE
handover: Read timestamp from chain storage instead of System

### DIFF
--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -443,6 +443,7 @@ pub struct System<Platform> {
     pub(crate) ecdh_key: EcdhKey,
     #[serde(skip)]
     last_challenge: Option<HandoverChallenge<chain::BlockNumber>>,
+    /// Be careful to use this field, as it is not updated in safe mode.
     worker_state: WorkerState,
     // Gatekeeper
     pub(crate) gatekeeper: Option<gk::Gatekeeper<SignedMessageChannel>>,
@@ -454,7 +455,11 @@ pub struct System<Platform> {
     sidevm_spawner: Spawner,
 
     // Cached for query
+    /// The block number of the last block that the worker has synced.
+    /// Be careful to use this field, as it is not updated in safe mode.
     pub(crate) block_number: BlockNumber,
+    /// The timestamp of the last block that the worker has synced.
+    /// Be careful to use this field, as it is not updated in safe mode.
     pub(crate) now_ms: u64,
 
     // If non-zero indicates the block which this worker loaded the chain state from.

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -557,7 +557,11 @@ impl<Platform: pal::Platform> System<Platform> {
         self.worker_state.registered
     }
 
-    pub fn get_worker_key_challenge(&mut self) -> HandoverChallenge<chain::BlockNumber> {
+    pub fn get_worker_key_challenge(
+        &mut self,
+        block_number: chain::BlockNumber,
+        now: u64,
+    ) -> HandoverChallenge<chain::BlockNumber> {
         let sgx_target_info = if self.dev_mode {
             vec![]
         } else {
@@ -566,8 +570,8 @@ impl<Platform: pal::Platform> System<Platform> {
         };
         let challenge = HandoverChallenge {
             sgx_target_info,
-            block_number: self.block_number,
-            now: self.now_ms,
+            block_number,
+            now,
             dev_mode: self.dev_mode,
             nonce: crate::generate_random_info(),
         };

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -9,6 +9,7 @@ use tokio::time::sleep;
 use codec::{Decode, Encode};
 use phala_pallets::pallet_registry::Attestation;
 use phaxt::{
+    dynamic::storage_key,
     rpc::ExtraRpcExt as _,
     sp_core::{crypto::Pair, sr25519},
     subxt, RpcClient,
@@ -414,10 +415,16 @@ async fn try_load_handover_proof(pr: &PrClient, api: &ParachainApi) -> Result<()
     }
     let current_block = info.blocknum - 1;
     let hash = get_header_hash(api, Some(current_block)).await?;
-    let id_key = phaxt::dynamic::storage_key("PhalaRegistry", "PRuntimeAddedAt");
-    let proof = chain_client::read_proofs(api, Some(hash), vec![&id_key])
-        .await
-        .context("Failed to get handover proof")?;
+    let proof = chain_client::read_proofs(
+        api,
+        Some(hash),
+        vec![
+            &storage_key("PhalaRegistry", "PRuntimeAddedAt")[..],
+            &storage_key("Timestamp", "Now")[..],
+        ],
+    )
+    .await
+    .context("Failed to get handover proof")?;
     info!("Loading handover proof at {current_block}");
     pr.load_storage_proof(prpc::StorageProof { proof }).await?;
     Ok(())

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -420,6 +420,7 @@ async fn try_load_handover_proof(pr: &PrClient, api: &ParachainApi) -> Result<()
         Some(hash),
         vec![
             &storage_key("PhalaRegistry", "PRuntimeAddedAt")[..],
+            &storage_key("PhalaRegistry", "PRuntimeAllowList")[..],
             &storage_key("Timestamp", "Now")[..],
         ],
     )


### PR DESCRIPTION
This is a fixup to the PR [Safe mode](https://github.com/Phala-Network/phala-blockchain/pull/1157)
Because the info in System would never be updated in safe mode.