### PR TITLE
pink-runtime: Limit parsed ink code size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
           submodules: 'true'
       - uses: ./.github/actions/install_toolchain
       - name: Run cargo tests
-        run: cargo test --tests -vv --workspace --exclude node-executor --exclude phala-node
+        run: cargo test --tests --release --workspace --exclude node-executor --exclude phala-node
 
   cargo-clippy:
     name: Run cargo clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7991,6 +7991,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "phala-wasm-checker"
+version = "0.1.0"
+dependencies = [
+ "wasmparser 0.102.0",
+]
+
+[[package]]
 name = "phat-offchain-rollup"
 version = "0.1.0"
 dependencies = [
@@ -8177,6 +8184,7 @@ dependencies = [
  "phala-serde-more",
  "phala-trie-storage",
  "phala-types",
+ "phala-wasm-checker",
  "pink-capi",
  "pink-extension",
  "pink-extension-runtime",
@@ -14446,6 +14454,16 @@ name = "wasmparser"
 version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64b20236ab624147dfbb62cf12a19aaf66af0e41b8398838b66e997d07d269d4"
+dependencies = [
+ "indexmap",
+ "url",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b"
 dependencies = [
  "indexmap",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
 	"crates/phala-async-executor",
 	"crates/phala-allocator",
 	"crates/phala-sanitized-logger",
+	"crates/phala-wasm-checker",
 	"crates/wasmer-tunables",
 	"crates/phala-rocket-middleware",
 	"crates/pink/runner",

--- a/crates/phala-wasm-checker/Cargo.toml
+++ b/crates/phala-wasm-checker/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "phala-wasm-checker"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasmparser = "0.102"

--- a/crates/phala-wasm-checker/src/error.rs
+++ b/crates/phala-wasm-checker/src/error.rs
@@ -8,7 +8,7 @@ impl Error for ParseError {}
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            ParseError::WasmError(e) => write!(f, "Wasm error: {}", e),
+            ParseError::WasmError(e) => write!(f, "Wasm error: {e}"),
         }
     }
 }

--- a/crates/phala-wasm-checker/src/error.rs
+++ b/crates/phala-wasm-checker/src/error.rs
@@ -1,0 +1,19 @@
+use std::error::Error;
+
+#[derive(Debug)]
+pub enum ParseError {
+    WasmError(wasmparser::BinaryReaderError),
+}
+impl Error for ParseError {}
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ParseError::WasmError(e) => write!(f, "Wasm error: {}", e),
+        }
+    }
+}
+impl From<wasmparser::BinaryReaderError> for ParseError {
+    fn from(e: wasmparser::BinaryReaderError) -> Self {
+        ParseError::WasmError(e)
+    }
+}

--- a/crates/phala-wasm-checker/src/lib.rs
+++ b/crates/phala-wasm-checker/src/lib.rs
@@ -4,21 +4,13 @@ use wasmparser::{Parser, Payload};
 
 mod error;
 
+#[derive(Default)]
 pub struct WasmInfo {
     pub num_instructions: u32,
     pub num_functions: u32,
     pub const_data_size: usize,
 }
 
-impl WasmInfo {
-    pub fn new() -> Self {
-        WasmInfo {
-            num_instructions: 0,
-            num_functions: 0,
-            const_data_size: 0,
-        }
-    }
-}
 
 impl WasmInfo {
     pub fn estimate_wasmi_memory_cost(&self) -> usize {
@@ -29,7 +21,7 @@ impl WasmInfo {
 
 pub fn wasm_info(data: &[u8]) -> Result<WasmInfo, ParseError> {
     let parser = Parser::new(0);
-    let mut stats = WasmInfo::new();
+    let mut stats = WasmInfo::default();
 
     for payload in parser.parse_all(data) {
         match payload? {

--- a/crates/phala-wasm-checker/src/lib.rs
+++ b/crates/phala-wasm-checker/src/lib.rs
@@ -1,0 +1,81 @@
+pub use error::ParseError;
+
+use wasmparser::{Parser, Payload};
+
+mod error;
+
+pub struct WasmInfo {
+    pub num_instructions: u32,
+    pub num_functions: u32,
+    pub const_data_size: usize,
+}
+
+impl WasmInfo {
+    pub fn new() -> Self {
+        WasmInfo {
+            num_instructions: 0,
+            num_functions: 0,
+            const_data_size: 0,
+        }
+    }
+}
+
+impl WasmInfo {
+    pub fn estimate_wasmi_memory_cost(&self) -> usize {
+        // Each instruction takes 16 bytes in wasmi's memory
+        self.num_instructions as usize * 16 + self.const_data_size
+    }
+}
+
+pub fn wasm_info(data: &[u8]) -> Result<WasmInfo, ParseError> {
+    let parser = Parser::new(0);
+    let mut stats = WasmInfo::new();
+
+    for payload in parser.parse_all(data) {
+        match payload? {
+            Payload::Version { .. } => {}
+            Payload::TypeSection(_) => {}
+            Payload::ImportSection(_) => {}
+            Payload::FunctionSection(_) => {}
+            Payload::TableSection(_) => {}
+            Payload::MemorySection(_) => {}
+            Payload::TagSection(_) => {}
+            Payload::GlobalSection(_) => {}
+            Payload::ExportSection(_) => {}
+            Payload::StartSection { .. } => {}
+            Payload::ElementSection(_) => {}
+            Payload::DataCountSection { .. } => {}
+            Payload::DataSection(data) => {
+                for entry in data {
+                    stats.const_data_size += entry?.data.len();
+                }
+            }
+            Payload::CodeSectionStart { .. } => {}
+            Payload::CodeSectionEntry(body) => {
+                stats.num_functions += 1;
+                let mut reader = body.get_operators_reader()?;
+                while !reader.eof() {
+                    let _op = reader.read()?;
+                    stats.num_instructions += 1;
+                }
+            }
+            Payload::ModuleSection { .. } => {}
+            Payload::InstanceSection(_) => {}
+            Payload::CoreTypeSection(_) => {}
+            Payload::ComponentSection { .. } => {}
+            Payload::ComponentInstanceSection(_) => {}
+            Payload::ComponentAliasSection(_) => {}
+            Payload::ComponentTypeSection(_) => {}
+            Payload::ComponentCanonicalSection(_) => {}
+            Payload::ComponentStartSection { .. } => {}
+            Payload::ComponentImportSection(_) => {}
+            Payload::ComponentExportSection(_) => {}
+            Payload::CustomSection(_) => {}
+            Payload::UnknownSection { .. } => {}
+            Payload::End(_) => {
+                break;
+            }
+        }
+    }
+    Ok(stats)
+}

--- a/crates/pink/runtime/Cargo.toml
+++ b/crates/pink/runtime/Cargo.toml
@@ -60,6 +60,7 @@ hash-db = "0.16.0"
 anyhow = "1"
 phala-git-revision = { path = "../../phala-git-revision" }
 subxt = { path = "../../../subxt/subxt" }
+phala-wasm-checker = { path = "../../phala-wasm-checker" }
 
 [dev-dependencies]
 insta = "1.7.2"

--- a/crates/pink/runtime/src/capi/ecall_impl.rs
+++ b/crates/pink/runtime/src/capi/ecall_impl.rs
@@ -135,10 +135,10 @@ impl ecall::ECalls for ECallImpl {
         If we allow 8 concurrent calls, the total memory cost would be 78MB * 8 = 624MB.
         */
         let info = phala_wasm_checker::wasm_info(&code)
-            .map_err(|err| format!("Invalid wasm: {:?}", err))?;
+            .map_err(|err| format!("Invalid wasm: {err:?}"))?;
         let max_wasmi_cost = crate::runtime::MaxCodeLen::get() as usize * 4;
         if info.estimate_wasmi_memory_cost() > max_wasmi_cost {
-            return Err("CodeTooLarge".into());
+            return Err("DecompressedCodeTooLarge".into());
         }
         crate::runtime::Contracts::bare_upload_code(
             account,

--- a/crates/pink/runtime/src/runtime.rs
+++ b/crates/pink/runtime/src/runtime.rs
@@ -106,16 +106,16 @@ impl pallet_timestamp::Config for PinkRuntime {
 // Workaround for the test failure in runtime_integrity_tests
 // https://github.com/paritytech/substrate/pull/12993/files#diff-67684005af418e25ff88c2ae5b520f0c040371f1d817e03a3652e76b9485224aR1217
 #[cfg(test)]
-const MAX_CODE_NAME: u32 = 64 * 1024;
+const MAX_CODE_LEN: u32 = 64 * 1024;
 #[cfg(not(test))]
-const MAX_CODE_NAME: u32 = 2 * 1024 * 1024;
+const MAX_CODE_LEN: u32 = 2 * 1024 * 1024;
 
 parameter_types! {
     pub DepositPerStorageByte: Balance = Pink::deposit_per_byte();
     pub DepositPerStorageItem: Balance = Pink::deposit_per_item();
     pub const DeletionQueueDepth: u32 = 1024;
     pub const DeletionWeightLimit: Weight = Weight::from_parts(500_000_000_000, 0);
-    pub const MaxCodeLen: u32 = MAX_CODE_NAME;
+    pub const MaxCodeLen: u32 = MAX_CODE_LEN;
     pub const MaxStorageKeyLen: u32 = 128;
     pub const MaxDebugBufferLen: u32 = 128 * 1024;
 


### PR DESCRIPTION
This pull request introduces a pre-check mechanism for uploading ink code to cluster storage. The check verifies that the code does not exceed 4 times the MaxCodeLen limit when parsed into wasmi's memory representation.