### PR TITLE
Add Phat Bricks Poller

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -86,3 +86,6 @@ pruntime/app/src/protos/*.rs
 pruntime/enclave/src/protos/*.rs
 pruntime/protos/tmp
 pruntime/tmp
+e2e
+*.Dockerfile
+.dockerignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8229,6 +8229,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "phat-poller"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap 4.3.0",
+ "futures",
+ "hex",
+ "pallet-contracts-primitives",
+ "parity-scale-codec",
+ "phactory-api",
+ "phala-crypto",
+ "phala-types",
+ "phaxt",
+ "rand 0.8.5",
+ "reqwest",
+ "rocket",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-runtime",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.14",
+]
+
+[[package]]
 name = "phaxt"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
 	"standalone/headers-cache",
 	"standalone/justification-validate",
 	"standalone/sfq-test",
+	"standalone/phat-poller",
 	"crates/phala-trie-storage",
 	"crates/phala-mq",
 	"crates/phala-crypto",

--- a/crates/phactory/api/src/pruntime_client.rs
+++ b/crates/phactory/api/src/pruntime_client.rs
@@ -17,13 +17,26 @@ pub fn new_pruntime_client(base_url: String) -> PhactoryApiClient<RpcRequest> {
     PhactoryApiClient::new(RpcRequest::new(base_url))
 }
 
+pub fn new_pruntime_client_no_log(base_url: String) -> PhactoryApiClient<RpcRequest> {
+    PhactoryApiClient::new(RpcRequest::new(base_url).disable_log())
+}
+
 pub struct RpcRequest {
     base_url: String,
+    disable_log: bool,
 }
 
 impl RpcRequest {
     pub fn new(base_url: String) -> Self {
-        Self { base_url }
+        Self {
+            base_url,
+            disable_log: false,
+        }
+    }
+
+    pub fn disable_log(mut self) -> Self {
+        self.disable_log = true;
+        self
     }
 }
 
@@ -43,7 +56,9 @@ impl RequestClient for RpcRequest {
             .await
             .map_err(from_display)?;
 
-        info!("{path}: {}", res.status());
+        if !self.disable_log {
+            info!("{path}: {}", res.status());
+        }
         let status = res.status();
         let body = res.bytes().await.map_err(from_display)?;
         if status.is_success() {

--- a/crates/pink-libs/utils/src/attestation.rs
+++ b/crates/pink-libs/utils/src/attestation.rs
@@ -1,5 +1,6 @@
+//! Utilities to create and verify off-chain attestation
+
 use alloc::vec::Vec;
-///! Utilities to create and verify off-chain attestation
 use core::fmt;
 use pink::chain_extension::{signing, SigType};
 use pink_extension as pink;

--- a/crates/pink-libs/utils/src/lib.rs
+++ b/crates/pink-libs/utils/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-///! Useful utilities for pink
+//! Useful utilities for pink
 extern crate alloc;
 
 pub mod attestation;

--- a/dockerfile.d/01_apt.sh
+++ b/dockerfile.d/01_apt.sh
@@ -1,5 +1,60 @@
-apt update && \
-apt upgrade -y && \
-apt install -y apt-utils apt-transport-https software-properties-common readline-common curl vim wget gnupg gnupg2 gnupg-agent ca-certificates unzip lsb-release debhelper gettext cmake reprepro autoconf automake bison build-essential curl dpkg-dev expect flex gcc gdb git git-core gnupg kmod libboost-system-dev libboost-thread-dev libcurl4-openssl-dev libiptcdata0-dev libjsoncpp-dev liblog4cpp5-dev libprotobuf-dev libssl-dev libtool libxml2-dev uuid-dev ocaml ocamlbuild pkg-config protobuf-compiler python texinfo llvm clang libclang-dev nginx python3-pip && \
-apt autoremove -y && \
+set -e
+apt update
+apt upgrade -y
+apt install -y apt-utils \
+ apt-transport-https \
+ software-properties-common \
+ readline-common \
+ curl \
+ vim \
+ wget \
+ gnupg \
+ gnupg2 \
+ gnupg-agent \
+ ca-certificates \
+ unzip \
+ lsb-release \
+ debhelper \
+ gettext \
+ cmake \
+ reprepro \
+ autoconf \
+ automake \
+ bison \
+ build-essential \
+ curl \
+ dpkg-dev \
+ expect \
+ flex \
+ gcc \
+ gdb \
+ git \
+ git-core \
+ gnupg \
+ kmod \
+ libboost-system-dev \
+ libboost-thread-dev \
+ libcurl4-openssl-dev \
+ libiptcdata0-dev \
+ libjsoncpp-dev \
+ liblog4cpp5-dev \
+ libprotobuf-dev \
+ libssl-dev \
+ libtool \
+ libxml2-dev \
+ uuid-dev \
+ ocaml \
+ ocamlbuild \
+ pkg-config \
+ protobuf-compiler \
+ python \
+ texinfo \
+ llvm \
+ clang \
+ libclang-dev \
+ nginx \
+ python3-pip \
+ musl-tools \
+
+apt autoremove -y
 rm -rf /var/lib/apt/lists/*

--- a/dockerfile.d/05_rust.sh
+++ b/dockerfile.d/05_rust.sh
@@ -1,3 +1,4 @@
+RUST_TOOLCHAIN=1.69
 cd /root && \
 curl 'https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init' --output /root/rustup-init && \
 chmod +x /root/rustup-init && \

--- a/gramine.Dockerfile
+++ b/gramine.Dockerfile
@@ -15,7 +15,6 @@ ARG CODENAME='focal'
 ADD ./dockerfile.d/04_psw.sh /root
 RUN bash /root/04_psw.sh
 
-ARG RUST_TOOLCHAIN='1.69.0'
 ADD ./dockerfile.d/05_rust.sh /root
 RUN bash /root/05_rust.sh
 

--- a/poller.Dockerfile
+++ b/poller.Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:20.04 as builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="${PATH}:/root/.cargo/bin"
+
+ADD dockerfile.d/01_apt.sh /root
+RUN bash /root/01_apt.sh
+
+ADD dockerfile.d/05_rust.sh /root
+RUN bash /root/05_rust.sh
+
+WORKDIR /root
+COPY . .
+RUN rustup target add x86_64-unknown-linux-musl
+RUN cargo build --target x86_64-unknown-linux-musl --release -p phat-poller
+RUN mkdir -p build-out/
+RUN cp target/x86_64-unknown-linux-musl/release/phat-poller build-out/
+RUN strip build-out/phat-poller
+
+FROM scratch
+WORKDIR /app
+COPY --from=builder /root/build-out/phat-poller .
+USER 1000:1000
+ENTRYPOINT ["./phat-poller"]

--- a/standalone/phat-poller/Cargo.toml
+++ b/standalone/phat-poller/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "phat-poller"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+phaxt = { path = "../../crates/phaxt" }
+phactory-api = { path = "../../crates/phactory/api", features = ["pruntime-client"] }
+phala-crypto = { path = "../../crates/phala-crypto" }
+phala-types = { path = "../../crates/phala-types" }
+
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "socks"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+anyhow = "1.0.69"
+clap = { version = "4.0.32", features = ["derive"] }
+tokio = { version = "1.24.2", features = ["full"] }
+chrono = { version = "0.4.22" }
+rocket = "0.5.0-rc.3"
+scale = { package = 'parity-scale-codec', version = "3.3" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+futures = "0.3"
+rand = "0.8"
+hex = "0.4"

--- a/standalone/phat-poller/src/app.rs
+++ b/standalone/phat-poller/src/app.rs
@@ -438,15 +438,15 @@ async fn poll_contract_inner(
     }
 }
 
-#[instrument(skip(worker, profile), name = "wf")]
-async fn poll_workflow(worker: Worker, profile: ContractId, flow_id: u64) -> Result<()> {
+#[instrument(skip(worker, profile), name = "flow")]
+async fn poll_workflow(worker: Worker, profile: ContractId, id: u64) -> Result<()> {
     debug!("polling workflow");
     let result = pink_query::<_, crate::contracts::PollResponse>(
         &worker.pubkey,
         &worker.uri,
         profile,
         SELECTOR_POLL,
-        (flow_id,),
+        (id,),
     )
     .await;
     debug!("result: {result:?}");

--- a/standalone/phat-poller/src/app.rs
+++ b/standalone/phat-poller/src/app.rs
@@ -1,0 +1,423 @@
+use crate::{
+    args::{parse_hash, RunArgs},
+    contracts::{SELECTOR_GET_USER_PROFILES, SELECTOR_POLL},
+    instant::Instant,
+    query::pink_query,
+};
+
+use std::{
+    collections::{BTreeMap, VecDeque},
+    future::Future,
+    sync::{Arc, Mutex, Weak},
+    time::Duration,
+};
+
+use anyhow::Result;
+use phaxt::AccountId;
+use sp_core::H256;
+use tokio::task::JoinHandle;
+use tracing::{debug, error, info, instrument, warn, Instrument};
+
+use serde::Serialize;
+
+use phala_types::WorkerPublicKey;
+
+pub type Config = RunArgs;
+pub type TaskId = u64;
+pub type ArcApp = Arc<App>;
+type ContractId = H256;
+
+#[derive(Clone, Serialize)]
+struct Worker {
+    pubkey: WorkerPublicKey,
+    uri: String,
+    probe_info: ProbeInfo,
+}
+
+impl Worker {
+    fn latency(&self) -> Option<Duration> {
+        let end = self.probe_info.probe_result.as_ref().ok()?;
+        Some(end.duration_since(self.probe_info.probe_start))
+    }
+}
+
+#[derive(Clone, Serialize)]
+struct ProbeInfo {
+    probe_start: Instant,
+    probe_result: Result<Instant, String>,
+}
+
+#[derive(Default, Serialize)]
+pub struct State {
+    next_task_id: TaskId,
+    workers: Vec<Worker>,
+    running_tasks: BTreeMap<TaskId, Task>,
+    history: VecDeque<Task>,
+    last_probe_time: Option<Instant>,
+    last_poll_time: Option<Instant>,
+    last_poll_result: BTreeMap<ContractId, PollResult>,
+}
+
+pub struct App {
+    weak_self: Weak<Self>,
+    pub config: Config,
+    pub state: Mutex<State>,
+}
+
+#[derive(Serialize)]
+struct PollResult {
+    worker: WorkerPublicKey,
+    start_time: Instant,
+    end_time: Option<Instant>,
+    result: Result<(), String>,
+}
+
+#[derive(Serialize)]
+struct Task {
+    id: TaskId,
+    name: String,
+    description: String,
+    start_time: Instant,
+    end_time: Option<Instant>,
+    duration: Option<Duration>,
+    result: Option<Result<(), String>>,
+}
+
+pub fn create_app(config: Config) -> ArcApp {
+    Arc::new_cyclic(|weak_app| App::new(config, weak_app.clone()))
+}
+
+impl App {
+    fn new(config: Config, weak_self: Weak<Self>) -> Self {
+        Self {
+            weak_self,
+            config,
+            state: Default::default(),
+        }
+    }
+
+    fn next_task_id(&self) -> u64 {
+        let mut state = self.state.lock().unwrap();
+        let id = state.next_task_id;
+        state.next_task_id += 1;
+        id
+    }
+
+    fn report_task_result<T>(&self, id: u64, result: &Result<T>) {
+        let mut state = self.state.lock().unwrap();
+        let Some(mut task) = state.running_tasks.remove(&id) else {
+            warn!(id, "task gone");
+            return;
+        };
+        task.end_time = Some(Instant::now());
+        task.duration = Some(task.end_time.unwrap().duration_since(task.start_time));
+        task.result = Some(match result {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err.to_string()),
+        });
+        state.history.push_back(task);
+        if state.history.len() > self.config.max_history {
+            state.history.pop_front();
+        }
+    }
+
+    fn spawn<T: Send + 'static>(
+        &self,
+        name: &str,
+        description: &str,
+        timeout: Duration,
+        task: impl Future<Output = Result<T>> + Send + 'static,
+    ) -> JoinHandle<Result<T>> {
+        let id = self.next_task_id();
+        let mut state = self.state.lock().unwrap();
+        state.running_tasks.insert(
+            id,
+            Task {
+                id,
+                name: name.to_string(),
+                description: description.to_string(),
+                start_time: Instant::now(),
+                end_time: None,
+                duration: None,
+                result: None,
+            },
+        );
+        let app = self.weak_self.clone();
+        tokio::spawn(
+            track_task_result(app, id, async move {
+                tokio::time::timeout(timeout, task)
+                    .await
+                    .or(Err(anyhow::anyhow!("timeout")))?
+            })
+            .instrument(tracing::info_span!("task", id, name)),
+        )
+    }
+
+    #[instrument(skip(self), name = "probe")]
+    async fn bg_update_worker_list(&self) {
+        loop {
+            info!("updating worker list");
+            let start = Instant::now();
+            self.state.lock().unwrap().last_probe_time = Some(start);
+            if let Err(err) = self.update_worker_list().await {
+                error!("failed to update worker list: {err}");
+            }
+            let rest_time = self.config.probe_interval.saturating_sub(start.elapsed());
+            info!("{}ms elapsed", start.elapsed().as_millis());
+            info!("next worker list update in {}s", rest_time.as_secs());
+            tokio::time::sleep(rest_time).await;
+        }
+    }
+
+    async fn update_worker_list(&self) -> Result<()> {
+        info!("connecting to node {uri}", uri = self.config.node_uri);
+        let chain_rpc = tokio::time::timeout(
+            Duration::from_secs(5),
+            phaxt::connect(&self.config.node_uri),
+        )
+        .await??;
+        info!("connected to node {uri}", uri = self.config.node_uri);
+        let workers = chain_rpc.get_workers(self.config.cluster_id).await?;
+        info!("{} workers found", workers.len());
+        if workers.is_empty() {
+            warn!("no workers found");
+            return Ok(());
+        }
+        let mut probe_tasks = Vec::with_capacity(workers.len());
+        let mut probe_workers = Vec::with_capacity(workers.len());
+        let mut workers_without_endpoints = Vec::new();
+
+        let probe_start = Instant::now();
+        let timeout = self.config.poll_timeout;
+        for worker in workers {
+            let endpoints = chain_rpc.get_endpoints(&worker).await?;
+            debug!("worker {worker:?} endpoints: {endpoints:?}");
+            let Some(uri) = endpoints
+                .into_iter()
+                .find(|url| url.starts_with("http://") || url.starts_with("https://"))
+            else {
+                workers_without_endpoints.push(worker);
+                continue;
+            };
+            let handle = self.spawn(
+                "probe",
+                &format!(r#""uri":"{uri}"}}"#),
+                timeout,
+                probe_worker(Some(worker), uri.clone()),
+            );
+            probe_tasks.push(handle);
+            probe_workers.push((worker, uri));
+        }
+        info!("probing {} workers", probe_tasks.len());
+        let probe_results = futures::future::join_all(probe_tasks).await;
+        let workers: Vec<_> = probe_workers
+            .into_iter()
+            .zip(probe_results)
+            .map(|((pubkey, uri), result)| {
+                let probe_result = match result {
+                    Ok(Ok((_, instant))) => Ok(instant),
+                    Ok(Err(err)) => Err(format!("{err}")),
+                    Err(err) => Err(format!("{err}")),
+                };
+                Worker {
+                    pubkey,
+                    uri,
+                    probe_info: ProbeInfo {
+                        probe_start,
+                        probe_result,
+                    },
+                }
+            })
+            .collect();
+        info!("{} workers updated", workers.len());
+        self.state.lock().unwrap().workers = workers;
+        Ok(())
+    }
+
+    async fn probe_dev_worker(&self) -> Result<()> {
+        let Some(uri) = self.config.dev_worker_uri.as_ref() else {
+            warn!("no dev worker uri specified");
+            return Ok(());
+        };
+        let handle = self.spawn(
+            "probe",
+            &format!("uri:{uri}"),
+            self.config.probe_timeout,
+            probe_worker(None, uri.clone()),
+        );
+        let t0 = Instant::now();
+        let (pubkey, t1) = handle.await??;
+        self.state.lock().unwrap().workers.push(Worker {
+            pubkey,
+            uri: uri.clone(),
+            probe_info: ProbeInfo {
+                probe_start: t0,
+                probe_result: Ok(t1),
+            },
+        });
+        Ok(())
+    }
+}
+
+async fn track_task_result<T>(
+    app: Weak<App>,
+    task_id: TaskId,
+    task: impl Future<Output = Result<T>>,
+) -> Result<T> {
+    let result = task.await;
+    if let Some(app) = app.upgrade() {
+        app.report_task_result(task_id, &result);
+    }
+    result
+}
+
+async fn probe_worker(
+    pubkey: Option<WorkerPublicKey>,
+    uri: String,
+) -> Result<(WorkerPublicKey, Instant)> {
+    debug!("probing worker {pubkey:?} at {uri}");
+    let prpc = phactory_api::pruntime_client::new_pruntime_client_no_log(uri);
+    let info = prpc.get_info(()).await?;
+    let Some(public_key) = &info.public_key else {
+        return Err(anyhow::anyhow!("worker is uninitialized"));
+    };
+    let public_key = WorkerPublicKey(parse_hash(public_key)?.0);
+    if let Some(pubkey) = pubkey {
+        if pubkey != public_key {
+            return Err(anyhow::anyhow!("public key mismatch"));
+        }
+    }
+    Ok((public_key, Instant::now()))
+}
+
+impl App {
+    #[instrument(skip(self), name = "poll")]
+    async fn bg_poll_contracts(&self) {
+        loop {
+            info!("poll contracts begin");
+            let start = Instant::now();
+            self.state.lock().unwrap().last_poll_time = Some(start);
+            if let Err(err) = self.poll_contracts().await {
+                warn!("failed to poll contracts: {err}");
+            }
+            let rest_time = self.config.poll_interval.saturating_sub(start.elapsed());
+            info!("{}ms elapsed", start.elapsed().as_millis());
+            info!("next poll in {}s", rest_time.as_secs());
+            tokio::time::sleep(rest_time).await;
+        }
+    }
+
+    async fn poll_contracts(&self) -> Result<()> {
+        let mut live_workers = self
+            .state
+            .lock()
+            .unwrap()
+            .workers
+            .iter()
+            .filter(|worker| worker.latency().is_some())
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if live_workers.is_empty() {
+            warn!("no live workers available");
+            return Ok(());
+        }
+        live_workers.sort_by_key(|worker| worker.latency().unwrap_or(Duration::MAX));
+        let top_workers = live_workers
+            .into_iter()
+            .take(self.config.use_top_workers)
+            .collect::<Vec<_>>();
+        info!("top workers:");
+        for worker in &top_workers {
+            info!(latency=?worker.latency().unwrap_or(Duration::MAX), "  {}", worker.pubkey);
+        }
+        let worker = &top_workers[0];
+        let contracts: Vec<(AccountId, ContractId)> =
+            pink_query::<_, crate::contracts::UserProfilesResponse>(
+                &worker.pubkey,
+                &worker.uri,
+                self.config.factory_contract,
+                SELECTOR_GET_USER_PROFILES,
+                (),
+            )
+            .await?
+            .or(Err(anyhow::anyhow!("query failed")))?;
+
+        let mut poll_handles = Vec::with_capacity(contracts.len());
+
+        let mut worker_index = 0;
+        for (user, profile) in contracts {
+            // call contract poll with workers in robin round
+            let worker = &top_workers[worker_index];
+            debug!(
+                "adding poll, user={user}, profile={profile:?}, worker={}",
+                worker.pubkey
+            );
+            let handle = self.spawn(
+                "poll",
+                &format!(
+                    r#"{{"worker":"{}","contract":"{profile:?}"}}"#,
+                    worker.pubkey
+                ),
+                self.config.poll_timeout,
+                poll_contract(worker.clone(), profile, self.weak_self.clone()),
+            );
+            poll_handles.push(handle);
+            worker_index = (worker_index + 1) % top_workers.len();
+        }
+        info!(count = poll_handles.len(), "polling contracts");
+        let poll_results = futures::future::join_all(poll_handles).await;
+        info!(count = poll_results.len(), "contracts polled");
+        Ok(())
+    }
+}
+
+async fn poll_contract(worker: Worker, profile: ContractId, weak_app: Weak<App>) -> Result<()> {
+    let pubkey = worker.pubkey;
+    let start_time = Instant::now();
+    let result = poll_contract_inner(worker, profile).await;
+    if let Some(app) = weak_app.upgrade() {
+        let result = match &result {
+            Ok(_) => Ok(()),
+            Err(err) => Err(format!("{err}")),
+        };
+        app.state.lock().unwrap().last_poll_result.insert(
+            profile,
+            PollResult {
+                worker: pubkey,
+                start_time,
+                end_time: Some(Instant::now()),
+                result,
+            },
+        );
+    }
+    result
+}
+
+async fn poll_contract_inner(worker: Worker, profile: ContractId) -> Result<()> {
+    pink_query::<_, crate::contracts::PollResponse>(
+        &worker.pubkey,
+        &worker.uri,
+        profile,
+        SELECTOR_POLL,
+        (),
+    )
+    .await?
+    .map_err(|err| anyhow::anyhow!("{err:?}"))?;
+    Ok(())
+}
+
+impl App {
+    pub async fn run(&self) -> Result<()> {
+        if self.config.dev_worker_uri.is_some() {
+            self.probe_dev_worker().await?;
+            self.bg_poll_contracts().await;
+        } else {
+            tokio::join! {
+                self.bg_update_worker_list(),
+                self.bg_poll_contracts(),
+            };
+        }
+        Ok(())
+    }
+}

--- a/standalone/phat-poller/src/args.rs
+++ b/standalone/phat-poller/src/args.rs
@@ -1,0 +1,130 @@
+
+use clap::{Parser, Subcommand};
+use sp_core::H256;
+use std::time::Duration;
+
+#[derive(Parser)]
+#[clap(about = "Cache server for relaychain headers", version, author)]
+pub struct AppArgs {
+    #[clap(subcommand)]
+    pub action: Action,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// Run
+    Run(RunArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct RunArgs {
+    /// The URI of a phala-node
+    #[arg(long, default_value = "ws://localhost:9944")]
+    pub node_uri: String,
+
+    /// The worker URL used to development
+    #[arg(long)]
+    pub dev_worker_uri: Option<String>,
+
+    /// Cluster ID
+    #[arg(long, value_parser = parse_hash, default_value = "0x0000000000000000000000000000000000000000000000000000000000000001")]
+    pub cluster_id: H256,
+
+    /// Max number of history tasks to keep in
+    #[arg(long, default_value = "200")]
+    pub max_history: usize,
+
+    /// The interval to update and probe the worker list
+    #[arg(long, value_parser = parse_duration, default_value = "5m")]
+    pub probe_interval: Duration,
+
+    /// The timeout to probe a worker
+    #[arg(long, value_parser = parse_duration, default_value = "5s")]
+    pub probe_timeout: Duration,
+
+    /// Contract poll interval
+    #[arg(long, value_parser = parse_duration, default_value = "10s")]
+    pub poll_interval: Duration,
+
+    /// Contract poll timeout
+    #[arg(long, value_parser = parse_duration, default_value = "10s")]
+    pub poll_timeout: Duration,
+
+    /// Top n workers to be used to poll
+    #[arg(long, default_value_t = 5)]
+    pub use_top_workers: usize,
+
+    /// Contract ID for the BricksProfileFactory to poll
+    #[arg(long, value_parser = parse_hash)]
+    pub factory_contract: H256,
+}
+
+#[derive(Debug)]
+pub struct InvalidDuration;
+
+impl std::fmt::Display for InvalidDuration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Invalid duration")
+    }
+}
+
+impl std::error::Error for InvalidDuration {}
+
+fn parse_duration(s: &str) -> Result<Duration, InvalidDuration> {
+    let mut num_str = s;
+    let mut unit = "s";
+
+    if let Some(idx) = s.find(|c: char| !c.is_numeric()) {
+        num_str = &s[..idx];
+        unit = &s[idx..];
+    }
+
+    let num = num_str.parse::<u64>().or(Err(InvalidDuration))?;
+
+    let num = match unit {
+        "s" | "" => num,
+        "m" => num * 60,
+        "h" => num * 60 * 60,
+        "d" => num * 60 * 60 * 24,
+        _ => return Err(InvalidDuration),
+    };
+
+    Ok(Duration::from_secs(num))
+}
+
+pub fn parse_hash(s: &str) -> Result<H256, hex::FromHexError> {
+    let s = s.trim_start_matches("0x");
+    if s.len() != 64 {
+        return Err(hex::FromHexError::InvalidStringLength);
+    }
+    let mut buf = [0u8; 32];
+    hex::decode_to_slice(s, &mut buf)?;
+    Ok(H256::from(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_duration() {
+        assert_eq!(parse_duration("10").unwrap(), Duration::from_secs(10));
+        assert_eq!(parse_duration("10s").unwrap(), Duration::from_secs(10));
+        assert_eq!(parse_duration("10m").unwrap(), Duration::from_secs(600));
+        assert_eq!(parse_duration("10h").unwrap(), Duration::from_secs(36000));
+        assert_eq!(parse_duration("10d").unwrap(), Duration::from_secs(864000));
+        assert_eq!(parse_duration("1").unwrap(), Duration::from_secs(1));
+        assert_eq!(parse_duration("100").unwrap(), Duration::from_secs(100));
+    }
+
+    #[test]
+    fn test_parse_duration_invalid() {
+        assert!(parse_duration("10x").is_err());
+        assert!(parse_duration("ms").is_err());
+    }
+
+    #[test]
+    fn test_parse_duration_empty() {
+        assert!(parse_duration("").is_err());
+    }
+}

--- a/standalone/phat-poller/src/args.rs
+++ b/standalone/phat-poller/src/args.rs
@@ -1,6 +1,5 @@
-
 use clap::{Parser, Subcommand};
-use sp_core::H256;
+use sp_core::{crypto::SecretStringError, Pair, H256};
 use std::time::Duration;
 
 #[derive(Parser)]
@@ -10,13 +9,13 @@ pub struct AppArgs {
     pub action: Action,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand)]
 pub enum Action {
     /// Run
     Run(RunArgs),
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser)]
 pub struct RunArgs {
     /// The URI of a phala-node
     #[arg(long, default_value = "ws://localhost:9944")]
@@ -57,6 +56,10 @@ pub struct RunArgs {
     /// Contract ID for the BricksProfileFactory to poll
     #[arg(long, value_parser = parse_hash)]
     pub factory_contract: H256,
+
+    /// Contract caller SR25519 private key mnemonic, private key seed, or derive path
+    #[arg(long, value_parser = parse_sr25519, default_value = "//Alice")]
+    pub caller: sp_core::sr25519::Pair,
 }
 
 #[derive(Debug)]
@@ -69,6 +72,10 @@ impl std::fmt::Display for InvalidDuration {
 }
 
 impl std::error::Error for InvalidDuration {}
+
+fn parse_sr25519(s: &str) -> Result<sp_core::sr25519::Pair, SecretStringError> {
+    <sp_core::sr25519::Pair as Pair>::from_string(s, None)
+}
 
 fn parse_duration(s: &str) -> Result<Duration, InvalidDuration> {
     let mut num_str = s;

--- a/standalone/phat-poller/src/contracts.rs
+++ b/standalone/phat-poller/src/contracts.rs
@@ -1,0 +1,29 @@
+use phaxt::AccountId;
+use scale::{Decode, Encode};
+// TODO: load from metadata?
+
+type ContractId = sp_core::H256;
+
+#[derive(Encode, Decode, Debug)]
+pub enum Error {
+    BadOrigin,
+    NotConfigured,
+    Deprecated,
+    NoPollForTransaction,
+    BadWorkflowSession,
+    BadEvmSecretKey,
+    BadUnsignedTransaction,
+    WorkflowNotFound,
+    WorkflowDisabled,
+    NoAuthorizedExternalAccount,
+    ExternalAccountNotFound,
+    ExternalAccountDisabled,
+    FailedToGetEthAccounts(String),
+    FailedToSignTransaction(String),
+}
+
+pub const SELECTOR_POLL: u32 = 0x1e44dfc6;
+pub const SELECTOR_GET_USER_PROFILES: u32 = 0xbcb18cc3;
+
+pub type UserProfilesResponse = Result<Vec<(AccountId, ContractId)>, Error>;
+pub type PollResponse = Result<(), Error>;

--- a/standalone/phat-poller/src/contracts.rs
+++ b/standalone/phat-poller/src/contracts.rs
@@ -24,6 +24,7 @@ pub enum Error {
 
 pub const SELECTOR_POLL: u32 = 0x1e44dfc6;
 pub const SELECTOR_GET_USER_PROFILES: u32 = 0xbcb18cc3;
+pub const SELECTOR_WORKFLOW_COUNT: u32 = 0x198e532a;
 
 pub type UserProfilesResponse = Result<Vec<(AccountId, ContractId)>, Error>;
 pub type PollResponse = Result<(), Error>;

--- a/standalone/phat-poller/src/instant.rs
+++ b/standalone/phat-poller/src/instant.rs
@@ -1,0 +1,32 @@
+use serde::Serialize;
+use std::time::{Duration, SystemTime};
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Instant(std::time::Instant);
+
+impl Serialize for Instant {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let now = std::time::SystemTime::now();
+        let elapsed = self.0.elapsed();
+        let time = now.checked_sub(elapsed).unwrap_or(SystemTime::UNIX_EPOCH);
+
+        let datetime: DateTime<Utc> = time.into();
+        let timestamp = datetime.format("%Y-%m-%dT%H:%M:%S.%fZ").to_string();
+        timestamp.serialize(serializer)
+    }
+}
+
+impl Instant {
+    pub fn now() -> Self {
+        Self(std::time::Instant::now())
+    }
+
+    pub fn duration_since(&self, earlier: Self) -> Duration {
+        self.0.duration_since(earlier.0)
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.0.elapsed()
+    }
+}

--- a/standalone/phat-poller/src/main.rs
+++ b/standalone/phat-poller/src/main.rs
@@ -1,0 +1,25 @@
+use clap::Parser;
+
+mod app;
+mod args;
+mod contracts;
+mod instant;
+mod query;
+mod web_api;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let args = args::AppArgs::parse();
+    match args.action {
+        args::Action::Run(args) => {
+            let app = app::create_app(args);
+            tokio::select! {
+                r = web_api::serve(app.clone()) => r?,
+                r = app.run() => r?,
+            }
+        }
+    }
+    Ok(())
+}

--- a/standalone/phat-poller/src/query.rs
+++ b/standalone/phat-poller/src/query.rs
@@ -94,7 +94,7 @@ pub async fn pink_query_raw(
 ) -> Result<Result<Vec<u8>, QueryError>> {
     let query = Query::InkMessage {
         payload: call_data,
-        deposit: 0,
+        deposit: 1_000_000_000_000_000_u128,
         transfer: 0,
         estimating: false,
     };

--- a/standalone/phat-poller/src/query.rs
+++ b/standalone/phat-poller/src/query.rs
@@ -1,0 +1,184 @@
+use anyhow::{anyhow, Result};
+use phactory_api::{
+    crypto::{CertificateBody, EncryptedData},
+    prpc,
+};
+use phala_crypto::ecdh::EcdhPublicKey;
+use phala_crypto::sr25519::KDF;
+use phala_types::contract;
+use phala_types::contract::ContractId;
+use scale::{Decode, Encode};
+use sp_core::Pair as _;
+use std::convert::TryFrom as _;
+
+#[derive(Debug, Encode, Decode)]
+pub enum Query {
+    InkMessage {
+        payload: Vec<u8>,
+        /// Amount of tokens deposit to the caller.
+        deposit: u128,
+        /// Amount of tokens transfer from the caller to the target contract.
+        transfer: u128,
+        /// Whether to use the gas estimation mode.
+        estimating: bool,
+    },
+    SidevmQuery(Vec<u8>),
+}
+
+#[derive(Debug, Encode, Decode)]
+pub enum Command {
+    InkMessage { nonce: Vec<u8>, message: Vec<u8> },
+}
+
+#[derive(Debug, Encode, Decode)]
+pub enum Response {
+    Payload(Vec<u8>),
+}
+
+#[derive(Debug, Encode, Decode)]
+pub enum QueryError {
+    BadOrigin,
+    RuntimeError(String),
+    SidevmNotFound,
+}
+impl std::fmt::Display for QueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryError::BadOrigin => write!(f, "Bad origin"),
+            QueryError::RuntimeError(msg) => write!(f, "Runtime error: {}", msg),
+            QueryError::SidevmNotFound => write!(f, "Sidevm not found"),
+        }
+    }
+}
+impl std::error::Error for QueryError {}
+
+#[derive(Debug, Encode, Decode)]
+pub enum LangError {
+    CouldNotReadInput,
+}
+
+impl std::fmt::Display for LangError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LangError::CouldNotReadInput => write!(f, "Could not read input"),
+        }
+    }
+}
+impl std::error::Error for LangError {}
+
+pub async fn pink_query<I: Encode, O: Decode>(
+    worker_pubkey: &[u8],
+    url: &str,
+    id: ContractId,
+    selector: u32,
+    args: I,
+) -> Result<O> {
+    let call_data = (selector.to_be_bytes(), args).encode();
+    let payload = pink_query_raw(worker_pubkey, url, id, call_data).await??;
+    let output =
+        pallet_contracts_primitives::ContractExecResult::<u128>::decode(&mut &payload[..])?
+            .result
+            .map_err(|err| anyhow::anyhow!("DispatchError({err:?})"))?;
+    if output.did_revert() {
+        return Err(anyhow!("Contract execution reverted"));
+    }
+    let r = Result::<O, LangError>::decode(&mut &output.data[..])??;
+    Ok(r)
+}
+
+pub async fn pink_query_raw(
+    worker_pubkey: &[u8],
+    url: &str,
+    id: ContractId,
+    call_data: Vec<u8>,
+) -> Result<Result<Vec<u8>, QueryError>> {
+    let query = Query::InkMessage {
+        payload: call_data,
+        deposit: 0,
+        transfer: 0,
+        estimating: false,
+    };
+    let result: Result<Response, QueryError> =
+        contract_query(worker_pubkey, url, id, query).await?;
+    Ok(result.map(|r| {
+        let Response::Payload(payload) = r;
+        payload
+    }))
+}
+
+pub async fn contract_query<Request: Encode, Response: Decode>(
+    worker_pubkey: &[u8],
+    url: &str,
+    id: ContractId,
+    data: Request,
+) -> Result<Response> {
+    // 2. Make ContractQuery
+    let nonce = rand::random::<[u8; 32]>();
+    let head = contract::ContractQueryHead { id, nonce };
+    let query = contract::ContractQuery { head, data };
+
+    let pr = phactory_api::pruntime_client::new_pruntime_client_no_log(url.into());
+
+    let remote_pubkey = EcdhPublicKey::try_from(worker_pubkey)?;
+
+    // 3. Encrypt the ContractQuery.
+
+    let ecdh_key = sp_core::sr25519::Pair::generate()
+        .0
+        .derive_ecdh_key()
+        .map_err(|_| anyhow!("Derive ecdh key failed"))?;
+
+    let iv = [1; 12];
+    let encrypted_data = EncryptedData::encrypt(&ecdh_key, &remote_pubkey, iv, &query.encode())
+        .map_err(|_| anyhow!("Encrypt data failed"))?;
+
+    // 4. Sign the encrypted data.
+    // 4.1 Make the root certificate.
+    let (root_key, _) = sp_core::sr25519::Pair::generate();
+    let root_cert_body = CertificateBody {
+        pubkey: root_key.public().to_vec(),
+        ttl: u32::MAX,
+        config_bits: 0,
+    };
+    let root_cert = prpc::Certificate::new(root_cert_body, None);
+
+    // 4.2 Generate a temporary key pair and sign it with root key.
+    let (key_g, _) = sp_core::sr25519::Pair::generate();
+
+    let data_cert_body = CertificateBody {
+        pubkey: key_g.public().to_vec(),
+        ttl: u32::MAX,
+        config_bits: 0,
+    };
+    let cert_signature = prpc::Signature {
+        signed_by: Some(Box::new(root_cert)),
+        signature_type: prpc::SignatureType::Sr25519 as _,
+        signature: root_key.sign(&data_cert_body.encode()).0.to_vec(),
+    };
+    let data_cert = prpc::Certificate::new(data_cert_body, Some(Box::new(cert_signature)));
+    let data_signature = prpc::Signature {
+        signed_by: Some(Box::new(data_cert)),
+        signature_type: prpc::SignatureType::Sr25519 as _,
+        signature: key_g.sign(&encrypted_data.encode()).0.to_vec(),
+    };
+
+    let request = prpc::ContractQueryRequest::new(encrypted_data, Some(data_signature));
+
+    // 5. Do the RPC call.
+    let response = pr.contract_query(request).await?;
+
+    // 6. Decrypt the response.
+    let encrypted_data = response.decode_encrypted_data()?;
+    let data = encrypted_data
+        .decrypt(&ecdh_key)
+        .map_err(|_| anyhow!("Decrypt data failed"))?;
+
+    // 7. Decode the response.
+    let response: contract::ContractQueryResponse<Response> = Decode::decode(&mut &data[..])?;
+
+    // 8. check the nonce is match the one we sent.
+    if response.nonce != nonce {
+        return Err(anyhow!("nonce mismatch"));
+    }
+    Ok(response.result)
+}

--- a/standalone/phat-poller/src/web_api.rs
+++ b/standalone/phat-poller/src/web_api.rs
@@ -1,0 +1,17 @@
+use crate::app::ArcApp;
+
+use rocket::{get, routes, State};
+
+#[get("/state")]
+fn state(app: &State<ArcApp>) -> String {
+    serde_json::to_string_pretty(&*app.state.lock().unwrap()).unwrap_or_else(|_| "null".to_string())
+}
+
+pub(crate) async fn serve(app: ArcApp) -> anyhow::Result<()> {
+    let _rocket = rocket::build()
+        .manage(app)
+        .mount("/", routes![state,])
+        .launch()
+        .await?;
+    Ok(())
+}


### PR DESCRIPTION
For @shelvenzhou 
```
Usage: phat-poller run [OPTIONS] --factory-contract <FACTORY_CONTRACT>

Options:
      --node-uri <NODE_URI>
          The URI of a phala-node [default: ws://localhost:9944]
      --dev-worker-uri <DEV_WORKER_URI>
          The worker URL used to development
      --cluster-id <CLUSTER_ID>
          Cluster ID [default: 0x0000000000000000000000000000000000000000000000000000000000000001]
      --max-history <MAX_HISTORY>
          Max number of history tasks to keep in [default: 200]
      --probe-interval <PROBE_INTERVAL>
          The interval to update and probe the worker list [default: 5m]
      --probe-timeout <PROBE_TIMEOUT>
          The timeout to probe a worker [default: 5s]
      --poll-interval <POLL_INTERVAL>
          Contract poll interval [default: 10s]
      --poll-timeout <POLL_TIMEOUT>
          Contract poll timeout [default: 10s]
      --use-top-workers <USE_TOP_WORKERS>
          Top n workers to be used to poll [default: 5]
      --factory-contract <FACTORY_CONTRACT>
          Contract ID for the BricksProfileFactory to poll
  -h, --help
          Print help
```

# Example
```
RUST_LOG=error,phat_poller=debug ROCKET_PORT=8003 ./target/release/phat-poller run --node-uri ws://phala-node.bj:9944 --factory-contract 0x4d545b010257f11c3ee5667d92c9e6ac0e70cdc42ffb75b9f120811c614c2d16
```
# Query its working state
```
curl localhost:8003/state
```
