### PR TITLE
Forbid nft transfer in pre_check function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13631,7 +13631,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7032,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-core"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9353,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "rmrk-traits"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13631,7 +13631,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -148,28 +148,6 @@ pub mod pallet {
 				// Forbid any delegation transfer before delegation nft transfer and sell is fully prepared.
 				// TODO(mingxuan): reopen pre_check function.
 				return false
-				/*if let Ok(net_value) = Pallet::<T>::get_net_value((*sender).clone()) {
-					let property_guard =
-						base_pool::Pallet::<T>::get_nft_attr_guard(*collection_id, *nft_id)
-							.expect("get nft should not fail: qed.");
-					let property = &property_guard.attr;
-					let account_status = match StakerAccounts::<T>::get(sender) {
-						Some(account_status) => account_status,
-						None => unreachable!(),
-					};
-					let pool_proxy = base_pool::Pallet::<T>::pool_collection(pid)
-						.expect("get pool should not fail: qed.");
-					let basepool = &match pool_proxy {
-						PoolProxy::Vault(p) => p.basepool,
-						PoolProxy::StakePool(p) => p.basepool,
-					};
-					if let Some(price) = basepool.share_price() {
-						let nft_value = bmul(property.shares, &price);
-						if account_status.locked + nft_value > net_value {
-							return false;
-						}
-					}
-				}*/
 			}
 
 			true

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -143,12 +143,12 @@ pub mod pallet {
 		T: pallet_democracy::Config<Currency = <T as crate::PhalaConfig>::Currency>,
 		T: Config + vault::Config,
 	{
-		fn pre_check(_sender: &T::AccountId, _collection_id: &CollectionId, _nft_id: &NftId) -> bool {
-			// Forbid any transfer before delegation nft transfer and sell is fully prepared.
-			// TODO(mingxuan): reopen pre_check function.
-			false
-			/*if let Some(pid) = base_pool::pallet::PoolCollections::<T>::get(collection_id) {
-				if let Ok(net_value) = Pallet::<T>::get_net_value((*sender).clone()) {
+		fn pre_check(_sender: &T::AccountId, collection_id: &CollectionId, _nft_id: &NftId) -> bool {
+			if base_pool::pallet::PoolCollections::<T>::get(collection_id).is_some() {
+				// Forbid any delegation transfer before delegation nft transfer and sell is fully prepared.
+				// TODO(mingxuan): reopen pre_check function.
+				return false
+				/*if let Ok(net_value) = Pallet::<T>::get_net_value((*sender).clone()) {
 					let property_guard =
 						base_pool::Pallet::<T>::get_nft_attr_guard(*collection_id, *nft_id)
 							.expect("get nft should not fail: qed.");
@@ -169,10 +169,10 @@ pub mod pallet {
 							return false;
 						}
 					}
-				}
-			};
+				}*/
+			}
 
-			true*/
+			true
 		}
 		fn post_transfer(
 			_sender: &T::AccountId,

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -143,7 +143,7 @@ pub mod pallet {
 		T: pallet_democracy::Config<Currency = <T as crate::PhalaConfig>::Currency>,
 		T: Config + vault::Config,
 	{
-		fn pre_check(_sender: &T::AccountId, collection_id: &CollectionId, _nft_id: &NftId) -> bool {
+		fn pre_check(_sender: &T::AccountId, _recipient: &T::AccountId, collection_id: &CollectionId, _nft_id: &NftId) -> bool {
 			if base_pool::pallet::PoolCollections::<T>::get(collection_id).is_some() {
 				// Forbid any delegation transfer before delegation nft transfer and sell is fully prepared.
 				// TODO(mingxuan): reopen pre_check function.

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -143,8 +143,11 @@ pub mod pallet {
 		T: pallet_democracy::Config<Currency = <T as crate::PhalaConfig>::Currency>,
 		T: Config + vault::Config,
 	{
-		fn pre_check(sender: &T::AccountId, collection_id: &CollectionId, nft_id: &NftId) -> bool {
-			if let Some(pid) = base_pool::pallet::PoolCollections::<T>::get(collection_id) {
+		fn pre_check(_sender: &T::AccountId, _collection_id: &CollectionId, _nft_id: &NftId) -> bool {
+			// Forbid any transfer before delegation nft transfer and sell is fully prepared.
+			// TODO(mingxuan): reopen pre_check function.
+			false
+			/*if let Some(pid) = base_pool::pallet::PoolCollections::<T>::get(collection_id) {
 				if let Ok(net_value) = Pallet::<T>::get_net_value((*sender).clone()) {
 					let property_guard =
 						base_pool::Pallet::<T>::get_nft_attr_guard(*collection_id, *nft_id)
@@ -169,7 +172,7 @@ pub mod pallet {
 				}
 			};
 
-			true
+			true*/
 		}
 		fn post_transfer(
 			_sender: &T::AccountId,

--- a/standalone/prouter/Cargo.lock
+++ b/standalone/prouter/Cargo.lock
@@ -3034,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-core"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3675,6 +3675,7 @@ version = "0.1.0"
 dependencies = [
  "hash-db",
  "im",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -4388,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "rmrk-traits"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6194,7 +6195,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-core"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5751,7 +5751,7 @@ checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 [[package]]
 name = "rmrk-traits"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7746,7 +7746,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 


### PR DESCRIPTION
Temporarily forbid delegation Nft transformation by simply returning `false` in the transfer pre_check hook.