### PR TITLE
pink: Support for batch HTTP request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6287,7 +6287,16 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.7",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -6300,6 +6309,18 @@ dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -8352,6 +8373,7 @@ dependencies = [
  "ink",
  "insta",
  "log",
+ "num_enum 0.6.1",
  "parity-scale-codec",
  "pink-extension-macro",
  "scale-info",
@@ -8377,6 +8399,7 @@ dependencies = [
 name = "pink-extension-runtime"
 version = "0.4.2"
 dependencies = [
+ "futures",
  "getrandom 0.2.7",
  "hex_fmt",
  "log",
@@ -11621,7 +11644,7 @@ dependencies = [
  "derive_more",
  "futures",
  "log",
- "num_enum",
+ "num_enum 0.5.7",
  "parity-scale-codec",
  "sidevm-macro",
  "tinyvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8410,6 +8410,7 @@ dependencies = [
  "ring 0.16.20",
  "sp-core",
  "sp-runtime-interface",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -373,13 +373,13 @@ impl OCalls for RuntimeHandle<'_> {
         result
     }
 
-    fn http_batch_request(
+    fn batch_http_request(
         &self,
         contract: AccountId,
         requests: Vec<HttpRequest>,
         timeout_ms: u64,
     ) -> Vec<Result<HttpResponse, HttpRequestError>> {
-        let results = pink_extension_runtime::http_batch_request(
+        let results = pink_extension_runtime::batch_http_request(
             requests,
             context::time_remaining().min(timeout_ms),
         );
@@ -460,14 +460,14 @@ impl OCalls for RuntimeHandleMut<'_> {
         self.readonly().http_request(contract, request)
     }
 
-    fn http_batch_request(
+    fn batch_http_request(
         &self,
         contract: AccountId,
         requests: Vec<HttpRequest>,
         timeout_ms: u64,
     ) -> Vec<Result<HttpResponse, HttpRequestError>> {
         self.readonly()
-            .http_batch_request(contract, requests, timeout_ms)
+            .batch_http_request(contract, requests, timeout_ms)
     }
 }
 

--- a/crates/pink/capi/src/v1/mod.rs
+++ b/crates/pink/capi/src/v1/mod.rs
@@ -127,7 +127,7 @@ pub mod ocall {
     use scale::{Decode, Encode};
 
     pub use pink_extension::chain_extension::{
-        HttpRequest, HttpRequestError, HttpResponse, StorageQuotaExceeded,
+        BatchHttpResult, HttpRequest, HttpRequestError, HttpResponse, StorageQuotaExceeded,
     };
     pub type StorageChanges = Vec<(Vec<u8>, (Vec<u8>, i32))>;
 
@@ -198,6 +198,6 @@ pub mod ocall {
             contract: AccountId,
             requests: Vec<HttpRequest>,
             timeout_ms: u64,
-        ) -> Vec<Result<HttpResponse, HttpRequestError>>;
+        ) -> BatchHttpResult;
     }
 }

--- a/crates/pink/capi/src/v1/mod.rs
+++ b/crates/pink/capi/src/v1/mod.rs
@@ -192,5 +192,12 @@ pub mod ocall {
             contract: AccountId,
             request: HttpRequest,
         ) -> Result<HttpResponse, HttpRequestError>;
+        #[xcall(id = 15)]
+        fn http_batch_request(
+            &self,
+            contract: AccountId,
+            requests: Vec<HttpRequest>,
+            timeout_ms: u64,
+        ) -> Vec<Result<HttpResponse, HttpRequestError>>;
     }
 }

--- a/crates/pink/capi/src/v1/mod.rs
+++ b/crates/pink/capi/src/v1/mod.rs
@@ -193,7 +193,7 @@ pub mod ocall {
             request: HttpRequest,
         ) -> Result<HttpResponse, HttpRequestError>;
         #[xcall(id = 15)]
-        fn http_batch_request(
+        fn batch_http_request(
             &self,
             contract: AccountId,
             requests: Vec<HttpRequest>,

--- a/crates/pink/pink-extension-runtime/Cargo.toml
+++ b/crates/pink/pink-extension-runtime/Cargo.toml
@@ -18,3 +18,4 @@ getrandom = "0.2"
 once_cell = "1.10.0"
 hex_fmt = "0.3.0"
 futures = "0.3"
+tokio = { version = "1", features = ["full"] }

--- a/crates/pink/pink-extension-runtime/Cargo.toml
+++ b/crates/pink/pink-extension-runtime/Cargo.toml
@@ -11,9 +11,10 @@ pink-extension = { version = "0.4.2", path = "../pink-extension" }
 reqwest-env-proxy = { version = "0.1", path = "../../reqwest-env-proxy" }
 sp-core = { version = "7", features = ["full_crypto"] }
 sp-runtime-interface = { version = "7", features = ["disable_target_static_assertions"] }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "socks", "blocking"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "socks"] }
 log = "0.4"
 ring = "0.16"
 getrandom = "0.2"
 once_cell = "1.10.0"
 hex_fmt = "0.3.0"
+futures = "0.3"

--- a/crates/pink/pink-extension-runtime/src/lib.rs
+++ b/crates/pink/pink-extension-runtime/src/lib.rs
@@ -46,7 +46,9 @@ impl<'a, T, E> DefaultPinkExtension<'a, T, E> {
 fn block_on<F: core::future::Future>(f: F) -> F::Output {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) => handle.block_on(f),
-        Err(_) => tokio::runtime::Runtime::new().unwrap().block_on(f),
+        Err(_) => tokio::runtime::Runtime::new()
+            .expect("Failed to create tokio runtime")
+            .block_on(f),
     }
 }
 

--- a/crates/pink/pink-extension-runtime/src/lib.rs
+++ b/crates/pink/pink-extension-runtime/src/lib.rs
@@ -43,7 +43,7 @@ impl<'a, T, E> DefaultPinkExtension<'a, T, E> {
     }
 }
 
-pub fn http_batch_request(
+pub fn batch_http_request(
     requests: Vec<HttpRequest>,
     timeout_ms: u64,
 ) -> Vec<Result<HttpResponse, HttpRequestError>> {
@@ -150,12 +150,12 @@ impl<T: PinkRuntimeEnv, E: From<&'static str>> PinkExtBackend for DefaultPinkExt
         http_request(request, 10 * 1000).map_err(|err| err.display().into())
     }
 
-    fn http_batch_request(
+    fn batch_http_request(
         &self,
         requests: Vec<HttpRequest>,
         timeout_ms: u64,
     ) -> Result<Vec<Result<HttpResponse, HttpRequestError>>, Self::Error> {
-        Ok(http_batch_request(requests, timeout_ms))
+        Ok(batch_http_request(requests, timeout_ms))
     }
 
     fn sign(

--- a/crates/pink/pink-extension-runtime/src/mock_ext.rs
+++ b/crates/pink/pink-extension-runtime/src/mock_ext.rs
@@ -26,6 +26,14 @@ impl ext::PinkExtBackend for MockExtension {
         super::DefaultPinkExtension::new(self).http_request(request)
     }
 
+    fn http_batch_request(
+        &self,
+        requests: Vec<ext::HttpRequest>,
+        timeout_ms: u64,
+    ) -> Result<Vec<Result<ext::HttpResponse, ext::HttpRequestError>>, Self::Error> {
+        super::DefaultPinkExtension::new(self).http_batch_request(requests, timeout_ms)
+    }
+
     fn sign(
         &self,
         sigtype: SigType,

--- a/crates/pink/pink-extension-runtime/src/mock_ext.rs
+++ b/crates/pink/pink-extension-runtime/src/mock_ext.rs
@@ -30,7 +30,7 @@ impl ext::PinkExtBackend for MockExtension {
         &self,
         requests: Vec<ext::HttpRequest>,
         timeout_ms: u64,
-    ) -> Result<Vec<Result<ext::HttpResponse, ext::HttpRequestError>>, Self::Error> {
+    ) -> Result<ext::BatchHttpResult, Self::Error> {
         super::DefaultPinkExtension::new(self).batch_http_request(requests, timeout_ms)
     }
 

--- a/crates/pink/pink-extension-runtime/src/mock_ext.rs
+++ b/crates/pink/pink-extension-runtime/src/mock_ext.rs
@@ -26,12 +26,12 @@ impl ext::PinkExtBackend for MockExtension {
         super::DefaultPinkExtension::new(self).http_request(request)
     }
 
-    fn http_batch_request(
+    fn batch_http_request(
         &self,
         requests: Vec<ext::HttpRequest>,
         timeout_ms: u64,
     ) -> Result<Vec<Result<ext::HttpResponse, ext::HttpRequestError>>, Self::Error> {
-        super::DefaultPinkExtension::new(self).http_batch_request(requests, timeout_ms)
+        super::DefaultPinkExtension::new(self).batch_http_request(requests, timeout_ms)
     }
 
     fn sign(

--- a/crates/pink/pink-extension/Cargo.toml
+++ b/crates/pink/pink-extension/Cargo.toml
@@ -14,6 +14,7 @@ pink-extension-macro = { version = "0.4.2", path = "./macro" }
 log = "0.4.17"
 dlmalloc = { version = "0.2.4", default-features = false, features = ["global"], optional = true }
 this-crate = { version = "0.1", path = "../../this-crate" }
+num_enum = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 insta = "1.7.2"
@@ -24,6 +25,7 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
+    "num_enum/std",
 ]
 runtime_utils = ["std"]
 dlmalloc = ["ink/no-allocator", "dep:dlmalloc"]

--- a/crates/pink/pink-extension/src/chain_extension.rs
+++ b/crates/pink/pink-extension/src/chain_extension.rs
@@ -2,7 +2,7 @@ use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use ink::ChainExtensionInstance;
 
-pub use http_request::{HttpRequest, HttpResponse, HttpRequestError};
+pub use http_request::{HttpRequest, HttpRequestError, HttpResponse};
 pub use ink::primitives::AccountId;
 pub use signing::SigType;
 
@@ -199,6 +199,13 @@ pub trait PinkExt {
     /// Get the version of the current contract runtime in this cluster.
     #[ink(extension = 21, handle_status = false)]
     fn runtime_version() -> (u32, u32);
+
+    /// Batch http request
+    #[ink(extension = 22, handle_status = true)]
+    fn http_batch_request(
+        requests: Vec<HttpRequest>,
+        timeout_ms: u64,
+    ) -> Vec<Result<HttpResponse, HttpRequestError>>;
 }
 
 pub fn pink_extension_instance() -> <PinkExt as ChainExtensionInstance>::Instance {

--- a/crates/pink/pink-extension/src/chain_extension.rs
+++ b/crates/pink/pink-extension/src/chain_extension.rs
@@ -97,6 +97,8 @@ impl ink::env::chain_extension::FromStatusCode for ErrorCode {
     }
 }
 
+pub type BatchHttpResult = Result<Vec<Result<HttpResponse, HttpRequestError>>, HttpRequestError>;
+
 /// Extensions for the ink runtime defined by phat contract.
 #[pink_extension_macro::chain_extension]
 pub trait PinkExt {
@@ -202,10 +204,7 @@ pub trait PinkExt {
 
     /// Batch http request
     #[ink(extension = 22, handle_status = true)]
-    fn batch_http_request(
-        requests: Vec<HttpRequest>,
-        timeout_ms: u64,
-    ) -> Vec<Result<HttpResponse, HttpRequestError>>;
+    fn batch_http_request(requests: Vec<HttpRequest>, timeout_ms: u64) -> BatchHttpResult;
 }
 
 pub fn pink_extension_instance() -> <PinkExt as ChainExtensionInstance>::Instance {

--- a/crates/pink/pink-extension/src/chain_extension.rs
+++ b/crates/pink/pink-extension/src/chain_extension.rs
@@ -84,7 +84,7 @@ impl<T: scale::Encode> EncodeOutputFallbask for EncodeOutput<T> {
     }
 }
 
-#[derive(scale::Encode, scale::Decode)]
+#[derive(scale::Encode, scale::Decode, Debug)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub struct ErrorCode(u32);
 

--- a/crates/pink/pink-extension/src/chain_extension.rs
+++ b/crates/pink/pink-extension/src/chain_extension.rs
@@ -202,7 +202,7 @@ pub trait PinkExt {
 
     /// Batch http request
     #[ink(extension = 22, handle_status = true)]
-    fn http_batch_request(
+    fn batch_http_request(
         requests: Vec<HttpRequest>,
         timeout_ms: u64,
     ) -> Vec<Result<HttpResponse, HttpRequestError>>;

--- a/crates/pink/pink-extension/src/chain_extension/http_request.rs
+++ b/crates/pink/pink-extension/src/chain_extension/http_request.rs
@@ -1,5 +1,8 @@
 use alloc::string::String;
 use alloc::vec::Vec;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+use super::ErrorCode;
 #[derive(scale::Encode, scale::Decode)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub struct HttpRequest {
@@ -18,8 +21,9 @@ pub struct HttpResponse {
     pub body: Vec<u8>,
 }
 
-#[derive(scale::Encode, scale::Decode)]
+#[derive(scale::Encode, scale::Decode, TryFromPrimitive, IntoPrimitive, Clone, Copy)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+#[repr(u32)]
 pub enum HttpRequestError {
     InvalidUrl,
     InvalidMethod,
@@ -27,6 +31,40 @@ pub enum HttpRequestError {
     InvalidHeaderValue,
     FailedToCreateClient,
     Timeout,
+    NotAllowed,
+    TooManyRequests,
+    NetworkError,
+    ResponseTooLarge,
+}
+
+impl super::sealed::Sealed for HttpRequestError {}
+impl super::CodableError for HttpRequestError {
+    fn encode(&self) -> u32 {
+        let code: u32 = (*self).into();
+        code + 1
+    }
+
+    fn decode(code: u32) -> Option<Self> {
+        if code == 0 {
+            return None;
+        }
+        core::convert::TryFrom::try_from(code - 1).ok()
+    }
+}
+
+impl From<ErrorCode> for HttpRequestError {
+    fn from(value: ErrorCode) -> Self {
+        match <Self as super::CodableError>::decode(value.0) {
+            None => crate::panic!("chain extension: invalid HttpRequestError"),
+            Some(err) => err,
+        }
+    }
+}
+
+impl From<scale::Error> for HttpRequestError {
+    fn from(_value: scale::Error) -> Self {
+        crate::panic!("chain_ext: failed to decocde HttpRequestError")
+    }
 }
 
 impl HttpRequestError {
@@ -38,6 +76,10 @@ impl HttpRequestError {
             Self::InvalidHeaderValue => "Invalid header value",
             Self::FailedToCreateClient => "Failed to create client",
             Self::Timeout => "Timeout",
+            Self::NotAllowed => "Not allowed",
+            Self::TooManyRequests => "Too many requests",
+            Self::NetworkError => "Network error",
+            Self::ResponseTooLarge => "Response too large",
         }
     }
 }

--- a/crates/pink/pink-extension/src/chain_extension/http_request.rs
+++ b/crates/pink/pink-extension/src/chain_extension/http_request.rs
@@ -21,7 +21,7 @@ pub struct HttpResponse {
     pub body: Vec<u8>,
 }
 
-#[derive(scale::Encode, scale::Decode, TryFromPrimitive, IntoPrimitive, Clone, Copy)]
+#[derive(scale::Encode, scale::Decode, TryFromPrimitive, IntoPrimitive, Clone, Copy, Debug)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 #[repr(u32)]
 pub enum HttpRequestError {

--- a/crates/pink/runner/tests/test_pink_contract.rs
+++ b/crates/pink/runner/tests/test_pink_contract.rs
@@ -254,7 +254,10 @@ fn test_qjs() {
 mod test_cluster {
     use pink_capi::v1::{
         ecall::ECalls,
-        ocall::{ExecContext, HttpRequest, HttpRequestError, HttpResponse, OCalls, StorageChanges},
+        ocall::{
+            BatchHttpResult, ExecContext, HttpRequest, HttpRequestError, HttpResponse, OCalls,
+            StorageChanges,
+        },
         CrossCall, CrossCallMut, ECall,
     };
     use pink_runner::{
@@ -486,7 +489,7 @@ mod test_cluster {
             _: AccountId,
             requests: Vec<HttpRequest>,
             timeout_ms: u64,
-        ) -> Vec<Result<HttpResponse, HttpRequestError>> {
+        ) -> BatchHttpResult {
             pink_extension_runtime::batch_http_request(requests, timeout_ms)
         }
     }

--- a/crates/pink/runner/tests/test_pink_contract.rs
+++ b/crates/pink/runner/tests/test_pink_contract.rs
@@ -480,6 +480,15 @@ mod test_cluster {
         ) -> Result<HttpResponse, HttpRequestError> {
             pink_extension_runtime::http_request(request, 10 * 1000)
         }
+
+        fn batch_http_request(
+            &self,
+            _: AccountId,
+            requests: Vec<HttpRequest>,
+            timeout_ms: u64,
+        ) -> Vec<Result<HttpResponse, HttpRequestError>> {
+            pink_extension_runtime::batch_http_request(requests, timeout_ms)
+        }
     }
 
     impl CrossCall for TestCluster {

--- a/crates/pink/runtime/src/runtime/extension.rs
+++ b/crates/pink/runtime/src/runtime/extension.rs
@@ -159,7 +159,7 @@ impl PinkExtBackend for CallInQuery {
         &self,
         requests: Vec<ext::HttpRequest>,
         timeout_ms: u64,
-    ) -> Result<Vec<Result<HttpResponse, ext::HttpRequestError>>, Self::Error> {
+    ) -> Result<ext::BatchHttpResult, Self::Error> {
         Ok(OCallImpl.batch_http_request(self.address.clone(), requests, timeout_ms))
     }
 
@@ -333,8 +333,8 @@ impl PinkExtBackend for CallInCommand {
         &self,
         _requests: Vec<ext::HttpRequest>,
         _timeout_ms: u64,
-    ) -> Result<Vec<Result<HttpResponse, ext::HttpRequestError>>, Self::Error> {
-        Ok(vec![])
+    ) -> Result<ext::BatchHttpResult, Self::Error> {
+        Ok(Err(ext::HttpRequestError::NotAllowed))
     }
     fn sign(
         &self,

--- a/crates/pink/runtime/src/runtime/extension.rs
+++ b/crates/pink/runtime/src/runtime/extension.rs
@@ -155,6 +155,14 @@ impl PinkExtBackend for CallInQuery {
             .map_err(|err| DispatchError::Other(err.display()))
     }
 
+    fn http_batch_request(
+        &self,
+        requests: Vec<ext::HttpRequest>,
+        timeout_ms: u64,
+    ) -> Result<Vec<Result<HttpResponse, ext::HttpRequestError>>, Self::Error> {
+        Ok(OCallImpl.http_batch_request(self.address.clone(), requests, timeout_ms))
+    }
+
     fn sign(
         &self,
         sigtype: SigType,
@@ -320,6 +328,13 @@ impl PinkExtBackend for CallInCommand {
             headers: vec![],
             body: vec![],
         })
+    }
+    fn http_batch_request(
+        &self,
+        _requests: Vec<ext::HttpRequest>,
+        _timeout_ms: u64,
+    ) -> Result<Vec<Result<HttpResponse, ext::HttpRequestError>>, Self::Error> {
+        Ok(vec![])
     }
     fn sign(
         &self,

--- a/crates/pink/runtime/src/runtime/extension.rs
+++ b/crates/pink/runtime/src/runtime/extension.rs
@@ -155,12 +155,12 @@ impl PinkExtBackend for CallInQuery {
             .map_err(|err| DispatchError::Other(err.display()))
     }
 
-    fn http_batch_request(
+    fn batch_http_request(
         &self,
         requests: Vec<ext::HttpRequest>,
         timeout_ms: u64,
     ) -> Result<Vec<Result<HttpResponse, ext::HttpRequestError>>, Self::Error> {
-        Ok(OCallImpl.http_batch_request(self.address.clone(), requests, timeout_ms))
+        Ok(OCallImpl.batch_http_request(self.address.clone(), requests, timeout_ms))
     }
 
     fn sign(
@@ -329,7 +329,7 @@ impl PinkExtBackend for CallInCommand {
             body: vec![],
         })
     }
-    fn http_batch_request(
+    fn batch_http_request(
         &self,
         _requests: Vec<ext::HttpRequest>,
         _timeout_ms: u64,

--- a/e2e/contracts/check_system/lib.rs
+++ b/e2e/contracts/check_system/lib.rs
@@ -113,6 +113,32 @@ mod check_system {
         pub fn runtime_version(&self) -> (u32, u32) {
             pink::ext().runtime_version()
         }
+
+        #[ink(message)]
+        pub fn http_batch_get(&self, urls: Vec<String>, timeout_ms: u64) -> Vec<(u16, String)> {
+            pink::ext()
+                .http_batch_request(
+                    urls.into_iter()
+                        .map(|url| pink::chain_extension::HttpRequest {
+                            url,
+                            method: "GET".into(),
+                            headers: Default::default(),
+                            body: Default::default(),
+                        })
+                        .collect(),
+                    timeout_ms,
+                )
+                .unwrap()
+                .into_iter()
+                .map(|result| match result {
+                    Ok(response) => (
+                        response.status_code,
+                        String::from_utf8(response.body).unwrap_or_default(),
+                    ),
+                    Err(err) => (524, alloc::format!("Error: {err:?}")),
+                })
+                .collect()
+        }
     }
 
     impl ContractDeposit for CheckSystem {

--- a/e2e/contracts/check_system/lib.rs
+++ b/e2e/contracts/check_system/lib.rs
@@ -115,9 +115,9 @@ mod check_system {
         }
 
         #[ink(message)]
-        pub fn http_batch_get(&self, urls: Vec<String>, timeout_ms: u64) -> Vec<(u16, String)> {
+        pub fn batch_http_get(&self, urls: Vec<String>, timeout_ms: u64) -> Vec<(u16, String)> {
             pink::ext()
-                .http_batch_request(
+                .batch_http_request(
                     urls.into_iter()
                         .map(|url| pink::chain_extension::HttpRequest {
                             url,

--- a/e2e/src/fullstack.js
+++ b/e2e/src/fullstack.js
@@ -766,7 +766,7 @@ describe('A full stack', function () {
             const info = await pruntime[0].getInfo();
             const url = `${pruntime[0].uri}/info`;
             const urls = [url, url];
-            const { output } = await ContractSystemChecker.query.httpBatchGet(alice, certAlice, urls, 1000);
+            const { output } = await ContractSystemChecker.query.batchHttpGet(alice, certAlice, urls, 1000);
             const responses = output.asOk.valueOf();
             assert.equal(responses.length, urls.length);
             responses.forEach(([code, body]) => {

--- a/e2e/src/fullstack.js
+++ b/e2e/src/fullstack.js
@@ -762,6 +762,19 @@ describe('A full stack', function () {
             assert.equal(info?.sidevm?.state, 'running');
         });
 
+        it('can send batch http request', async function () {
+            const info = await pruntime[0].getInfo();
+            const url = `${pruntime[0].uri}/info`;
+            const urls = [url, url];
+            const { output } = await ContractSystemChecker.query.httpBatchGet(alice, certAlice, urls, 1000);
+            const responses = output.asOk.valueOf();
+            assert.equal(responses.length, urls.length);
+            responses.forEach(([code, body]) => {
+                assert.equal(code, 200);
+                assert.equal(JSON.parse(body).system.public_key, info.system.publicKey);
+            });
+        });
+
         it('cannot dup-instantiate', async function () {
             const codeIndex = api.createType('CodeIndex', { 'WasmCode': codeHash });
             await assert.txFailed(

--- a/e2e/src/utils/pm.js
+++ b/e2e/src/utils/pm.js
@@ -87,7 +87,7 @@ class Process {
 }
 
 class TempDir {
-    constructor(prefix = 'phala-e2e-') {
+    constructor(prefix = `phala-e2e-${new Date().toISOString()}-`) {
         this.dir = fs.mkdtempSync(prefix);
     }
     cleanup() {

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -3254,7 +3254,16 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.7",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -3267,6 +3276,18 @@ dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.99",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -4742,6 +4763,7 @@ version = "0.4.3"
 dependencies = [
  "ink",
  "log",
+ "num_enum 0.6.1",
  "parity-scale-codec",
  "pink-extension-macro",
  "scale-info",
@@ -4765,6 +4787,7 @@ dependencies = [
 name = "pink-extension-runtime"
 version = "0.4.2"
 dependencies = [
+ "futures",
  "getrandom 0.2.7",
  "hex_fmt",
  "log",
@@ -6169,7 +6192,7 @@ dependencies = [
  "derive_more",
  "futures",
  "log",
- "num_enum",
+ "num_enum 0.5.7",
  "parity-scale-codec",
  "sidevm-macro",
  "tinyvec",

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -4798,6 +4798,7 @@ dependencies = [
  "ring 0.16.20",
  "sp-core",
  "sp-runtime-interface",
+ "tokio",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a new extension function to send multiple HTTP requests simultaneously:
```rust
 #[ink(extension = 22, handle_status = true)]
 fn http_batch_request(
    requests: Vec<HttpRequest>,
    timeout_ms: u64,
 ) -> Vec<Result<HttpResponse, HttpRequestError>>;
```
The PR requires runtime upgrading for the already deployed cluster.

Usage:
https://github.com/Phala-Network/phala-blockchain/pull/1280/files#diff-ede8afeb0bf8928e02cd43f590808488c91465e013f2be7cc8adbf9b1715dad2R119-R140