### PR TITLE
pherry: Optimize memory usage by trimming justifications during sync

### DIFF
--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -645,6 +645,13 @@ async fn batch_sync_block(
 
         let mut header_batch = header_batch;
         header_batch.retain(|h| h.header.number >= next_headernum);
+        // Remove justifications for all headers except the last one to reduce data overhead
+        // and improve sync performance.
+        if let Some((_last, rest_headers)) = header_batch.split_last_mut() {
+            for header in rest_headers {
+                header.justification = None;
+            }
+        }
         let r = req_sync_header(pr, header_batch, authrotiy_change).await?;
         info!("  ..sync_header: {:?}", r);
         next_headernum = r.synced_to + 1;


### PR DESCRIPTION
We recently discovered that when syncing blocks with pherry and without headers-cache, the memory usage of pruntime would jitter, as shown in the following graph:

<img width="541" alt="image" src="https://user-images.githubusercontent.com/6442159/231166470-011c3c93-3155-4004-a07c-fd1fbdc1892c.png">

This is one of the reasons that cause issue #1188.

When syncing with headers-cache, the jitter is not observed. The reason for this behavior is that pherry keeps all justifications in the headers sent to pruntime, while headers-cache only retains the justification for the last header. 

This PR resolves the issue by adopting the same strategy as headers-cache and only keeping the justification for the last header in the batch.