### PR TITLE
fix vault withdraw_queue edge issue

### DIFF
--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -738,6 +738,7 @@ pub mod pallet {
 			pool: &BasePool<T::AccountId, BalanceOf<T>>,
 			now: u64,
 			grace_period: u64,
+			maybe_vault_queue_period: Option<u64>,
 			releasing_stake: BalanceOf<T>,
 		) -> bool {
 			// If the pool is bankrupt, or there's no share, we just skip this pool.
@@ -747,6 +748,11 @@ pub mod pallet {
 			};
 			let mut budget = pool.get_free_stakes::<T>() + releasing_stake;
 			for request in &pool.withdraw_queue {
+				if let Some(vault_period) = maybe_vault_queue_period {
+					if now - request.start_time > vault_period {
+						return true;
+					}
+				}
 				let nft_guard = Self::get_nft_attr_guard(pool.cid, request.nft_id)
 					.expect("get nftattr should always success; qed.");
 				let withdraw_nft = nft_guard.attr.clone();

--- a/pallets/phala/src/compute/stake_pool_v2.rs
+++ b/pallets/phala/src/compute/stake_pool_v2.rs
@@ -635,6 +635,7 @@ pub mod pallet {
 				&pool.basepool,
 				now,
 				grace_period,
+				None,
 				releasing_stake,
 			) {
 				for worker in pool.workers.iter() {
@@ -673,6 +674,10 @@ pub mod pallet {
 			let mut maybe_vault = None;
 			if let Some(vault_pid) = as_vault {
 				let vault_info = ensure_vault::<T>(vault_pid)?;
+				ensure!(
+					!vault::pallet::VaultLocks::<T>::contains_key(vault_pid),
+					Error::<T>::VaultIsLocked
+				);
 				ensure!(
 					who == vault_info.basepool.owner,
 					Error::<T>::UnauthorizedPoolOwner

--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -70,6 +70,7 @@ parameter_types! {
 	pub const MinWorkingStaking: Balance = DOLLARS;
 	pub const MinContribution: Balance = CENTS;
 	pub const WorkingGracePeriod: u64 = 7 * 24 * 3600;
+	pub const VaultQueuePeriod: u64 = 21 * 24 * 3600;
 	pub const MinInitP: u32 = 1;
 	pub const MaxPoolWorkers: u32 = 10;
 	pub const NoneAttestationEnabled: bool = true;
@@ -391,6 +392,7 @@ parameter_types! {
 impl vault::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type InitialPriceCheckPoint = InitialPriceCheckPoint;
+	type VaultQueuePeriod = VaultQueuePeriod;
 }
 
 impl base_pool::Config for Test {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1303,6 +1303,7 @@ parameter_types! {
     pub const MinWorkingStaking: Balance = 1 * DOLLARS;
     pub const MinContribution: Balance = 1 * CENTS;
     pub const WorkingGracePeriod: u64 = 7 * 24 * 3600;
+    pub const VaultQueuePeriod: u64 = 21 * 24 * 3600;
     pub const MinInitP: u32 = 50;
     pub const MaxPoolWorkers: u32 = 200;
     pub const NoneAttestationEnabled: bool = true;
@@ -1366,6 +1367,7 @@ parameter_types! {
 impl pallet_vault::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type InitialPriceCheckPoint = InitialPriceCheckPoint;
+    type VaultQueuePeriod = VaultQueuePeriod;
 }
 parameter_types! {
     pub const CollectionDeposit: Balance = 0; // 1 UNIT deposit to create collection


### PR DESCRIPTION
Fix two edge cases that will let vault's withdraw_queue proceed itself unexpected.
1.Currently the vault could contribute to stakepools even if it is locked.It will lead to a edge case that the vault's stakepool-withdrawal will be re-contribute to stakepools before it satisfy the vault's withdraw_queue which it should do. It will lead to the vault locked forever and users can not reclaim his withdrawal.
We now forbid the vault to contribute to stakepools when it is locked, and we add a additional call that could unlock the vault then re-check it for those vaults already met this edge case.
2.Forbid a potential case that vault owner can keep users' delegation in the pool longer than the grace_period by adding a vault_queue_period which has 21 days limitation before it is forced to shutdown.