### PR TITLE
e2e: Fix delegate call types

### DIFF
--- a/e2e/contracts/check_system/Cargo.toml
+++ b/e2e/contracts/check_system/Cargo.toml
@@ -15,6 +15,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 pink-extension = { version = "0.4", default-features = false, path = "../../../crates/pink/pink-extension" }
+phat_js = { version = "0.1.1", default-features = false }
 
 [dependencies.indeterministic_functions]
 version = "0.1"
@@ -34,6 +35,7 @@ default = ["std"]
 std = [
     "ink/std",
     "scale/std",
+    "phat_js/std",
     "scale-info/std",
     "pink-extension/std",
     "indeterministic_functions/std",


### PR DESCRIPTION
ink 4.2.1 introduced a breaking change that changed the delegate call return type. That causes our delegate calls to break.
This PR adapts the new ABI.