### PR TITLE
pruntime: Show timestamp in git revision

### DIFF
--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -33,7 +33,7 @@ use sp_core::{crypto::Pair, sr25519, H256};
 
 use phactory_api::{
     blocks::{self, SyncCombinedHeadersReq, SyncParachainHeaderReq},
-    ecall_args::{git_revision, InitArgs},
+    ecall_args::InitArgs,
     endpoints::EndpointType,
     prpc::{GetEndpointResponse, InitRuntimeResponse, NetworkConfig},
     storage_sync::{StorageSynchronizer, Synchronizer},
@@ -282,14 +282,6 @@ impl<Platform: pal::Platform> Phactory<Platform> {
     }
 
     pub fn init(&mut self, args: InitArgs) {
-        if args.git_revision != git_revision() {
-            panic!(
-                "git revision mismatch: {}(app) vs {}(enclave)",
-                args.git_revision,
-                git_revision()
-            );
-        }
-
         if args.init_bench {
             benchmark::resume();
         }

--- a/crates/phala-git-revision/build.rs
+++ b/crates/phala-git-revision/build.rs
@@ -12,6 +12,18 @@ fn export_git_revision() {
         .stdout;
     let revision = String::from_utf8_lossy(&cmd);
     let revision = revision.trim();
+    let timestamp = Command::new("git")
+        .args([
+            "show",
+            "-s",
+            "--format=%cd",
+            "--date=format:%Y%m%d%H%M%S",
+            revision,
+        ])
+        .output()
+        .unwrap()
+        .stdout;
+    let timestamp = String::from_utf8_lossy(&timestamp);
     let dirty = !Command::new("git")
         .args(["diff", "HEAD", "--quiet"])
         .output()
@@ -24,5 +36,7 @@ fn export_git_revision() {
         println!("cargo:warning=⚠️ Please ensure you have git installed and are compiling from a git repository.");
     }
     println!("cargo:rustc-env=PHALA_GIT_REVISION={revision}{tail}");
+    println!("cargo:rustc-env=PHALA_GIT_COMMIT_TS={timestamp}");
+    println!("cargo:rustc-env=PHALA_GIT_REVISION_WITH_TS={revision}-{timestamp}{tail}");
     println!("cargo:rerun-if-changed=always-rerun");
 }

--- a/crates/phala-git-revision/src/lib.rs
+++ b/crates/phala-git-revision/src/lib.rs
@@ -3,3 +3,11 @@
 pub fn git_revision() -> &'static str {
     env!("PHALA_GIT_REVISION")
 }
+
+pub fn git_commit_timestamp() -> &'static str {
+    env!("PHALA_GIT_COMMIT_TS")
+}
+
+pub fn git_revision_with_ts() -> &'static str {
+    env!("PHALA_GIT_REVISION_WITH_TS")
+}

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -5001,6 +5001,7 @@ dependencies = [
  "phactory-api",
  "phactory-pal",
  "phala-allocator",
+ "phala-git-revision",
  "phala-rocket-middleware",
  "phala-sanitized-logger",
  "phala-types",

--- a/standalone/pruntime/Cargo.toml
+++ b/standalone/pruntime/Cargo.toml
@@ -39,6 +39,7 @@ phactory-pal = { path = "../../crates/phactory/pal" }
 phala-allocator = { path = "../../crates/phala-allocator" }
 phala-rocket-middleware = { path = "../../crates/phala-rocket-middleware" }
 phala-types = { path = "../../crates/phala-types", features = ["enable_serde", "sgx"] }
+phala-git-revision = { path = "../../crates/phala-git-revision" }
 sgx-api-lite = { path = "../../crates/sgx-api-lite" }
 hex_fmt = "0.3.0"
 

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -8,7 +8,8 @@ use std::{env, thread};
 use clap::Parser;
 use log::{error, info};
 
-use phactory_api::ecall_args::{git_revision, InitArgs};
+use phactory_api::ecall_args::InitArgs;
+use phala_git_revision::git_revision_with_ts;
 
 mod handover;
 use phala_sanitized_logger as logger;
@@ -137,7 +138,7 @@ async fn main() -> Result<(), rocket::Error> {
             storage_path: storage_path.into(),
             init_bench: args.init_bench,
             version: env!("CARGO_PKG_VERSION").into(),
-            git_revision: git_revision().to_string(),
+            git_revision: git_revision_with_ts().to_string(),
             enable_checkpoint: !args.disable_checkpoint,
             checkpoint_interval: args.checkpoint_interval,
             remove_corrupted_checkpoint: args.remove_corrupted_checkpoint,


### PR DESCRIPTION
This PR append the `git commit timestamp` to the `git_revision` in `get_info`:
```bash
$ curl -s localhost:8000/prpc/PhactoryAPI.GetInfo | jq .git_revision
"7cab7494121109a227b2460d0703fb97fdc3f4fd-20230321070215"
```
This makes some troubleshooting easier.