### PR TITLE
Prevent early registered workers from being added to pools

### DIFF
--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -458,6 +458,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 pub fn set_block_1() {
 	System::set_block_number(1);
+	Timestamp::set_timestamp(1);
+	PhalaRegistry::internal_set_gk_launched_at(0, 0);
 }
 
 pub fn take_events() -> Vec<RuntimeEvent> {

--- a/pallets/phala/src/registry.rs
+++ b/pallets/phala/src/registry.rs
@@ -117,6 +117,10 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type GatekeeperMasterPubkey<T: Config> = StorageValue<_, MasterPublicKey>;
 
+	/// The block number and unix timestamp when the gatekeeper is launched
+	#[pallet::storage]
+	pub type GatekeeperLaunchedAt<T: Config> = StorageValue<_, (T::BlockNumber, u64)>;
+
 	/// The rotation counter starting from 1, it always equals to the latest rotation id.
 	/// The totation id 0 is reserved for the first master key before we introduce the rotation.
 	#[pallet::storage]
@@ -234,6 +238,7 @@ pub mod pallet {
 		},
 		MinimumPRuntimeVersionChangedTo(u32, u32, u32),
 		PRuntimeConsensusVersionChangedTo(u32),
+		GatekeeperLaunched,
 	}
 
 	#[pallet::error]
@@ -997,6 +1002,32 @@ pub mod pallet {
 				}
 			}
 			Ok(())
+		}
+
+		pub fn on_gk_launch_message_received(
+			message: DecodedMessage<GatekeeperLaunch>,
+		) -> DispatchResult {
+			if !message.sender.is_gatekeeper() {
+				return Err(Error::<T>::InvalidSender.into());
+			}
+
+			if let GatekeeperLaunch::MasterPubkeyOnChain(_) = message.payload {
+				let block_number = frame_system::Pallet::<T>::block_number();
+				let now = T::UnixTime::now().as_secs().saturated_into::<u64>();
+				GatekeeperLaunchedAt::<T>::put((block_number, now));
+				Self::deposit_event(Event::<T>::GatekeeperLaunched);
+			}
+			Ok(())
+		}
+
+		pub fn is_worker_registered_after_gk_launched(worker: &WorkerPublicKey) -> bool {
+			let Some(worker) = Workers::<T>::get(worker) else {
+				return false;
+			};
+			let Some((_, gk_launched_at)) = GatekeeperLaunchedAt::<T>::get() else {
+				return false;
+			};
+			worker.last_updated > gk_launched_at
 		}
 
 		#[cfg(test)]

--- a/pallets/phala/src/registry.rs
+++ b/pallets/phala/src/registry.rs
@@ -323,7 +323,7 @@ pub mod pallet {
 				pubkey,
 				ecdh_pubkey,
 				runtime_version: 0,
-				last_updated: 0,
+				last_updated: 1,
 				operator,
 				attestation_provider: Some(AttestationProvider::Root),
 				confidence_level: 128u8,
@@ -1037,6 +1037,11 @@ pub mod pallet {
 					w.initial_score = score;
 				}
 			});
+		}
+
+		#[cfg(test)]
+		pub(crate) fn internal_set_gk_launched_at(block: T::BlockNumber, ts: u64) {
+			GatekeeperLaunchedAt::<T>::put((block, ts));
 		}
 	}
 

--- a/pallets/phala/src/test.rs
+++ b/pallets/phala/src/test.rs
@@ -1170,6 +1170,7 @@ fn restart_computing_should_work() {
 			RuntimeOrigin::signed(2),
 			500 * DOLLARS
 		));
+		set_block_1();
 		setup_workers(1);
 		setup_stake_pool_with_workers(1, &[1]); // pid=0
 		assert_ok!(PhalaStakePoolv2::contribute(

--- a/standalone/runtime/src/msg_routing.rs
+++ b/standalone/runtime/src/msg_routing.rs
@@ -32,6 +32,7 @@ impl pallet_mq::QueueNotifyConfig for MessageRouteConfig {
         route_handlers! {
             PhalaRegistry::on_message_received,
             PhalaRegistry::on_gk_message_received,
+            PhalaRegistry::on_gk_launch_message_received,
             PhalaComputation::on_gk_message_received,
             PhalaComputation::on_working_message_received,
             PhalaPhatContracts::on_worker_cluster_message_received,


### PR DESCRIPTION
Gatekeepers track the state of workers starting from their initial registration event. If any worker registered before the first Gatekeeper was launched begins computing without re-registering, the Gatekeeper will not be able to track their entire state, leading to inconsistent worker states and further panic.

This pull request ensures that all workers registered prior to the launch of the first Gatekeeper must re-register in order to be added to a pool.