### PR TITLE
pRPC: Support JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8746,6 +8746,7 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "prost 0.11.2",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/phactory/api/Cargo.toml
+++ b/crates/phactory/api/Cargo.toml
@@ -32,10 +32,10 @@ log = { version = "0.4.14" }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["rustls-tls", "socks"] }
 
 primitive-types = { version = "0.12.1", optional = true, default-features = false }
+serde_json = "1.0.79"
 
 [dev-dependencies]
 insta = "1.13.0"
-serde_json = "1.0.79"
 
 [build-dependencies]
 prpc-build = { path = "../../../crates/prpc-build" }

--- a/crates/phactory/api/build.rs
+++ b/crates/phactory/api/build.rs
@@ -21,35 +21,11 @@ fn main() {
         .out_dir(out_dir)
         .mod_prefix("crate::prpc::")
         .disable_package_emission();
-    for r#type in [
-        "InitRuntimeResponse",
-        "Attestation",
-        "AttestationReport",
-        "TokenomicInfo",
-        "TokenomicStat",
-        "WorkerState",
-        "WorkerStat",
-        "BenchState",
-        "WorkingState",
-        "NetworkConfig",
-        "NetworkStatus",
-        "PhactoryInfo",
-        "MemoryUsage",
-        "GatekeeperStatus",
-        "SystemInfo",
-        "ContractInfo",
-        "SidevmInfo",
-        "ClusterInfo",
-    ] {
-        builder = builder.type_attribute(
-            r#type,
-            "#[derive(::serde::Serialize, ::serde::Deserialize)]",
-        )
-    }
-    builder = builder.field_attribute(
-        "InitRuntimeResponse.attestation",
-        "#[serde(skip, default)]",
+    builder = builder.type_attribute(
+        ".pruntime_rpc",
+        "#[derive(::serde::Serialize, ::serde::Deserialize)]",
     );
+    builder = builder.field_attribute("InitRuntimeResponse.attestation", "#[serde(skip, default)]");
     builder
         .compile(&["pruntime_rpc.proto"], &[render_dir])
         .unwrap();

--- a/crates/phactory/api/src/proto_generated/mod.rs
+++ b/crates/phactory/api/src/proto_generated/mod.rs
@@ -5,6 +5,8 @@ mod pruntime_rpc;
 pub use protos_codec_extensions::*;
 pub use pruntime_rpc::*;
 
+pub const PROTO_DEF: &str = include_str!("../../proto/pruntime_rpc.proto");
+
 /// Helper struct used to compat the output of `get_info` for logging.
 #[derive(Debug)]
 pub struct Info<'a> {

--- a/crates/prpc/Cargo.toml
+++ b/crates/prpc/Cargo.toml
@@ -9,6 +9,7 @@ derive_more = "0.99.16"
 prost = { version = "0.11.2", default-features = false, features = ["prost-derive"] }
 anyhow = { version = "1.0.42", default-features = false }
 parity-scale-codec = { version = "3.1", default-features = false }
+serde_json = { version = "1", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/prpc/src/lib.rs
+++ b/crates/prpc/src/lib.rs
@@ -51,6 +51,11 @@ pub mod server {
         }
     }
 
+    impl From<serde_json::Error> for Error {
+        fn from(e: serde_json::Error) -> Self {
+            Self::DecodeError(DecodeError::new(e.to_string()))
+        }
+    }
 
     /// The final Error type of RPCs to be serialized to protobuf.
     #[derive(Display, Message)]

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -26,5 +26,111 @@ Return the next mq sequence number for given sender which take the ready transac
 **Returns:** `u64` - the next expected sequence number of the sender.
 
 ## pRuntime (pRPC)
+### RPC Definition
+pRuntime provides some interfaces for external applications through pRPC, which are defined in [Protobuf documents](https://github.com/Phala-Network/prpc-protos/blob/master/pruntime_rpc.proto). The proto definition document can be obtained by HTTP GET request `/help`.
+For example:
+```
+$ curl -s localhost:8000/help | head -n 20
 
-TODO
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package pruntime_rpc;
+
+// The Phactory Runtime service definition.
+service PhactoryAPI {
+  // Get basic information about Phactory state.
+  rpc GetInfo (google.protobuf.Empty) returns (PhactoryInfo) {}
+
+  // Sync the parent chain header
+  rpc SyncHeader (HeadersToSync) returns (SyncedTo) {}
+
+  // Sync the parachain header
+  rpc SyncParaHeader (ParaHeadersToSync) returns (SyncedTo) {}
+
+```
+### pRPC Visibility
+These pRuntime interfaces are divided into two categories: internal RPC and external RPC. Internal RPC is used for block synchronization and other tasks, while external RPC is mainly used to provide contract call services. Therefore, pRuntime provides two server ports specified by `--port` and `--public-port`. All RPCs are available on the port specified by `--port`, while only external RPC services are provided on the port specified by `--public-port`. RPC visibility is shown in the table below:
+
+| RPC Method | Visibility |
+| ---------- | ---------- |
+| SyncHeader | Private |
+| SyncParaHeader | Private |
+| SyncCombinedHeaders | Private |
+| DispatchBlocks | Private |
+| InitRuntime | Private |
+| GetRuntimeInfo | Private |
+| GetEgressMessages | Private |
+| GetWorkerState | Private |
+| AddEndpoint | Private |
+| RefreshEndpointSigningTime | Private |
+| GetEndpointInfo | Private |
+| SignEndpointInfo | Private |
+| DerivePhalaI2pKey | Private |
+| Echo | Private |
+| HandoverCreateChallenge | Private |
+| HandoverStart | Private |
+| HandoverAcceptChallenge | Private |
+| HandoverReceive | Private |
+| ConfigNetwork | Private |
+| HttpFetch | Private |
+| GetNetworkConfig | Private |
+| LoadChainState | Private |
+| Stop | Private |
+| LoadStorageProof | Private |
+| TakeCheckpoint | Private |
+| GetInfo | Public |
+| ContractQuery | Public |
+| GetContractInfo | Public |
+| GetClusterInfo | Public |
+| UploadSidevmCode | Public |
+| CalculateContractId | Public |
+
+### pRPC Invocation
+pRuntime starts an HTTP server on the aforementioned server ports, and the pRPC service is located at the path `/prpc/<method>`. When pRuntime is started, the available pRPC method list is printed in the logs:
+```
+[...] Methods under /prpc:
+[...]     /prpc/PhactoryAPI.GetInfo
+[...]     /prpc/PhactoryAPI.SyncHeader
+[...]     /prpc/PhactoryAPI.SyncParaHeader
+[...]     /prpc/PhactoryAPI.SyncCombinedHeaders
+[...]     /prpc/PhactoryAPI.DispatchBlocks
+[...]     /prpc/PhactoryAPI.InitRuntime
+[...]     /prpc/PhactoryAPI.GetRuntimeInfo
+...
+```
+#### Protobuf over HTTP Protocol
+By default, pRPC uses the protobuf over HTTP protocol. The protocol uses the HTTP POST method, and the RPC parameters and returned data are carried in the HTTP request and response body in protobuf encoding. Client code for various programming languages can be generated based on the [protobuf definition file](https://github.com/Phala-Network/prpc-protos/blob/master/pruntime_rpc.proto).
+
+#### JSON over HTTP Protocol
+pRPC also supports the JSON over HTTP protocol. The protocol uses the HTTP GET or POST method. When using GET, the JSON protocol is used. When using POST, the JSON protocol can be switched by adding the `?json` parameter to the URL path or by adding `Content-Type: application/json` to the request header.
+
+**Examples**:
+
+Via GET:
+```bash
+$ curl localhost:8000/prpc/PhactoryAPI.GetInfo
+```
+Via POST with a query argument `json`:
+```bash
+$ curl -d "" localhost:8000/prpc/PhactoryAPI.GetInfo?json
+```
+Or via POST with the Content-Type of JSON:
+```bash
+$ curl -d "" -H "Content-Type: application/json" localhost:8000/prpc/PhactoryAPI.GetInfo
+```
+
+With any of the above calls, the RPC will respond in JSON format:
+```json
+{"initialized":false,"registered":false,"genesis_block_hash":null,"public_key":null,"ecdh_public_key":null,"headernum":0,"para_headernum":0,"blocknum":0,"state_root":"","dev_mode":false,"pending_messages":0,"score":0,"gatekeeper":{"role":0,"master_public_key":""},"version":"2.0.1","git_revision":"45d5fb4b66d842d6fdec4fe696f29abe675e389d-dirty","memory_usage":{"rust_used":510350,"rust_peak_used":510350,"total_peak_used":16637444096},"waiting_for_paraheaders":false,"system":null,"can_load_chain_state":true,"safe_mode_level":0,"current_block_time":0}
+```
+
+Input arguments can also use JSON. For example:
+```bash
+curl -d '{"url":"https://httpbin.org/post","method":"POST","body":[],"headers":[]}' localhost:8000/prpc/PhactoryAPI.HttpFetch?json
+```
+Outputs:
+```json
+{"status_code":200,"headers":[{"name":"date","value":"Thu, 09 Mar 2023 03:45:22 GMT"},{"name":"content-type","value":"application/json"},{"name":"content-length","value":"314"},{"name":"server","value":"gunicorn/19.9.0"},{"name":"access-control-allow-origin","value":"*"},{"name":"access-control-allow-credentials","value":"true"}],"body":[123,10,32,32,34,...]}
+```

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -4592,6 +4592,7 @@ dependencies = [
  "reqwest",
  "scale-info",
  "serde",
+ "serde_json",
  "sp-application-crypto",
  "sp-core",
  "sp-finality-grandpa",
@@ -5255,6 +5256,7 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "prost 0.11.2",
+ "serde_json",
 ]
 
 [[package]]

--- a/standalone/pruntime/src/api_server.rs
+++ b/standalone/pruntime/src/api_server.rs
@@ -144,6 +144,11 @@ fn getinfo() -> String {
     runtime::ecall_getinfo()
 }
 
+#[get("/help")]
+fn help() -> String {
+    phactory_api::prpc::PROTO_DEF.to_string()
+}
+
 enum RpcType {
     Public,
     Private,
@@ -366,7 +371,7 @@ pub(super) fn rocket(args: &super::Args) -> rocket::Rocket<impl Phase> {
                 ),
             ],
         )
-        .mount("/", routes![getinfo]);
+        .mount("/", routes![getinfo, help]);
 
     if args.enable_kick_api {
         info!("ENABLE `kick` API");
@@ -407,7 +412,7 @@ pub(super) fn rocket_acl(args: &super::Args) -> Option<rocket::Rocket<impl Phase
         .merge(("port", public_port))
         .merge(("limits", Limits::new().limit("json", 100.mebibytes())));
 
-    let mut server_acl = rocket::custom(figment).mount("/", routes![getinfo]);
+    let mut server_acl = rocket::custom(figment).mount("/", routes![getinfo, help]);
 
     server_acl = server_acl.mount("/prpc", routes![prpc_proxy_acl, prpc_proxy_get_acl]);
 

--- a/standalone/pruntime/src/runtime.rs
+++ b/standalone/pruntime/src/runtime.rs
@@ -19,32 +19,6 @@ pub fn ecall_getinfo() -> String {
     serde_json::to_string_pretty(&info).unwrap_or_default()
 }
 
-fn serialize_result<T: serde::Serialize, E: std::fmt::Debug>(result: Result<T, E>) -> String {
-    match result {
-        Ok(inner) => serde_json::to_string_pretty(&inner).unwrap_or_default(),
-        Err(err) => {
-            let error = format!("{err:?}");
-            serde_json::to_string_pretty(&serde_json::json!({ "error": error }))
-        }
-        .unwrap_or_default(),
-    }
-}
-
-pub fn ecall_get_contract_info(ids: &str) -> String {
-    let ids = if ids.is_empty() {
-        vec![]
-    } else {
-        ids.split(',').map(|it| it.to_owned()).collect()
-    };
-    let result = APPLICATION.lock_phactory().get_contract_info(&ids);
-    serialize_result(result.map(|it| it.contracts))
-}
-
-pub fn ecall_get_cluster_info() -> String {
-    let result = APPLICATION.lock_phactory().get_cluster_info();
-    serialize_result(result.map(|it| it.clusters))
-}
-
 pub fn ecall_sign_http_response(data: &[u8]) -> Option<String> {
     APPLICATION.lock_phactory().sign_http_response(data)
 }
@@ -89,8 +63,8 @@ pub fn ecall_bench_run(index: u32) {
     }
 }
 
-pub async fn ecall_prpc_request(path: String, data: &[u8]) -> (u16, Vec<u8>) {
-    let (code, data) = APPLICATION.dispatch_request(path, data).await;
+pub async fn ecall_prpc_request(path: String, data: &[u8], json: bool) -> (u16, Vec<u8>) {
+    let (code, data) = APPLICATION.dispatch_request(path, data, json).await;
     info!("pRPC status code: {}, data len: {}", code, data.len());
     (code, data)
 }


### PR DESCRIPTION
The PR adds support for talking to the pRPC with JSON input/output. This makes it easier for more external tools to connect to pruntime RPC.

Example:
Via GET:
```bash
$ curl localhost:8000/prpc/PhactoryAPI.GetInfo
```
Via POST with a query argument `json`:
```bash
$ curl -d "" localhost:8000/prpc/PhactoryAPI.GetInfo?json
```
Or via POST with the Content-Type of JSON:
```bash
$ curl -d "" -H "Content-Type: application/json" localhost:8000/prpc/PhactoryAPI.GetInfo
```

With any of the above calls, the RPC will respond in JSON format:
```json
{"initialized":false,"registered":false,"genesis_block_hash":null,"public_key":null,"ecdh_public_key":null,"headernum":0,"para_headernum":0,"blocknum":0,"state_root":"","dev_mode":false,"pending_messages":0,"score":0,"gatekeeper":{"role":0,"master_public_key":""},"version":"2.0.1","git_revision":"45d5fb4b66d842d6fdec4fe696f29abe675e389d-dirty","memory_usage":{"rust_used":510350,"rust_peak_used":510350,"total_peak_used":16637444096},"waiting_for_paraheaders":false,"system":null,"can_load_chain_state":true,"safe_mode_level":0,"current_block_time":0}
```

Input arguments can also use JSON. For example:
```bash
curl -d '{"url":"https://httpbin.org/post","method":"POST","body":[],"headers":[]}' localhost:8000/prpc/PhactoryAPI.HttpFetch?json
```
outputs:
```json
{"status_code":200,"headers":[{"name":"date","value":"Thu, 09 Mar 2023 03:45:22 GMT"},{"name":"content-type","value":"application/json"},{"name":"content-length","value":"314"},{"name":"server","value":"gunicorn/19.9.0"},{"name":"access-control-allow-origin","value":"*"},{"name":"access-control-allow-credentials","value":"true"}],"body":[123,10,32,32,34,...]}
```

Also added an mount point `/help` the return the pRPC proto definition:
```
$ curl localhost:8000/help 2>/dev/null | head -n 20

syntax = "proto3";

import "google/protobuf/empty.proto";

package pruntime_rpc;

// The Phactory Runtime service definition.
service PhactoryAPI {
  // Get basic information about Phactory state.
  rpc GetInfo (google.protobuf.Empty) returns (PhactoryInfo) {}

  // Sync the parent chain header
  rpc SyncHeader (HeadersToSync) returns (SyncedTo) {}

  // Sync the parachain header
  rpc SyncParaHeader (ParaHeadersToSync) returns (SyncedTo) {}

```

