### PR TITLE
Fix dead loop

### DIFF
--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -1066,7 +1066,7 @@ pub mod pallet {
 				None => return,
 			};
 
-			while pool_info.get_free_stakes::<T>() >= T::WPhaMinBalance::get() {
+			while pool_info.get_free_stakes::<T>() > T::WPhaMinBalance::get() {
 				if let Some(withdraw) = pool_info.withdraw_queue.front().cloned() {
 					// Must clear the pending reward before any stake change
 					let mut withdraw_nft_guard =


### PR DESCRIPTION
Fixed a bug that will lead to dead loop when user call `withdraw` while the `PoolAccount`'s balance reach the min limit.