### PR TITLE
pruntime: Increase stack size to 1MB

### DIFF
--- a/standalone/pruntime/gramine-build/pruntime.manifest.template
+++ b/standalone/pruntime/gramine-build/pruntime.manifest.template
@@ -15,6 +15,7 @@ insecure__use_cmdline_argv = true
   poll, so it's safe to enable it.
 #}
 insecure__allow_eventfd = true
+stack.size = "1M"
 
 [loader.env]
 LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"


### PR DESCRIPTION
This fixes the stack overflow issue while loading checkpoints.