### PR TITLE
pruntime: Use mimalloc as allocator

### DIFF
--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -2977,6 +2977,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libsecp256k1"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3202,6 +3212,15 @@ dependencies = [
  "keccak",
  "rand_core 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -5288,6 +5307,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "mimalloc",
  "num_cpus",
  "parity-scale-codec",
  "phactory",

--- a/standalone/pruntime/Cargo.toml
+++ b/standalone/pruntime/Cargo.toml
@@ -40,6 +40,7 @@ phala-allocator = { path = "../../crates/phala-allocator" }
 phala-rocket-middleware = { path = "../../crates/phala-rocket-middleware" }
 phala-types = { path = "../../crates/phala-types", features = ["enable_serde", "sgx"] }
 sgx-api-lite = { path = "../../crates/sgx-api-lite" }
+mimalloc = { version = "0.1", default-features = false }
 
 [patch.crates-io]
 rocket = { version = "0.5.0-rc.2", git = "https://github.com/SergioBenitez/Rocket" }

--- a/standalone/pruntime/src/pal_gramine.rs
+++ b/standalone/pruntime/src/pal_gramine.rs
@@ -1,7 +1,6 @@
 use anyhow::anyhow;
 use log::info;
 use parity_scale_codec::Encode;
-use std::alloc::System;
 
 use phactory_pal::{AppInfo, AppVersion, Machine, MemoryStats, MemoryUsage, Sealing, RA};
 use phala_allocator::StatSizeAllocator;
@@ -120,7 +119,7 @@ impl Machine for GraminePlatform {
 }
 
 #[global_allocator]
-static ALLOCATOR: StatSizeAllocator<System> = StatSizeAllocator::new(System);
+static ALLOCATOR: StatSizeAllocator<mimalloc::MiMalloc> = StatSizeAllocator::new(mimalloc::MiMalloc);
 
 impl MemoryStats for GraminePlatform {
     fn memory_usage(&self) -> MemoryUsage {


### PR DESCRIPTION
This is another choice to debug the memory issue in #1171.
There are some popular allocators, jemalloc from Facebook, tcmalloc from Google, mimalloc from Microsoft.
This PR tries mimalloc.