### PR TITLE
Fix reward below min balance (ED)

### DIFF
--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -72,7 +72,6 @@ pub mod pallet {
 	{
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type MigrationAccountId: Get<Self::AccountId>;
-		type WPhaMinBalance: Get<BalanceOf<Self>>;
 	}
 
 	#[derive(Encode, Decode, TypeInfo, Clone, PartialEq, Eq, RuntimeDebug)]
@@ -1032,7 +1031,8 @@ pub mod pallet {
 				None => return false,
 			};
 			let current_balance = bmul(nft.shares, &price);
-			if current_balance > T::WPhaMinBalance::get() {
+			let wpha_min = wrapped_balances::Pallet::<T>::min_balance();
+			if current_balance > wpha_min {
 				return false;
 			}
 			pool_info.total_shares -= nft.shares;
@@ -1068,7 +1068,8 @@ pub mod pallet {
 				None => return,
 			};
 
-			while pool_info.get_free_stakes::<T>() > T::WPhaMinBalance::get() {
+			let wpha_min = wrapped_balances::Pallet::<T>::min_balance();
+			while pool_info.get_free_stakes::<T>() > wpha_min {
 				if let Some(withdraw) = pool_info.withdraw_queue.front().cloned() {
 					// Must clear the pending reward before any stake change
 					let mut withdraw_nft_guard =

--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -404,7 +404,6 @@ impl vault::Config for Test {
 impl base_pool::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type MigrationAccountId = ConstU64<1234>;
-	type WPhaMinBalance = WPhaMinBalance;
 }
 
 impl stake_pool::Config for Test {
@@ -475,14 +474,12 @@ pub fn take_events() -> Vec<RuntimeEvent> {
 		.into_iter()
 		.map(|evt| evt.event)
 		.collect::<Vec<_>>();
-	println!("event(): {evt:?}");
 	System::reset_events();
 	evt
 }
 
 pub fn take_messages() -> Vec<Message> {
 	let messages = PhalaMq::messages();
-	println!("messages(): {messages:?}");
 	mq::OutboundMessages::<Test>::kill();
 	messages
 }

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1415,7 +1415,6 @@ parameter_types! {
     pub const PropertiesLimit: u32 = 15;
     pub const CollectionSymbolLimit: u32 = 100;
     pub const MaxResourcesOnMint: u32 = 100;
-    pub const WPhaMinBalance: Balance = CENTS;
 }
 impl pallet_rmrk_core::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
@@ -1469,7 +1468,6 @@ impl Get<AccountId32> for MigrationAccount {
 impl pallet_base_pool::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type MigrationAccountId = MigrationAccount;
-    type WPhaMinBalance = WPhaMinBalance;
 }
 
 parameter_types! {


### PR DESCRIPTION
When the calculated reward (to either the pool owner, or the pool distribution reward) is below ED, and the corresponding accounts are new, pallet-assets will refuse to mint the WPHA. In such case, we should handle it carefully as below:

- If the pool is already frozen (pool's total share < share dust), dismiss the reward entirely;
- If the reward is below the dust, dismiss the reward entirely;
- Otherwise, the reward will be divided into `owner` and `to_distribute` rewards, and will be distributed separately:
    - The total reward will be transferred to `wrapped_balances` to increase its reserve.
    - Mint WPHA to the owner reward account for owner commission. However if it's below WPHA ED, it will be dismissed;
    - Mint WPHA to the pool income account for staker reward. However if it's below WPHA ED, it will be dismissed.

To deal with the above cases, there are four dismiss errors:

1. RewardDismissedNoShare
2. RewardDismissedDust
3. RewardToOwnerDismissedDust
4. RewardToDistributionDismissedDust