### PR TITLE
pruntime: Print enclave info on startup

### DIFF
--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -5287,6 +5287,7 @@ dependencies = [
  "clap",
  "colored",
  "env_logger 0.9.0",
+ "hex_fmt",
  "lazy_static",
  "libc",
  "log",

--- a/standalone/pruntime/Cargo.toml
+++ b/standalone/pruntime/Cargo.toml
@@ -40,6 +40,7 @@ phala-allocator = { path = "../../crates/phala-allocator" }
 phala-rocket-middleware = { path = "../../crates/phala-rocket-middleware" }
 phala-types = { path = "../../crates/phala-types", features = ["enable_serde", "sgx"] }
 sgx-api-lite = { path = "../../crates/sgx-api-lite" }
+hex_fmt = "0.3.0"
 
 [patch.crates-io]
 rocket = { version = "0.5.0-rc.2", git = "https://github.com/SergioBenitez/Rocket" }

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -84,6 +84,8 @@ struct Args {
 
 #[rocket::main]
 async fn main() -> Result<(), rocket::Error> {
+    pal_gramine::print_target_info();
+
     // Disable the thread local arena(memory pool) for glibc.
     // See https://github.com/gramineproject/gramine/issues/342#issuecomment-1014475710
     #[cfg(target_env = "gnu")]


### PR DESCRIPTION
Requested by @jasl 
Info printed on startup:
```
$ ./gramine-sgx pruntime --version
Gramine is starting. Parsing TOML manifest file, this may take some time...
...
Running in Gramine-SGX
mr_enclave  : 0xb944d736f53e398e2f0167a8f84290b98a87d418318ed75efd9661f71ab66d0d
mr_signer   : 0x83d719e77deaca1470f6baf62a4d774303c899db69020f9c70ee1dfc08c7ce9e
isv_svn     : 0x0000
isv_prod_id : 0x0000
pruntime 2.0.1
```