### PR TITLE
pruntime: targeting musl

### DIFF
--- a/.github/actions/install_toolchain/action.yml
+++ b/.github/actions/install_toolchain/action.yml
@@ -10,6 +10,8 @@ runs:
         override: true
         target: wasm32-unknown-unknown
         components: rustfmt
-    - run: sudo apt-get install build-essential cmake pkg-config libssl-dev git llvm clang libclang-dev protobuf-compiler
+    - run: rustup target add x86_64-unknown-linux-musl
+      shell: bash
+    - run: sudo apt-get install build-essential cmake pkg-config libssl-dev git llvm clang libclang-dev protobuf-compiler musl-tools
       shell: bash
 

--- a/standalone/pruntime/Makefile
+++ b/standalone/pruntime/Makefile
@@ -1,4 +1,6 @@
 SGX_MODE ?= SW
+TARGET=x86_64-unknown-linux-musl
+BUILT_PRUNTIME=target/${TARGET}/release/pruntime
 
 .PHONY: all clean
 ifeq ($(SGX_MODE),SW)
@@ -10,12 +12,12 @@ bin/app: bin/pruntime
 bin/Rocket.toml: gramine-build/Rocket.toml
 	cp $? $@
 
-bin/pruntime: target/release/pruntime
+bin/pruntime: ${BUILT_PRUNTIME}
 	cp $? $@
 
-.PHONY: target/release/pruntime
-target/release/pruntime:
-	cargo build --release
+.PHONY: ${BUILT_PRUNTIME}
+${BUILT_PRUNTIME}:
+	cargo build --release --target ${TARGET}
 
 clean:
 	rm -rf bin/*


### PR DESCRIPTION
Memory blowing up happened in recent pruntime v2 testing. 
![image](https://user-images.githubusercontent.com/6442159/219989823-035ef2ff-e5e4-4d47-a594-f5fd6022e7ea.png)
As shown in the picture, the peak memory usage increased significantly at a height of approximately 3.3M. However, the rust peak did not show any fluctuation at that point. Therefore, there may be some issues with glibc or gramine libOS.

@jasl 
**This pull request compiles pruntime with musl libc. By using this pruntime, we can synchronize blocks and see if there are any differences.**

Don't merge.