### PR TITLE
Pin Rustc to 1.69

### DIFF
--- a/.github/actions/install_toolchain/action.yml
+++ b/.github/actions/install_toolchain/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Install latest stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
         override: true
         target: wasm32-unknown-unknown
         components: cargo, clippy, rust-analyzer, rust-src, rust-std, rustc-dev, rustc, rustfmt

--- a/gramine.Dockerfile
+++ b/gramine.Dockerfile
@@ -15,7 +15,7 @@ ARG CODENAME='focal'
 ADD ./dockerfile.d/04_psw.sh /root
 RUN bash /root/04_psw.sh
 
-ARG RUST_TOOLCHAIN='stable'
+ARG RUST_TOOLCHAIN='1.69.0'
 ADD ./dockerfile.d/05_rust.sh /root
 RUN bash /root/05_rust.sh
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.69.0"
 components = [
     "cargo",
     "clippy",
@@ -10,5 +10,5 @@ components = [
     "rustc",
     "rustfmt",
 ]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "wasm32-wasi"]
 profile = "minimal"


### PR DESCRIPTION
Our phat contracts don't compile with rustc 1.70
See the follow links for more detail:
    https://github.com/paritytech/cargo-contract/issues/1139
    https://github.com/rust-lang/rust/issues/109807