### PR TITLE
Enable transfer and list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7032,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-core"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9353,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "rmrk-traits"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13631,7 +13631,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7048,6 +7048,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-rmrk-market"
+version = "0.0.1"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-rmrk-core",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "rmrk-traits",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.37#f38bd6671d460293c93062cc1e4fe9e9e490cb29"
@@ -7886,6 +7905,7 @@ dependencies = [
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-rmrk-core",
+ "pallet-rmrk-market",
  "pallet-scheduler",
  "pallet-session",
  "pallet-session-benchmarking",
@@ -7950,6 +7970,7 @@ dependencies = [
  "pallet-preimage",
  "pallet-randomness-collective-flip",
  "pallet-rmrk-core",
+ "pallet-rmrk-market",
  "pallet-scheduler",
  "pallet-timestamp",
  "pallet-uniques",
@@ -13631,7 +13652,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/pallets/phala/Cargo.toml
+++ b/pallets/phala/Cargo.toml
@@ -23,6 +23,7 @@ pallet-preimage = { git = "https://github.com/paritytech/substrate", branch = "p
 # RMRK dependencies
 pallet-rmrk-core = { git = "https://github.com/Phala-Network/rmrk-substrate", branch = "polkadot-v0.9.37", default-features = false }
 rmrk-traits = { git = "https://github.com/Phala-Network/rmrk-substrate", branch = "polkadot-v0.9.37", default-features = false }
+pallet-rmrk-market = { git = "https://github.com/Phala-Network/rmrk-substrate", branch = "polkadot-v0.9.37", default-features = false }
 
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
@@ -86,6 +87,7 @@ std = [
 	"phala-types/enable_serde",
 	"pallet-rmrk-core/std",
 	"rmrk-traits/std",
+	"pallet-rmrk-market/std",
 	"pallet-collective/std",
 	"pallet-randomness-collective-flip/std",
 	"pallet-preimage/std",

--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -91,10 +91,7 @@ pub mod pallet {
 	#[pallet::getter(fn next_nft_id)]
 	pub type NextNftId<T: Config> = StorageMap<_, Twox64Concat, CollectionId, NftId, ValueQuery>;
 
-	type LockKey = (
-		CollectionId,
-		NftId,
-	);
+	type LockKey = (CollectionId, NftId);
 
 	#[pallet::storage]
 	pub type LockIterateStartPos<T> = StorageValue<_, Option<LockKey>, ValueQuery>;
@@ -511,8 +508,7 @@ pub mod pallet {
 			let last_pos = LockIterateStartPos::<T>::get();
 			let mut iter = match last_pos {
 				Some(pos) => {
-					let key: Vec<u8> =
-						pallet_rmrk_core::pallet::Lock::<T>::hashed_key_for(pos);
+					let key: Vec<u8> = pallet_rmrk_core::pallet::Lock::<T>::hashed_key_for(pos);
 					pallet_rmrk_core::pallet::Lock::<T>::iter_from(key)
 				}
 				None => pallet_rmrk_core::pallet::Lock::<T>::iter(),
@@ -520,8 +516,10 @@ pub mod pallet {
 			let mut record_vec = vec![];
 			let mut i = 0;
 			for ((cid, nft_id), _) in iter.by_ref() {
-				if cid >= RESERVE_CID_START && !pallet_rmrk_core::pallet::Nfts::<T>::contains_key(cid, nft_id) {
-						record_vec.push((cid, nft_id));
+				if cid >= RESERVE_CID_START
+					&& !pallet_rmrk_core::pallet::Nfts::<T>::contains_key(cid, nft_id)
+				{
+					record_vec.push((cid, nft_id));
 				}
 				i += 1;
 				if i > max_iterations {
@@ -639,11 +637,7 @@ pub mod pallet {
 					Error::<T>::NotInContributeWhitelist
 				);
 			}
-			Self::merge_nft_for_staker(
-				pool.cid,
-				account_id.clone(),
-				pool.pid,
-			)?;
+			Self::merge_nft_for_staker(pool.cid, account_id.clone(), pool.pid)?;
 			// The nft instance must be wrote to Nft storage at the end of the function
 			// this nft's property shouldn't be accessed or wrote again from storage before set_nft_attr
 			// is called. Or the property of the nft will be overwrote incorrectly.
@@ -909,11 +903,12 @@ pub mod pallet {
 			pid: u64,
 		) -> Result<Option<NftId>, DispatchError> {
 			let mut total_shares: BalanceOf<T> = Zero::zero();
-			let nfts: Vec<_> = pallet_uniques::Pallet::<T>::owned_in_collection(&cid, &staker).collect();
+			let nfts: Vec<_> =
+				pallet_uniques::Pallet::<T>::owned_in_collection(&cid, &staker).collect();
 			match nfts.len() {
-			  0 => return Ok(None),
-			  1 => return Ok(Some(nfts[0])),
-			  _ => (),
+				0 => return Ok(None),
+				1 => return Ok(Some(nfts[0])),
+				_ => (),
 			};
 			for nftid in nfts {
 				let nft_guard =
@@ -952,10 +947,7 @@ pub mod pallet {
 			})
 		}
 
-		fn set_nft_desc_attr(
-			cid: CollectionId,
-			nft_id: NftId,
-		) -> DispatchResult {
+		fn set_nft_desc_attr(cid: CollectionId, nft_id: NftId) -> DispatchResult {
 			pallet_rmrk_core::Pallet::<T>::set_lock((cid, nft_id), false);
 			let key: BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit> = "createtime"
 				.as_bytes()

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -148,28 +148,6 @@ pub mod pallet {
 				// Forbid any delegation transfer before delegation nft transfer and sell is fully prepared.
 				// TODO(mingxuan): reopen pre_check function.
 				return false
-				/*if let Ok(net_value) = Pallet::<T>::get_net_value((*sender).clone()) {
-					let property_guard =
-						base_pool::Pallet::<T>::get_nft_attr_guard(*collection_id, *nft_id)
-							.expect("get nft should not fail: qed.");
-					let property = &property_guard.attr;
-					let account_status = match StakerAccounts::<T>::get(sender) {
-						Some(account_status) => account_status,
-						None => unreachable!(),
-					};
-					let pool_proxy = base_pool::Pallet::<T>::pool_collection(pid)
-						.expect("get pool should not fail: qed.");
-					let basepool = &match pool_proxy {
-						PoolProxy::Vault(p) => p.basepool,
-						PoolProxy::StakePool(p) => p.basepool,
-					};
-					if let Some(price) = basepool.share_price() {
-						let nft_value = bmul(property.shares, &price);
-						if account_status.locked + nft_value > net_value {
-							return false;
-						}
-					}
-				}*/
 			}
 
 			true

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -31,6 +31,7 @@ pub mod pallet {
 		+ crate::PhalaConfig
 		+ registry::Config
 		+ pallet_rmrk_core::Config
+		+ pallet_rmrk_market::Config
 		+ computation::Config
 		+ pallet_assets::Config
 		+ pallet_democracy::Config
@@ -143,12 +144,39 @@ pub mod pallet {
 		T: pallet_democracy::Config<Currency = <T as crate::PhalaConfig>::Currency>,
 		T: Config + vault::Config,
 	{
-		fn pre_check(_sender: &T::AccountId, _recipient: &T::AccountId, collection_id: &CollectionId, _nft_id: &NftId) -> bool {
-			if base_pool::pallet::PoolCollections::<T>::get(collection_id).is_some() {
-				// Forbid any delegation transfer before delegation nft transfer and sell is fully prepared.
-				// TODO(mingxuan): reopen pre_check function.
-				return false
-			}
+		fn pre_check(
+			sender: &T::AccountId,
+			recipient: &T::AccountId,
+			collection_id: &CollectionId,
+			nft_id: &NftId,
+		) -> bool {
+			if let Some(pid) = base_pool::pallet::PoolCollections::<T>::get(collection_id) {
+				if Self::have_nft_on_list(recipient, collection_id) {
+					return false;
+				}
+				if let Ok(net_value) = Pallet::<T>::get_net_value((*sender).clone()) {
+					let property_guard =
+						base_pool::Pallet::<T>::get_nft_attr_guard(*collection_id, *nft_id)
+							.expect("get nft should not fail: qed.");
+					let property = &property_guard.attr;
+					let account_status = match StakerAccounts::<T>::get(sender) {
+						Some(account_status) => account_status,
+						None => unreachable!(),
+					};
+					let pool_proxy = base_pool::Pallet::<T>::pool_collection(pid)
+						.expect("get pool should not fail: qed.");
+					let basepool = &match pool_proxy {
+						PoolProxy::Vault(p) => p.basepool,
+						PoolProxy::StakePool(p) => p.basepool,
+					};
+					if let Some(price) = basepool.share_price() {
+						let nft_value = bmul(property.shares, &price);
+						if account_status.locked + nft_value > net_value {
+							return false;
+						}
+					}
+				}
+			};
 
 			true
 		}
@@ -442,6 +470,18 @@ pub mod pallet {
 				aye: total_aye_amount,
 				nay: total_nay_amount,
 			}
+		}
+
+		/// Check if recipient has Nft listing in a specific collection.
+		pub fn have_nft_on_list(recipient: &T::AccountId, collection_id: &CollectionId) -> bool {
+			let iter = pallet_uniques::Pallet::<T>::owned_in_collection(collection_id, &recipient)
+				.take_while(|nftid| {
+					pallet_rmrk_market::ListedNfts::<T>::contains_key(collection_id, nftid)
+				});
+			if iter.count() > 0 {
+				return true;
+			}
+			false
 		}
 
 		/// Tries to update locked W-PHA amount of the user

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -143,12 +143,12 @@ pub mod pallet {
 		T: pallet_democracy::Config<Currency = <T as crate::PhalaConfig>::Currency>,
 		T: Config + vault::Config,
 	{
-		fn pre_check(_sender: &T::AccountId, _collection_id: &CollectionId, _nft_id: &NftId) -> bool {
-			// Forbid any transfer before delegation nft transfer and sell is fully prepared.
-			// TODO(mingxuan): reopen pre_check function.
-			false
-			/*if let Some(pid) = base_pool::pallet::PoolCollections::<T>::get(collection_id) {
-				if let Ok(net_value) = Pallet::<T>::get_net_value((*sender).clone()) {
+		fn pre_check(_sender: &T::AccountId, collection_id: &CollectionId, _nft_id: &NftId) -> bool {
+			if base_pool::pallet::PoolCollections::<T>::get(collection_id).is_some() {
+				// Forbid any delegation transfer before delegation nft transfer and sell is fully prepared.
+				// TODO(mingxuan): reopen pre_check function.
+				return false
+				/*if let Ok(net_value) = Pallet::<T>::get_net_value((*sender).clone()) {
 					let property_guard =
 						base_pool::Pallet::<T>::get_nft_attr_guard(*collection_id, *nft_id)
 							.expect("get nft should not fail: qed.");
@@ -169,10 +169,10 @@ pub mod pallet {
 							return false;
 						}
 					}
-				}
-			};
+				}*/
+			}
 
-			true*/
+			true
 		}
 		fn post_transfer(
 			_sender: &T::AccountId,

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -143,7 +143,7 @@ pub mod pallet {
 		T: pallet_democracy::Config<Currency = <T as crate::PhalaConfig>::Currency>,
 		T: Config + vault::Config,
 	{
-		fn pre_check(_sender: &T::AccountId, collection_id: &CollectionId, _nft_id: &NftId) -> bool {
+		fn pre_check(_sender: &T::AccountId, _recipient: &T::AccountId, collection_id: &CollectionId, _nft_id: &NftId) -> bool {
 			if base_pool::pallet::PoolCollections::<T>::get(collection_id).is_some() {
 				// Forbid any delegation transfer before delegation nft transfer and sell is fully prepared.
 				// TODO(mingxuan): reopen pre_check function.

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -143,8 +143,11 @@ pub mod pallet {
 		T: pallet_democracy::Config<Currency = <T as crate::PhalaConfig>::Currency>,
 		T: Config + vault::Config,
 	{
-		fn pre_check(sender: &T::AccountId, collection_id: &CollectionId, nft_id: &NftId) -> bool {
-			if let Some(pid) = base_pool::pallet::PoolCollections::<T>::get(collection_id) {
+		fn pre_check(_sender: &T::AccountId, _collection_id: &CollectionId, _nft_id: &NftId) -> bool {
+			// Forbid any transfer before delegation nft transfer and sell is fully prepared.
+			// TODO(mingxuan): reopen pre_check function.
+			false
+			/*if let Some(pid) = base_pool::pallet::PoolCollections::<T>::get(collection_id) {
 				if let Ok(net_value) = Pallet::<T>::get_net_value((*sender).clone()) {
 					let property_guard =
 						base_pool::Pallet::<T>::get_nft_attr_guard(*collection_id, *nft_id)
@@ -169,7 +172,7 @@ pub mod pallet {
 				}
 			};
 
-			true
+			true*/
 		}
 		fn post_transfer(
 			_sender: &T::AccountId,

--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -232,6 +232,21 @@ impl pallet_rmrk_core::Config for Test {
 	type Helper = pallet_rmrk_core::RmrkBenchmark;
 }
 
+parameter_types! {
+    pub const MinimumOfferAmount: Balance = DOLLARS / 10_000;
+	pub const MarketFee: Permill = Permill::from_parts(5_000);
+}
+
+impl pallet_rmrk_market::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type ProtocolOrigin = EnsureRoot<Self::AccountId>;
+    type Currency = Balances;
+    type MinimumOfferAmount = MinimumOfferAmount;
+	type WeightInfo = pallet_rmrk_market::weights::SubstrateWeight<Runtime>;
+    type MarketplaceHooks = ();
+    type MarketFee = MarketFee;
+}
+
 impl computation::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type ExpectedBlockTimeSec = ExpectedBlockTimeSec;

--- a/pallets/phala/src/utils/balance_convert.rs
+++ b/pallets/phala/src/utils/balance_convert.rs
@@ -14,7 +14,9 @@ impl FixedPointConvert for u128 {
 		Self::from_fixed(&FixedPoint::from_bits(bits))
 	}
 	fn from_fixed(v: &FixedPoint) -> Self {
-		U80F48::unwrapped_from_num(*v).unwrapped_mul_int(PHA).to_num()
+		U80F48::unwrapped_from_num(*v)
+			.unwrapped_mul_int(PHA)
+			.to_num()
 	}
 	fn to_fixed(&self) -> FixedPoint {
 		let v = U80F48::unwrapped_from_num(*self);

--- a/standalone/prouter/Cargo.lock
+++ b/standalone/prouter/Cargo.lock
@@ -3034,12 +3034,31 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-core"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "rmrk-traits",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-rmrk-market"
+version = "0.0.1"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-rmrk-core",
  "pallet-uniques",
  "parity-scale-codec",
  "rmrk-traits",
@@ -3583,6 +3602,7 @@ dependencies = [
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-rmrk-core",
+ "pallet-rmrk-market",
  "pallet-scheduler",
  "pallet-session",
  "pallet-session-benchmarking",
@@ -3642,6 +3662,7 @@ dependencies = [
  "pallet-preimage",
  "pallet-randomness-collective-flip",
  "pallet-rmrk-core",
+ "pallet-rmrk-market",
  "pallet-uniques",
  "parity-scale-codec",
  "phala-types",
@@ -3675,6 +3696,7 @@ version = "0.1.0"
 dependencies = [
  "hash-db",
  "im",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -4388,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "rmrk-traits"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6194,7 +6216,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -4064,12 +4064,31 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-core"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "rmrk-traits",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-rmrk-market"
+version = "0.0.1"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-rmrk-core",
  "pallet-uniques",
  "parity-scale-codec",
  "rmrk-traits",
@@ -4697,6 +4716,7 @@ dependencies = [
  "pallet-randomness-collective-flip",
  "pallet-recovery",
  "pallet-rmrk-core",
+ "pallet-rmrk-market",
  "pallet-scheduler",
  "pallet-session",
  "pallet-session-benchmarking",
@@ -4756,6 +4776,7 @@ dependencies = [
  "pallet-preimage",
  "pallet-randomness-collective-flip",
  "pallet-rmrk-core",
+ "pallet-rmrk-market",
  "pallet-uniques",
  "parity-scale-codec",
  "phala-types",
@@ -5751,7 +5772,7 @@ checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 [[package]]
 name = "rmrk-traits"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#9cc8d217464685a5d090b962f66dbce41d602ad4"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.37#a7e970cd6bd4b7b50f6611ea1023d1570721633c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7746,7 +7767,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -98,6 +98,7 @@ phat-offchain-rollup = { path = "../../pallets/offchain-rollup", default-feature
 # RMRK dependencies
 pallet-rmrk-core = { git = "https://github.com/Phala-Network/rmrk-substrate", branch = "polkadot-v0.9.37", default-features = false }
 rmrk-traits = { git = "https://github.com/Phala-Network/rmrk-substrate", branch = "polkadot-v0.9.37", default-features = false }
+pallet-rmrk-market = { git = "https://github.com/Phala-Network/rmrk-substrate", branch = "polkadot-v0.9.37", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", optional = true }
@@ -180,6 +181,7 @@ std = [
 	"pallet-uniques/std",
 	"pallet-rmrk-core/std",
 	"rmrk-traits/std",
+	"pallet-rmrk-market/std",
 	"phat-offchain-rollup/std",
 ]
 runtime-benchmarks = [

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1504,6 +1504,22 @@ parameter_types! {
     pub const QueueCapacity: u32 = 128;
 }
 
+parameter_types! {
+    pub const MinimumOfferAmount: Balance = DOLLARS / 10_000;
+    pub const MarketFee: Permill = Permill::from_parts(5_000);
+}
+
+
+impl pallet_rmrk_market::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type ProtocolOrigin = EnsureRoot<AccountId>;
+    type Currency = Balances;
+    type MinimumOfferAmount = MinimumOfferAmount;
+    type WeightInfo = pallet_rmrk_market::weights::SubstrateWeight<Runtime>;
+    type MarketplaceHooks = ();
+    type MarketFee = MarketFee;
+}
+
 impl pallet_anchor::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type OnResponse = PhatOracle;
@@ -1586,6 +1602,7 @@ construct_runtime!(
         // NFT
         Uniques: pallet_uniques::{Pallet, Storage, Event<T>},
         RmrkCore: pallet_rmrk_core::{Pallet, Call, Event<T>},
+        RmrkMarket: pallet_rmrk_market::{Pallet, Call, Event<T>},
     }
 );
 


### PR DESCRIPTION
**Background**
The Phala delegation will synchronously apply for Nft transfer and listing features with Phala World.
**New feature**
1. If a delegation nft is on the list, the owner of the nft can not contribute to or withdraw from the pool to which the nft belongs to.
2. The owner of the listing nft can not be assigned as the recipient of the vault owner-claimed shares.
3. Nfts can not be transferred to the owner of the listing nft.