### PR TITLE
double budget limit

### DIFF
--- a/pallets/phala/src/compute/computation.rs
+++ b/pallets/phala/src/compute/computation.rs
@@ -586,8 +586,9 @@ pub mod pallet {
 				block_number > LastBugdetUpdateBlock::<T>::get(),
 				Error::<T>::BudgetUpdateBlockInvalid,
 			);
+			// Double the maxbudgetlimit to compensate budget miss-caculated during the last nonce.
 			ensure!(
-				budget <= MaxBudgetLimit::<T>::get(),
+				budget <= MaxBudgetLimit::<T>::get() * 2,
 				Error::<T>::BudgetExceedMaxLimit,
 			);
 			let mut tokenomic = TokenomicParameters::<T>::get()


### PR DESCRIPTION
Double the maxbudgetlimit to compensate budget miss-caculated during the last nonce.