### PR TITLE
pruntime: Add entry contract to pink log records

### DIFF
--- a/crates/phactory/src/contracts/support.rs
+++ b/crates/phactory/src/contracts/support.rs
@@ -1,8 +1,5 @@
 use anyhow::{anyhow, bail, Result};
-use pink::{
-    capi::v1::ecall::ECalls,
-    types::{AccountId, ExecutionMode, TransactionArguments},
-};
+use pink::types::{AccountId, ExecutionMode, TransactionArguments};
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 
@@ -214,7 +211,7 @@ impl Contract {
             gas_limit,
         };
         let mut handle = env.contract_cluster.runtime_mut(env.log_handler.clone());
-        _ = handle.contract_call(
+        _ = handle.call(
             self.address().clone(),
             input_data.to_vec(),
             ExecutionMode::Transaction,

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -1185,7 +1185,8 @@ impl<Platform: pal::Platform> System<Platform> {
                             let result = log_handler.try_send(SidevmCommand::PushSystemMessage(
                                 SystemMessage::PinkLog {
                                     block_number: block.block_number,
-                                    contract: system_contract.into(),
+                                    contract: system_contract.clone().into(),
+                                    entry: system_contract.into(),
                                     exec_mode: ExecutionMode::Transaction.display().into(),
                                     timestamp_ms: block.now_ms,
                                     level: $level as usize as u8,
@@ -1294,7 +1295,7 @@ impl<Platform: pal::Platform> System<Platform> {
                             storage_deposit_limit,
                         };
                         let mut runtime = cluster.runtime_mut(log_handler.clone());
-                        let _result = runtime.contract_instantiate(
+                        let _result = runtime.instantiate(
                             code_hash,
                             contract_info.instantiate_data,
                             contract_info.salt,

--- a/crates/sidevm/env/src/messages.rs
+++ b/crates/sidevm/env/src/messages.rs
@@ -15,6 +15,7 @@ pub enum SystemMessage {
     PinkLog {
         block_number: u32,
         contract: AccountId,
+        entry: AccountId,
         exec_mode: String,
         timestamp_ms: u64,
         level: u8,


### PR DESCRIPTION
This PR Adds a field `entry`(stands for the entry contract id) to log items being sent to the log server, a feature requested from @shelvenzhou,  as shown below:

<img width="697" alt="image" src="https://user-images.githubusercontent.com/6442159/230591826-8fc422bd-9403-48f8-9ce1-7574b77ab531.png">

This should be the last feature added to milestone 2.0.

**Breaking**
This would break the communication between pruntime and the contract log_server. That's saying, the new log_server can not work with the previous versions of pruntime or vice versa.
No external APIs changed.
