### PR TITLE
add may be subscribe pools & fix `wrap` clean account_status issue

### DIFF
--- a/pallets/phala/src/compute/vault.rs
+++ b/pallets/phala/src/compute/vault.rs
@@ -266,6 +266,11 @@ pub mod pallet {
 				pool_info.basepool.pid,
 			)?;
 			pool_info.owner_shares -= shares;
+			wrapped_balances::Pallet::<T>::maybe_subscribe_to_pool(
+				&who,
+				vault_pid,
+				pool_info.basepool.cid,
+			)?;
 			base_pool::pallet::Pools::<T>::insert(vault_pid, PoolProxy::Vault(pool_info));
 			Self::deposit_event(Event::<T>::OwnerSharesClaimed {
 				pid: vault_pid,

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -198,13 +198,15 @@ pub mod pallet {
 				KeepAlive,
 			)?;
 			Self::mint_into(&user, amount)?;
-			StakerAccounts::<T>::insert(
-				&user,
-				FinanceAccount::<BalanceOf<T>> {
-					invest_pools: vec![],
-					locked: Zero::zero(),
-				},
-			);
+			if !StakerAccounts::<T>::contains_key(&user) {
+				StakerAccounts::<T>::insert(
+					&user,
+					FinanceAccount::<BalanceOf<T>> {
+						invest_pools: vec![],
+						locked: Zero::zero(),
+					},
+				);
+			}
 			Self::deposit_event(Event::<T>::Wrapped { user, amount });
 			Ok(())
 		}
@@ -340,8 +342,26 @@ pub mod pallet {
 
 			Ok(())
 		}
-	}
 
+		#[pallet::call_index(5)]
+		#[pallet::weight(0)]
+		#[frame_support::transactional]
+		pub fn update_wrappedbalance_vote_lock(origin: OriginFor<T>) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			base_pool::Pallet::<T>::ensure_migration_root(who)?;
+			let mut iter = VoteAccountMap::<T>::iter();
+			for (_, account_id, (aye_amount, nay_amount)) in iter.by_ref() {
+				let mut account_status = StakerAccounts::<T>::get(&account_id)
+					.expect("account_status should be found when it already voted; qed.");
+				let total_amount = aye_amount + nay_amount;
+				if account_status.locked  < total_amount {
+					account_status.locked = total_amount;
+					StakerAccounts::<T>::insert(account_id, account_status);
+				}
+			}
+			Ok(())
+		}
+	}
 	impl<T: Config> Pallet<T>
 	where
 		BalanceOf<T>: sp_runtime::traits::AtLeast32BitUnsigned + Copy + FixedPointConvert + Display,

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -346,7 +346,7 @@ pub mod pallet {
 		#[pallet::call_index(5)]
 		#[pallet::weight(0)]
 		#[frame_support::transactional]
-		pub fn update_wrappedbalance_vote_lock(origin: OriginFor<T>) -> DispatchResult {
+		pub fn backfill_vote_lock(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			base_pool::Pallet::<T>::ensure_migration_root(who)?;
 			let mut iter = VoteAccountMap::<T>::iter();

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -354,7 +354,7 @@ pub mod pallet {
 				let mut account_status = StakerAccounts::<T>::get(&account_id)
 					.expect("account_status should be found when it already voted; qed.");
 				let total_amount = aye_amount + nay_amount;
-				if account_status.locked  < total_amount {
+				if account_status.locked < total_amount {
 					account_status.locked = total_amount;
 					StakerAccounts::<T>::insert(account_id, account_status);
 				}


### PR DESCRIPTION
1.Fixed a problem that when a vault owners gain his owner shares, the vault will not be added into his `subscribe_pools`.It may lead to his net_value miscalculation.
2.`wrap` now will create a new account_status data every time it is called which is clearly an bug, the push fix it and added a remedy function to update account_status.locked to correct value.