### PR TITLE
fix dust panic on first loop

### DIFF
--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -25,9 +25,8 @@ pub mod pallet {
 	use frame_support::{
 		pallet_prelude::*,
 		traits::{
-			tokens::fungibles::{Inspect, Transfer},
-			tokens::nonfungibles::InspectEnumerable,
-			StorageVersion, UnixTime,
+			tokens::fungibles::Transfer, tokens::nonfungibles::InspectEnumerable, StorageVersion,
+			UnixTime,
 		},
 	};
 

--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -1026,11 +1026,7 @@ pub mod pallet {
 				None => return false,
 			};
 			let current_balance = bmul(nft.shares, &price);
-			let min_balance =
-				<pallet_assets::pallet::Pallet<T> as Inspect<T::AccountId>>::minimum_balance(
-					<T as wrapped_balances::Config>::WPhaAssetId::get(),
-				);
-			if current_balance > min_balance {
+			if current_balance > T::WPhaMinBalance::get() {
 				return false;
 			}
 			pool_info.total_shares -= nft.shares;

--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -1063,6 +1063,12 @@ pub mod pallet {
 						Self::get_nft_attr_guard(pool_info.cid, withdraw.nft_id)
 							.expect("get nftattr should always success; qed.");
 					let mut withdraw_nft = withdraw_nft_guard.attr.clone();
+					if Self::maybe_remove_dust(pool_info, &withdraw_nft) {
+						pool_info.withdraw_queue.pop_front();
+						Self::burn_nft(&pallet_id(), pool_info.cid, withdraw.nft_id)
+							.expect("burn nft should always success");
+						continue;
+					}
 					// Try to fulfill the withdraw requests as much as possible
 					let free_shares = if price == fp!(0) {
 						withdraw_nft.shares // 100% slashed

--- a/pallets/phala/src/test.rs
+++ b/pallets/phala/src/test.rs
@@ -9,7 +9,7 @@ use frame_support::{
 	assert_noop, assert_ok,
 	pallet_prelude::Get,
 	traits::{
-		tokens::fungibles::{Create, Inspect},
+		tokens::fungibles::{Create, Inspect, Transfer},
 		StorePreimage,
 	},
 };
@@ -31,6 +31,29 @@ use phala_types::{messaging::SettleInfo, WorkerPublicKey};
 use rmrk_traits::primitives::NftId;
 use sp_runtime::Permill;
 use sp_std::{collections::vec_deque::VecDeque, vec::Vec};
+
+#[test]
+fn test_min_transfer() {
+	new_test_ext().execute_with(|| {
+		mock_asset_id();
+		assert_ok!(PhalaWrappedBalances::wrap(
+			RuntimeOrigin::signed(1),
+			999999999999
+		));
+		assert_ok!(PhalaWrappedBalances::wrap(
+			RuntimeOrigin::signed(2),
+			0,
+		));
+		assert_ok!(<pallet_assets::pallet::Pallet<Test> as Transfer<u64>>::transfer(
+			<Test as wrapped_balances::Config>::WPhaAssetId::get(),
+			&1,
+			&2,
+			100000000,
+			false
+		));
+
+	});
+}
 
 #[test]
 fn test_pool_subaccount() {
@@ -2002,7 +2025,7 @@ fn mock_asset_id() {
 		<Test as wrapped_balances::Config>::WPhaAssetId::get(),
 		1,
 		true,
-		1000000000,
+		100000000,
 	)
 	.expect("create should success .qed");
 }

--- a/pallets/phala/src/test.rs
+++ b/pallets/phala/src/test.rs
@@ -9,7 +9,7 @@ use frame_support::{
 	assert_noop, assert_ok,
 	pallet_prelude::Get,
 	traits::{
-		tokens::fungibles::{Create, Inspect, Transfer},
+		tokens::fungibles::{Create, Inspect},
 		StorePreimage,
 	},
 };
@@ -31,29 +31,6 @@ use phala_types::{messaging::SettleInfo, WorkerPublicKey};
 use rmrk_traits::primitives::NftId;
 use sp_runtime::Permill;
 use sp_std::{collections::vec_deque::VecDeque, vec::Vec};
-
-#[test]
-fn test_min_transfer() {
-	new_test_ext().execute_with(|| {
-		mock_asset_id();
-		assert_ok!(PhalaWrappedBalances::wrap(
-			RuntimeOrigin::signed(1),
-			999999999999
-		));
-		assert_ok!(PhalaWrappedBalances::wrap(
-			RuntimeOrigin::signed(2),
-			0,
-		));
-		assert_ok!(<pallet_assets::pallet::Pallet<Test> as Transfer<u64>>::transfer(
-			<Test as wrapped_balances::Config>::WPhaAssetId::get(),
-			&1,
-			&2,
-			100000000,
-			false
-		));
-
-	});
-}
 
 #[test]
 fn test_pool_subaccount() {


### PR DESCRIPTION
**Background**
When a pool tries to process its withdraw queue, it will make sure the withdraw is partially fulfilled, if not, we will drop the dust withdraw Nft. But in extreme condition, if the withdraw is already a dust on the first loop, we will throw a panic that the balance amount is too low before we drop the dust at the end of every loop.
**Solution** 
We will check if the withdraw is a dust in the first place the loop begins.