### PR TITLE
Wpha Council

### DIFF
--- a/pallets/phala/src/lib.rs
+++ b/pallets/phala/src/lib.rs
@@ -39,6 +39,9 @@ type NegativeImbalanceOf<T> = <<T as PhalaConfig>::Currency as frame_support::tr
 	<T as frame_system::Config>::AccountId,
 >>::NegativeImbalance;
 
+type PositiveImbalanceOf<T> = <<T as PhalaConfig>::Currency as frame_support::traits::Currency<
+	<T as frame_system::Config>::AccountId,
+>>::PositiveImbalance;
 // Alias
 pub use compute::base_pool as pallet_base_pool;
 pub use compute::computation as pallet_computation;

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -931,7 +931,7 @@ const_assert!(DesiredMembers::get() <= CouncilMaxMembers::get());
 impl pallet_elections_phragmen::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type PalletId = ElectionsPhragmenPalletId;
-    type Currency = Balances;
+    type Currency = PhalaWrappedBalances;
     type ChangeMembers = Council;
     // NOTE: this implies that council's genesis members cannot be set directly and must come from
     // this module.


### PR DESCRIPTION
This pr introduce a new council which use wpha to vote for members.
The pallet `wrapped_balance` implement `Currency`, `ReserveableCurrency`, `LockableCurrency` trait which are required to satisfying type`Currency`'s trait bound in pallet_elections_phragmen::Config. 
By replacing Balances to wrapped_balance, the council election can run with wpha.