### PR TITLE
pruntime: Fix tracing instrument on pRPC

### DIFF
--- a/standalone/pruntime/src/api_server.rs
+++ b/standalone/pruntime/src/api_server.rs
@@ -45,8 +45,8 @@ macro_rules! do_ecall_handle {
 
 macro_rules! proxy_post {
     ($rpc: literal, $name: ident, $num: expr) => {
-        #[post($rpc, format = "json", data = "<contract_input>")]
         #[instrument(target="prpc", fields(%id), skip_all)]
+        #[post($rpc, format = "json", data = "<contract_input>")]
         fn $name(id: TraceId, contract_input: Json<ContractInput>) -> JsonValue {
             let input_string = serde_json::to_string(&*contract_input).unwrap();
             do_ecall_handle!(id.id(), $num, input_string.as_bytes())
@@ -56,8 +56,8 @@ macro_rules! proxy_post {
 
 macro_rules! proxy_get {
     ($rpc: literal, $name: ident, $num: expr) => {
-        #[get($rpc)]
         #[instrument(target="prpc", fields(%id), skip_all)]
+        #[get($rpc)]
         fn $name(id: TraceId) -> JsonValue {
             let input_string = r#"{ "input": {} }"#.to_string();
             do_ecall_handle!(id.id(), $num, input_string.as_bytes())
@@ -94,8 +94,8 @@ async fn read_data(data: Data<'_>, limit: ByteUnit) -> ReadData {
 
 macro_rules! proxy_bin {
     ($rpc: literal, $name: ident, $num: expr) => {
-        #[post($rpc, data = "<data>")]
         #[instrument(target="prpc", fields(%id), skip_all)]
+        #[post($rpc, data = "<data>")]
         async fn $name(id: TraceId, data: Data<'_>, limits: &Limits) -> JsonValue {
             let limit = limits.get(stringify!($name)).unwrap_or(100.mebibytes());
             let data = match read_data(data, limit).await {
@@ -138,8 +138,8 @@ fn kick() -> String {
     std::process::exit(0);
 }
 
-#[get("/info")]
 #[instrument(target="prpc", fields(id=%_id), skip_all)]
+#[get("/info")]
 fn getinfo(_id: TraceId) -> String {
     runtime::ecall_getinfo()
 }
@@ -263,8 +263,8 @@ fn limit_for_method(method: &str, limits: &Limits) -> ByteUnit {
     }
 }
 
-#[post("/<method>?<json>", data = "<data>")]
 #[instrument(target="prpc", name="prpc", fields(%id), skip_all)]
+#[post("/<method>?<json>", data = "<data>")]
 async fn prpc_proxy(
     id: TraceId,
     method: String,
@@ -308,8 +308,8 @@ async fn prpc_call(id: u64, method: String, data: &[u8], json: bool) -> Custom<V
     }
 }
 
-#[post("/<method>?<json>", data = "<data>")]
 #[instrument(target="prpc", name="prpc", fields(%id), skip_all)]
+#[post("/<method>?<json>", data = "<data>")]
 async fn prpc_proxy_acl(
     id: TraceId,
     method: String,
@@ -326,8 +326,8 @@ async fn prpc_proxy_acl(
     prpc_proxy_inner(id.id(), method, data, limits, content_type, json).await
 }
 
-#[get("/<method>")]
 #[instrument(target="prpc", name="prpc", fields(%id), skip_all)]
+#[get("/<method>")]
 async fn prpc_proxy_get_acl(id: TraceId, method: String) -> Custom<Vec<u8>> {
     info!(method, "prpc_acl get enter");
     if !rpc_type(&method).is_public() {
@@ -337,8 +337,8 @@ async fn prpc_proxy_get_acl(id: TraceId, method: String) -> Custom<Vec<u8>> {
     prpc_call(id.id(), method, b"", true).await
 }
 
-#[get("/<method>")]
 #[instrument(target="prpc", name="prpc", fields(%id), skip_all)]
+#[get("/<method>")]
 async fn prpc_proxy_get(id: TraceId, method: String) -> Custom<Vec<u8>> {
     prpc_call(id.id(), method, b"", true).await
 }


### PR DESCRIPTION
I found the `tracing::instrument` on pRPCs no longer works after we upgraded the Rocket to 0.5-rc3:
```
[2023-03-23T10:57:30.586276Z INFO  phactory::prpc_service] Dispatching request: PhactoryAPI.DispatchBlocks
[2023-03-23T10:57:30.586314Z INFO  phactory::prpc_service] dispatch_block from=Some(1) to=Some(4)
[2023-03-23T10:57:30.586320Z INFO  phactory::prpc_service] Dispatching block: 1
```
Swapping the attribute macro order fixes the issue:
```
2023-04-11T08:19:17.156303Z  INFO prpc{id=42}: phactory::prpc_service: Dispatching request: PhactoryAPI.DispatchBlocks
2023-04-11T08:19:17.157606Z  INFO prpc{id=42}: phactory::prpc_service: dispatch_block range=(Some(3291234), Some(3291237))
2023-04-11T08:19:17.157629Z  INFO prpc{id=42}: phactory::prpc_service: Dispatching block=3291234
```