### PR TITLE
pink: Add API driver_history

### DIFF
--- a/crates/pink-drivers/system/lib.rs
+++ b/crates/pink-drivers/system/lib.rs
@@ -262,6 +262,11 @@ mod system {
         }
 
         #[ink(message)]
+        fn code_hash(&self, account: AccountId) -> Option<ink::primitives::Hash> {
+            self.env().code_hash(&account).ok()
+        }
+
+        #[ink(message)]
         fn driver_history(&self, name: String) -> Option<Vec<(BlockNumber, AccountId)>> {
             self.drivers_history.get(&name)
         }

--- a/crates/pink-drivers/system/lib.rs
+++ b/crates/pink-drivers/system/lib.rs
@@ -25,6 +25,12 @@ mod system {
         current: AccountId,
     }
 
+    /// A new administrator is added.
+    #[ink(event)]
+    pub struct AdministratorAdded {
+        user: AccountId,
+    }
+
     /// Pink's system contract.
     #[ink(storage)]
     pub struct System {
@@ -111,7 +117,9 @@ mod system {
         #[ink(message)]
         fn grant_admin(&mut self, contract_id: AccountId) -> Result<()> {
             self.ensure_owner()?;
-            self.administrators.insert(contract_id, &());
+            self.administrators.insert(&contract_id, &());
+            self.env()
+                .emit_event(AdministratorAdded { user: contract_id });
             Ok(())
         }
 

--- a/crates/pink-drivers/system/lib.rs
+++ b/crates/pink-drivers/system/lib.rs
@@ -16,6 +16,15 @@ mod system {
 
     use this_crate::{version_tuple, VersionTuple};
 
+    /// A new driver is set.
+    #[ink(event)]
+    pub struct DriverChanged {
+        #[ink(topic)]
+        name: String,
+        previous: Option<AccountId>,
+        current: AccountId,
+    }
+
     /// Pink's system contract.
     #[ink(storage)]
     pub struct System {
@@ -23,8 +32,12 @@ mod system {
         owner: AccountId,
         /// The administrators
         administrators: Mapping<AccountId, ()>,
-        /// The drivers
+        /// The drivers (deprecated)
         drivers: Mapping<String, AccountId>,
+        /// The drivers
+        drivers2: Mapping<String, (BlockNumber, AccountId)>,
+        /// The history of drivers
+        drivers_history: Mapping<String, Vec<(BlockNumber, AccountId)>>,
     }
 
     impl System {
@@ -34,6 +47,8 @@ mod system {
                 owner: Self::env().caller(),
                 administrators: Default::default(),
                 drivers: Default::default(),
+                drivers2: Default::default(),
+                drivers_history: Default::default(),
             }
         }
 
@@ -109,13 +124,36 @@ mod system {
                 }
                 _ => {}
             }
-            self.drivers.insert(name, &contract_id);
+
+            let previous = self.get_driver2(name.clone());
+            if let Some((block, previous)) = previous {
+                if previous == contract_id {
+                    return Ok(());
+                }
+                let mut history = self.drivers_history.get(&name).unwrap_or_default();
+                history.push((block, previous));
+                self.drivers_history.insert(&name, &history);
+            }
+            self.drivers2
+                .insert(&name, &(self.env().block_number(), contract_id));
+            self.env().emit_event(DriverChanged {
+                name,
+                previous: previous.map(|(_, id)| id),
+                current: contract_id,
+            });
             Ok(())
         }
 
         #[ink(message)]
         fn get_driver(&self, name: String) -> Option<AccountId> {
-            self.drivers.get(&name)
+            self.get_driver2(name).map(|(_, id)| id)
+        }
+
+        #[ink(message)]
+        fn get_driver2(&self, name: String) -> Option<(BlockNumber, AccountId)> {
+            self.drivers2
+                .get(&name)
+                .or_else(|| self.drivers.get(&name).map(|id| (0, id)))
         }
 
         #[ink(message)]
@@ -221,6 +259,11 @@ mod system {
         #[ink(message)]
         fn code_exists(&self, code_hash: [u8; 32], code_type: CodeType) -> bool {
             pink::ext().code_exists(code_hash.into(), code_type.is_sidevm())
+        }
+
+        #[ink(message)]
+        fn driver_history(&self, name: String) -> Option<Vec<(BlockNumber, AccountId)>> {
+            self.drivers_history.get(&name)
         }
     }
 

--- a/crates/pink-drivers/system/lib.rs
+++ b/crates/pink-drivers/system/lib.rs
@@ -10,6 +10,7 @@ pub use system::System;
 mod system {
     use super::pink;
     use alloc::string::String;
+    use alloc::vec::Vec;
     use ink::{codegen::Env, storage::Mapping};
     use pink::system::{CodeType, ContractDeposit, ContractDepositRef, DriverError, Error, Result};
     use pink::{HookPoint, PinkEnvironment};

--- a/crates/pink-drivers/tokenomic/lib.rs
+++ b/crates/pink-drivers/tokenomic/lib.rs
@@ -10,6 +10,13 @@ mod tokenomic {
 
     type Result<T> = core::result::Result<T, Error>;
 
+    #[ink(event)]
+    pub struct WeightChanged {
+        #[ink(topic)]
+        contract_id: AccountId,
+        weight: u32,
+    }
+
     #[ink(storage)]
     pub struct PhatTokenomic {}
 
@@ -40,7 +47,12 @@ mod tokenomic {
             const CENTS: Balance = 10_000_000_000;
             let system = SystemRef::instance();
             let weight = deposit / CENTS;
-            system.set_contract_weight(contract_id, weight.try_into().unwrap_or(u32::MAX))?;
+            let weight = weight.try_into().unwrap_or(u32::MAX);
+            system.set_contract_weight(contract_id.clone(), weight)?;
+            self.env().emit_event(WeightChanged {
+                contract_id,
+                weight
+            });
             Ok(())
         }
     }

--- a/crates/pink/pink-extension/src/system.rs
+++ b/crates/pink/pink-extension/src/system.rs
@@ -64,10 +64,12 @@ pub trait System {
     fn set_driver(&mut self, name: String, contract_id: AccountId) -> Result<()>;
 
     /// Get driver contract id for `name`.
-    ///
-    /// The caller must be the owner of the cluster or an administrator.
     #[ink(message)]
     fn get_driver(&self, name: String) -> Option<AccountId>;
+
+    /// Get driver contract id for `name` and the set block number.
+    #[ink(message)]
+    fn get_driver2(&self, name: String) -> Option<(crate::BlockNumber, AccountId)>;
 
     /// Deploy a sidevm instance attached to a given contract.
     ///
@@ -125,6 +127,10 @@ pub trait System {
     /// Check if the code is already uploaded to the cluster with given code hash.
     #[ink(message)]
     fn code_exists(&self, code_hash: Hash, code_type: CodeType) -> bool;
+
+    /// Get the history of given driver.
+    #[ink(message)]
+    fn driver_history(&self, name: String) -> Option<Vec<(crate::BlockNumber, AccountId)>>;
 }
 
 /// Errors that can occur upon calling a driver contract.

--- a/crates/pink/pink-extension/src/system.rs
+++ b/crates/pink/pink-extension/src/system.rs
@@ -3,6 +3,7 @@
 use pink_extension_macro as pink;
 
 use alloc::string::String;
+use alloc::vec::Vec;
 use scale::{Decode, Encode};
 
 use crate::{AccountId, Balance, Hash};

--- a/crates/pink/pink-extension/src/system.rs
+++ b/crates/pink/pink-extension/src/system.rs
@@ -128,6 +128,10 @@ pub trait System {
     #[ink(message)]
     fn code_exists(&self, code_hash: Hash, code_type: CodeType) -> bool;
 
+    /// Get the current code hash of given contract.
+    #[ink(message)]
+    fn code_hash(&self, account: AccountId) -> Option<ink::primitives::Hash>;
+
     /// Get the history of given driver.
     #[ink(message)]
     fn driver_history(&self, name: String) -> Option<Vec<(crate::BlockNumber, AccountId)>>;


### PR DESCRIPTION
Split from [pink: Add API code_history](https://github.com/Phala-Network/phala-blockchain/pull/1287).
We might still want this feature since it's low overhead and make it more convenient to audit the drivers.