### PR TITLE
headers-cache: Finish grabing storage gracefully

### DIFF
--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -140,7 +140,7 @@ struct Serve {
     grab_storage_changes: bool,
     /// Batch size for grabing storage changes
     #[clap(long)]
-    #[clap(default_value_t = 4)]
+    #[clap(default_value_t = 1)]
     grab_storage_changes_batch: BlockNumber,
     /// The relaychain RPC endpoint
     #[clap(long, default_value = "ws://localhost:9945")]

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -314,7 +314,12 @@ pub async fn grab_storage_changes(
 
     for from in (start_at..=to).step_by(batch_size as _) {
         let to = to.min(from.saturating_add(batch_size - 1));
-        let headers = crate::fetch_storage_changes(api, None, from, to).await?;
+        let headers = match crate::fetch_storage_changes(api, None, from, to).await {
+            Err(e) if e.to_string().contains("not found") => {
+                break;
+            }
+            other => other?,
+        };
         for header in headers {
             f(header)?;
             grabbed += 1;


### PR DESCRIPTION
rather than raise the error