### PR TITLE
pruntime: Fix trie node corruption

### DIFF
--- a/crates/pink/runner/src/storage.rs
+++ b/crates/pink/runner/src/storage.rs
@@ -28,10 +28,11 @@ impl ClusterStorage {
         match self.kv_store.get_mut(&key) {
             Some((ref mut old_rc, ref mut old_value)) => {
                 *old_rc += rc;
+                if rc > 0 {
+                    *old_value = value;
+                }
                 if *old_rc == 0 {
                     self.kv_store.remove(&key);
-                } else {
-                    *old_value = value;
                 }
             }
             None => {


### PR DESCRIPTION
The trie framework will pass an empty value when the `rc` is negative. So, the value would be mis-cleared when decreasing the rc.
This PR fixes it by setting the value only when `rc > 0`.