### PR TITLE
pink: Example for larger HTTP response

### DIFF
--- a/e2e/contracts/check_system/Cargo.toml
+++ b/e2e/contracts/check_system/Cargo.toml
@@ -9,7 +9,7 @@ debug-assertions = false
 overflow-checks = false
 
 [dependencies]
-ink = { version = "4", default-features = false }
+ink = { version = "4", default-features = false, features = ["static-buffer-1M"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
@@ -43,3 +43,6 @@ std = [
     "indeterministic_functions/std",
 ]
 ink-as-dependency = []
+
+[patch.crates-io]
+ink = { git = "https://github.com/kvinwang/ink.git", branch = "config-buffer" }

--- a/e2e/src/fullstack.js
+++ b/e2e/src/fullstack.js
@@ -762,6 +762,18 @@ describe('A full stack', function () {
             assert.equal(info?.sidevm?.state, 'running');
         });
 
+        it('can get big http response', async function () {
+            const urls = ["https://files.kvin.wang:8443/512k.txt"];
+            const { output } = await ContractSystemChecker.query.batchHttpGet(alice, certAlice, urls, 1000);
+            // console.log(`output`, output.toHuman());
+            const [code, body] = output.asOk.valueOf()[0];
+            console.log(`status code: ${code}`);
+            console.log(`body length: ${body.length}`);
+            if (code != 200) {
+                console.log(`body: ${body}`);
+            }
+        });
+
         it('can send batch http request', async function () {
             const info = await pruntime[0].getInfo();
             const url = `${pruntime[0].uri}/info`;


### PR DESCRIPTION
# Note
Don't merge. This PR shows an example of how to handle a bigger HTTP response.

In PR https://github.com/Phala-Network/phala-blockchain/pull/1280, we have implemented support for batch HTTP requests and increased the HTTP response limit to 2MB. The following example is based on that PR.

# Things not ready yet
- At present, ink uses a static buffer with a hardcoded size of 16KB to exchange data across the boundary of the wasm virtual machine. The downstream contract does not have the ability to alter this configuration. Although a [customizable solution](https://github.com/paritytech/ink/issues/1471) has been proposed upstream, it has yet to be implemented. While we await their completion, we can implement a temporary solution by [patching ink](https://github.com/paritytech/ink/compare/master...kvinwang:ink:config-buffer) to expand the size of this static buffer.

- cargo-contract is currently rigid in that it hardcodes the maximum available memory for the output WASM as 1MB. To overcome this, we've submitted a [PR](https://github.com/paritytech/cargo-contract/pull/1128) upstream to allow for runtime configuration. Until that PR is merged, we can use our [fork](https://github.com/kvinwang/cargo-contract/tree/max-memory) of `cargo-contract` for compilation to bypass this limitation.

# Steps to build this example

- Install the patched `cargo-contract`
```bash
git clone https://github.com/kvinwang/cargo-contract
cd cargo-contract
git checkout max-memory
cargo install --path crates/cargo-contract
```

- Clone and checkout this PR

```bash
git clone https://github.com/Phala-Network/phala-blockchain
cd phala-blockchain/e2e/contracts/check_system
git checkout big-http
cargo contract build --max-memory-pages 32
```