### PR TITLE
Strip log_server.sidevm.wasm

### DIFF
--- a/crates/pink-drivers/log_server/sideprog/Cargo.toml
+++ b/crates/pink-drivers/log_server/sideprog/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 
+[profile.release]
+strip = true
+
 [package]
 edition = "2021"
 name = "sideprog"


### PR DESCRIPTION
Before strip:
2.17 MB
After strip:
244K