### PR TITLE
node-rpc-ext: Remove rayon (Fix deadlock)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7818,7 +7818,6 @@ dependencies = [
  "phala-mq",
  "phala-node-rpc-ext-types",
  "phala-pallets",
- "rayon",
  "sc-client-api",
  "sc-rpc",
  "sc-transaction-pool-api",

--- a/crates/phala-node-rpc-ext/Cargo.toml
+++ b/crates/phala-node-rpc-ext/Cargo.toml
@@ -32,6 +32,3 @@ phala-mq = { path = "../../crates/phala-mq" }
 phala-pallets = { path = "../../pallets/phala" }
 pallet-mq-runtime-api = { path = "../../pallets/phala/mq-runtime-api" }
 ext-types = { path = "./types", package = "phala-node-rpc-ext-types" }
-
-rayon = "1"
-

--- a/crates/phala-node-rpc-ext/src/storage_changes.rs
+++ b/crates/phala-node-rpc-ext/src/storage_changes.rs
@@ -1,6 +1,5 @@
 use super::*;
 pub use ext_types::*;
-use rayon::prelude::*;
 
 /// State RPC errors.
 #[derive(Debug, thiserror::Error)]
@@ -107,7 +106,7 @@ where
     }
 
     headers
-        .into_par_iter()
+        .into_iter()
         .map(|(id, mut header)| -> Result<_, Error> {
             let api = client.runtime_api();
             let hash = client.expect_block_hash_from_id(&id).expect("Should get the block hash");


### PR DESCRIPTION
We have got a deadlock in the `khala-node` while getting storage changes.
According to the gdb stack frame dump, we found the deadlock is caused by the following flow:
```
[time 0] Thread A: locked(rayon default thread pool) in `pha_getStorageChanges`.
[time 1] Thread B: locked(sp wasm runtime cache) in block executor.
[time 2] Thread B: acquiring (rayon default thread pool) in `fn runtime_version`.
[time 3] Thread A: acquiring (sp wasm runtime cache) `fn runtime_version`.
```
Ideally, this can be solved by replacing the rayon thread pool used in `pha_getStorageChanges` with a separate pool rather than the default one.
However, due to the thread pool API of rayon:
```rust
thread_pool.install(|| {
        let result = headers
            .into_par_iter()
            .for_each(|| { /*do the work*/ })
            .collect();
})
```
The codes running in the inner closure inherit the installed thread_pool automatically.
So it would still deadlock in this single thread like:
```
[time 0] Thread A: locked(rayon custom thread pool) in `pha_getStorageChanges`.
[time 1] Thread A: locked(sp wasm runtime cache) in block executor.
[time 2] Thread A: acquiring (rayon custom thread pool) in `fn runtime_version`.  < deadlock here
```

Turns out this is an aged issue laying [there](https://github.com/rayon-rs/rayon/issues/592) for a long time.

I've also tried to replace the rayon with a different version:
```
rayon = { version = "1", git = "https://github.com/rayon-rs/rayon.git" }
```
But it failed to compile due to that they depend on the external lib.

So, let's just remove the rayon at the moment.

@h4x3rotab @jasl 