### PR TITLE
PoC: dumping storage for different key (from the same machine)

### DIFF
--- a/crates/phactory/api/src/ecall_args.rs
+++ b/crates/phactory/api/src/ecall_args.rs
@@ -25,6 +25,9 @@ pub struct InitArgs {
     /// Enable checkpoint
     pub enable_checkpoint: bool,
 
+    /// Dump checkpoint for different key
+    pub dump_checkpoint_for_key: Option<String>,
+
     /// Checkpoint interval in seconds
     pub checkpoint_interval: u64,
 

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -49,7 +49,6 @@ use phala_serde_more as more;
 use phala_types::WorkerRegistrationInfo;
 use std::time::Instant;
 use types::Error;
-use phactory_api::{prpc as pb};
 
 pub use contracts::pink;
 pub use side_task::SideTaskManager;

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -369,14 +369,8 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
         let runtime_data = match Self::load_runtime_data(platform, sealing_path) {
             Ok(data) => data,
             Err(err) => match err {
-                Error::PersistentRuntimeNotFound => {
-                    error!("PersistentRuntimeNotFound");
-                    return Ok(None);
-                },
-                _ => {
-                    error!("Different error");
-                    return Err(err.into());
-                },
+                Error::PersistentRuntimeNotFound => return Ok(None),
+                _ => return Err(err.into()),
             },
         };
         let checkpoint_file = PathBuf::from(sealing_path).join(CHECKPOINT_FILE);
@@ -403,12 +397,8 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
 
         let file = match platform.open_protected_file(&tmpfile, &runtime_data.sk) {
             Ok(Some(file)) => file,
-            Ok(None) => {
-                error!("File not opened");
-                return Ok(None);
-            },
+            Ok(None) => return Ok(None),
             Err(err) => {
-                error!("Failed to open checkpoint file");
                 if remove_corrupted {
                     remove_file(&checkpoint_file);
                 }

--- a/standalone/pruntime/app/src/main.rs
+++ b/standalone/pruntime/app/src/main.rs
@@ -90,6 +90,9 @@ struct Args {
     #[structopt(long)]
     remove_corrupted_checkpoint: bool,
 
+    #[structopt(long)]
+    dump_checkpoint_for_key: Option<String>,
+
     /// Measuring the time it takes to process each RPC call.
     #[structopt(long)]
     measure_rpc_time: bool,
@@ -655,6 +658,7 @@ async fn main() {
         git_revision: git_revision(),
         geoip_city_db: args.geoip_city_db,
         enable_checkpoint: !args.disable_checkpoint,
+        dump_checkpoint_for_key: args.dump_checkpoint_for_key,
         checkpoint_interval: args.checkpoint_interval,
         remove_corrupted_checkpoint: args.remove_corrupted_checkpoint,
         gc_interval: args.gc_interval,

--- a/standalone/pruntime/enclave/src/lib.rs
+++ b/standalone/pruntime/enclave/src/lib.rs
@@ -82,10 +82,11 @@ pub extern "C" fn ecall_init(args: *const u8, args_len: usize) -> sgx_status_t {
                 factory.set_args(args.clone());
 
                 // dump for different key
-                info!("{:?}", args.dump_checkpoint_for_key);
-
                 if args.dump_checkpoint_for_key.is_some() {
-                    info!("Taking checkpoint for different key...");
+                    info!(
+                        "Taking checkpoint for different key... {:?}",
+                        args.dump_checkpoint_for_key
+                    );
 
                     match factory.dump_checkpoint_for_different_key(
                         &SgxPlatform.clone(),


### PR DESCRIPTION
I made dirty PoC of dumping synced storage for different key.

How to reproduce:
1. Start node (with fast block producing for better testing)
2. Start pruntime (with low checkpoint interval)
3. Start pherry injecting first key. Wait for sync and checkpoint generation
4. Stop pruntime and pherry. 
5. Move `checkpoint.seal` and `pruntime-data.seal` to different location (let it be `worker2`)
6. Wait for node to generate a lot more blocks
7. Start pruntime again
8. Start pherry injecting second key.
9. Stop pruntime and pherry. Copy `checkpoint.seal` and `pruntime-data.seal` to different location (let it be `worker1`)
10. Start pruntime with params
```
./app --dump-checkpoint-for-key=<abs-path-to-worker2>
```
Output like
```
[INFO  enclaveapp] Loaded checkpoint
[INFO  enclaveapp] Some("/home/l00k/.../standalone/pruntime/bin/sample2")
[INFO  enclaveapp] Taking checkpoint for different key...
[INFO  phactory] Loading different key from Some("/home/l00k/.../standalone/pruntime/bin/sample2")
[INFO  phactory] Loaded checkpoint for different key
[INFO  phactory] Taking checkpoint...
[INFO  phactory] Checkpoint saved to "/home/l00k/.../standalone/pruntime/bin/./checkpoint.seal"
[INFO  enclaveapp] Checkpoint for different key dumped
```
11. Now you have `checkpoint.seal` in root directory. Copy `worker2/pruntime-data.seal` into root directory.  `worker2` is now fully synced