### PR TITLE
headers-cache: Support for hot fixing blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,19 +653,20 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite 0.2.9",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.20",
@@ -3914,10 +3915,13 @@ dependencies = [
  "chrono",
  "clap 4.0.22",
  "env_logger 0.9.0",
+ "futures",
+ "hex",
  "log",
  "parity-scale-codec",
  "phala-rocket-middleware",
  "pherry",
+ "rand 0.8.5",
  "reqwest",
  "rocket",
  "rocksdb",
@@ -8090,6 +8094,7 @@ name = "pherry"
 version = "0.1.2"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "base64 0.13.0",
  "clap 4.0.22",

--- a/standalone/headers-cache/Cargo.toml
+++ b/standalone/headers-cache/Cargo.toml
@@ -19,3 +19,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 phala-rocket-middleware = { path = "../../crates/phala-rocket-middleware" }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "socks"] }
+futures = "0.3"
+rand = "0.8"
+hex = "0.4"

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -154,6 +154,9 @@ struct Serve {
     /// Prefered minimum number of blocks between justification
     #[arg(long, default_value_t = 1000)]
     justification_interval: BlockNumber,
+    /// Token for uploading APIs.
+    #[arg(long)]
+    token: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -248,6 +251,7 @@ async fn main() -> anyhow::Result<()> {
 
 async fn serve(config: Serve) -> anyhow::Result<()> {
     let db = db::CacheDB::open(&config.db)?;
+    let token = config.token.clone();
 
     if let Some(upstream) = config.mirror.clone() {
         if config.grab_headers {
@@ -272,7 +276,7 @@ async fn serve(config: Serve) -> anyhow::Result<()> {
             std::process::exit(1);
         });
     }
-    web_api::serve(db).await?;
+    web_api::serve(db, token).await?;
     Ok(())
 }
 

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -145,11 +145,11 @@ async fn process_items(
             Ok(record) => {
                 let number = record
                     .header()
-                    .map_err(|e| BadRequest(Some(format!("Decode error: {}", e))))?
+                    .map_err(|e| BadRequest(Some(format!("Decode error: {e}"))))?
                     .number;
                 handler(app, number, record.payload());
             }
-            Err(e) => return Err(BadRequest(Some(format!("Decode error: {}", e)))),
+            Err(e) => return Err(BadRequest(Some(format!("Decode error: {e}")))),
         }
     }
     Ok(())

--- a/standalone/headers-cache/src/web_api/auth.rs
+++ b/standalone/headers-cache/src/web_api/auth.rs
@@ -1,0 +1,30 @@
+use rocket::http::Status;
+use rocket::request::{self, FromRequest};
+use rocket::Request;
+
+pub struct Token {
+    pub value: String,
+}
+
+pub struct Authorized;
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for Authorized {
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+        let token = request
+            .rocket()
+            .state::<Token>()
+            .expect("Token state not available.");
+        if token.value.is_empty() {
+            return request::Outcome::Success(Authorized);
+        }
+        match request.headers().get_one("X-Token") {
+            Some(header_token) if header_token == token.value => {
+                request::Outcome::Success(Authorized)
+            }
+            _ => request::Outcome::Failure((Status::Forbidden, ())),
+        }
+    }
+}

--- a/standalone/pherry/Cargo.toml
+++ b/standalone/pherry/Cargo.toml
@@ -40,3 +40,4 @@ phala-mq = { path = "../../crates/phala-mq" }
 phactory-api = { path = "../../crates/phactory/api", features = ["pruntime-client"] }
 
 phaxt = { path = "../../crates/phaxt" }
+async-stream = "0.3.4"

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -98,12 +98,12 @@ impl<'a> Record<'a> {
     pub fn write(&self, mut writer: impl Write) -> Result<usize> {
         let length = self.payload.len() as u32;
         writer.write_all(&length.to_be_bytes())?;
-        writer.write_all(&*self.payload)?;
+        writer.write_all(&self.payload)?;
         Ok(self.payload.len() + 4)
     }
 
     pub fn payload(&'a self) -> &'a [u8] {
-        &*self.payload
+        &self.payload
     }
 
     pub fn header(&self) -> Result<Header> {
@@ -160,7 +160,7 @@ pub async fn async_read_items(
 }
 
 /// Read headers from grabbed file asynchronously.
-pub fn read_items_stream<'a>(
+pub fn read_items_stream(
     mut input: impl AsyncRead + Unpin,
 ) -> impl Stream<Item = io::Result<Record<'static>>> {
     async_stream::stream! {

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -6,9 +6,12 @@ use phaxt::{
     subxt::{self, rpc::types::NumberOrHex},
     BlockNumber, ParachainApi, RelaychainApi,
 };
-use std::io::{Read, Write};
+use std::borrow::Cow;
+use std::io::{self, Read, Write};
 
+use futures::stream::Stream;
 use log::{error, info, warn};
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 pub use phactory_api::blocks::{AuthoritySetChange, BlockHeaderWithChanges, GenesisBlockInfo};
 
@@ -29,20 +32,28 @@ pub struct ParaHeader {
 
 #[derive(Clone)]
 pub struct Record<'a> {
-    payload: &'a [u8],
+    payload: Cow<'a, [u8]>,
 }
 
 impl<'a> Record<'a> {
     pub fn new(payload: &'a [u8]) -> Self {
-        Self { payload }
+        Self {
+            payload: payload.into(),
+        }
     }
 
     pub fn read(mut input: impl Read, buffer: &'a mut Vec<u8>) -> Result<Option<Self>> {
         let mut len_buf = [0u8; 4];
 
-        if input.read(&mut len_buf)? != 4 {
-            // EOF
-            return Ok(None);
+        match input.read_exact(&mut len_buf) {
+            Ok(_) => {}
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                    return Ok(None);
+                } else {
+                    return Err(e.into());
+                }
+            }
         }
 
         let length = u32::from_be_bytes(len_buf) as usize;
@@ -56,19 +67,53 @@ impl<'a> Record<'a> {
         Ok(Some(Self::new(&buffer[..length])))
     }
 
+    pub async fn async_read<'b>(
+        mut input: impl AsyncRead + Unpin,
+        buffer: &'b mut Vec<u8>,
+    ) -> Result<Option<Record<'b>>, std::io::Error> {
+        let mut len_buf = [0u8; 4];
+
+        match input.read_exact(&mut len_buf).await {
+            Ok(_) => {}
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                    return Ok(None);
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+
+        let length = u32::from_be_bytes(len_buf) as usize;
+
+        if length > buffer.len() {
+            buffer.resize(length, 0);
+        }
+
+        input.read_exact(&mut buffer[..length]).await?;
+
+        Ok(Some(Record::new(&buffer[..length])))
+    }
+
     pub fn write(&self, mut writer: impl Write) -> Result<usize> {
         let length = self.payload.len() as u32;
         writer.write_all(&length.to_be_bytes())?;
-        writer.write_all(self.payload)?;
+        writer.write_all(&*self.payload)?;
         Ok(self.payload.len() + 4)
     }
 
-    pub fn payload(&self) -> &'a [u8] {
-        self.payload
+    pub fn payload(&'a self) -> &'a [u8] {
+        &*self.payload
     }
 
     pub fn header(&self) -> Result<Header> {
         Ok(Decode::decode(&mut &self.payload[..])?)
+    }
+
+    pub fn to_owned(&self) -> Record<'static> {
+        Record {
+            payload: self.payload.to_vec().into(),
+        }
     }
 }
 
@@ -91,6 +136,48 @@ pub fn read_items(
         }
     }
     Ok(count)
+}
+
+/// Read headers from grabbed file asynchronously.
+pub async fn async_read_items(
+    mut input: impl AsyncRead + Unpin,
+    mut f: impl FnMut(Record<'_>) -> Result<bool> + Unpin,
+) -> Result<u32> {
+    let mut count = 0_u32;
+    let mut buffer = vec![0u8; 1024 * 100];
+    loop {
+        match Record::async_read(&mut input, &mut buffer).await? {
+            None => break,
+            Some(record) => {
+                count += 1;
+                if f(record)? {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(count)
+}
+
+/// Read headers from grabbed file asynchronously.
+pub fn read_items_stream<'a>(
+    mut input: impl AsyncRead + Unpin,
+) -> impl Stream<Item = io::Result<Record<'static>>> {
+    async_stream::stream! {
+        let mut buffer = vec![0u8; 1024 * 100];
+        loop {
+            match Record::async_read(&mut input, &mut buffer).await {
+                Ok(None) => break,
+                Ok(Some(record)) => {
+                    yield Ok(record.to_owned());
+                },
+                Err(e) => {
+                    yield Err(e);
+                    break;
+                },
+            }
+        }
+    }
 }
 
 /// Dump headers from the chain to a log file.


### PR DESCRIPTION
Sometimes, headers-cache would grab broken block data from the chain node.
This PR adds 3 web APIs for headers-cache to upload in order to hot fix those broken data without interrupting the service.

Usage:
Startup headers-cache with a token:
```bash
ROCKET_PORT=8002 ./headers-cache serve --grab-headers --grab-para-headers --grab-storage-changes --token 123
```
Assuming that block 3532919 is broken, we can fetch the block from another node:
```bash
./headers-cache grab storage-changes --para-node-uri ws://the-node:9944 --from-block 3532919 --count 1 storage-changes.bin
```
Then patch the broken block by upload the file:
```bash
curl -XPUT -H "X-Token: 123" --data-binary @storage-changes.bin localhost:8002/storage-changes
```
@jasl 