### PR TITLE
Fix vault owner shares redelegate problem

### DIFF
--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -384,12 +384,12 @@ pub mod pallet {
 			cid: CollectionId,
 		) -> DispatchResult {
 			let mut account_status =
-				StakerAccounts::<T>::get(who).ok_or(Error::<T>::StakerAccountNotFound)?;
+				StakerAccounts::<T>::get(who).unwrap_or_default();
 
 			if !account_status.invest_pools.contains(&(pid, cid)) {
 				account_status.invest_pools.push((pid, cid));
-				StakerAccounts::<T>::insert(who, account_status);
 			}
+			StakerAccounts::<T>::insert(who, account_status);
 			Ok(())
 		}
 


### PR DESCRIPTION
Fixed a potential problem that may trigger the `StakerAccountNotFound` error event when a vault owner claim his owner shares into balances and try to re-delegate. 