### PR TITLE
pallet_compute: Add option to disable worker reg time checking

### DIFF
--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -76,6 +76,7 @@ parameter_types! {
 	pub const NoneAttestationEnabled: bool = true;
 	pub const VerifyPRuntime: bool = false;
 	pub const VerifyRelaychainGenesisBlockHash: bool = true;
+	pub const CheckWorkerRegisterTime: bool = true;
 }
 impl system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;
@@ -257,6 +258,7 @@ impl computation::Config for Test {
 	type UpdateTokenomicOrigin = EnsureRoot<Self::AccountId>;
 	type SetBudgetOrigins = EnsureSignedBy<SetBudgetMembers, Self::AccountId>;
 	type SetContractRootOrigins = EnsureRoot<Self::AccountId>;
+	type CheckWorkerRegisterTime = CheckWorkerRegisterTime;
 }
 
 parameter_types! {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1317,6 +1317,7 @@ parameter_types! {
     pub const VerifyPRuntime: bool = false;
     pub const VerifyRelaychainGenesisBlockHash: bool = false;
     pub ParachainId: u32 = ParachainInfo::parachain_id().0;
+    pub const CheckWorkerRegisterTime: bool = true;
 }
 
 impl pallet_registry::Config for Runtime {
@@ -1355,6 +1356,7 @@ impl pallet_computation::Config for Runtime {
     type UpdateTokenomicOrigin = EnsureRootOrHalfCouncil;
     type SetBudgetOrigins = EnsureSignedBy<SetBudgetMembers, AccountId>;
     type SetContractRootOrigins = EnsureRootOrHalfCouncil;
+    type CheckWorkerRegisterTime = CheckWorkerRegisterTime;
 }
 impl pallet_stake_pool_v2::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;


### PR DESCRIPTION
The worker-checking logic was introduced for Phala and later new test networks. It was launched to Khala by mistake and caused the following error:
![image](https://github.com/Phala-Network/phala-blockchain/assets/6442159/067c3304-e984-4a56-9a1e-662832e54ba4)

This PR adds an option to turn it off. And please set it to false on Khala. @jasl 