### PR TITLE
pruntime: Increase brk max size to 256M

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7524,6 +7524,7 @@ dependencies = [
  "im",
  "insta",
  "itertools",
+ "libc",
  "log",
  "num-bigint 0.4.3",
  "num-traits",

--- a/crates/phactory/Cargo.toml
+++ b/crates/phactory/Cargo.toml
@@ -82,6 +82,7 @@ phala-scheduler = { path = "../phala-scheduler" }
 sgx-api-lite = { path = "../sgx-api-lite" }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "socks"] }
 reqwest-env-proxy = { path = "../reqwest-env-proxy" }
+libc = "0.2"
 
 environmental = "1"
 once_cell = "1"

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -1275,7 +1275,9 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> PhactoryApi for Rpc
     /// Get basic information about Phactory state.
     async fn get_info(&mut self, _request: ()) -> RpcResult<pb::PhactoryInfo> {
         let info = self.lock_phactory(true, true)?.get_info();
-        info!("Got info: {:?}", info.debug_info());
+        info!("Got info: {:?} mallinfo: {:?}", info.debug_info(), unsafe {
+            libc::mallinfo()
+        });
         Ok(info)
     }
 

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -4284,6 +4284,7 @@ dependencies = [
  "hex_fmt",
  "im",
  "itertools",
+ "libc",
  "log",
  "num-bigint",
  "num-traits",

--- a/standalone/pruntime/gramine-build/pruntime.manifest.template
+++ b/standalone/pruntime/gramine-build/pruntime.manifest.template
@@ -16,11 +16,14 @@ insecure__use_cmdline_argv = true
 #}
 insecure__allow_eventfd = true
 stack.size = "1M"
+brk.max_size = "256M"
 
 [loader.env]
 LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
 {# Without this, Glibc would allocate a 64MB ARENA for each thread. #}
 MALLOC_ARENA_MAX = "1"
+{# Chunks over 256K would alloc with mmap. #}
+MALLOC_MMAP_THRESHOLD_ = "262144"
 {#
 The size of the thread pool for the tokio runtime created by rocket that
 serving the async tasks.


### PR DESCRIPTION
This PR might fix #1188.
This PR increases the default max brk size in Gramine from 128KB to 256MB to address an issue in Glibc where, upon falling back to mmap for memory allocation when heap memory exceeds the threshold, the allocated memory is never returned to the system even after being released by the app. As a consequence, Gramine LibOS will preallocate memory for it of the max_size, which is acceptable. 

An alternative solution to consider is using different allocators.