### PR TITLE
sidevm: Allow writing to stdout and stderr

### DIFF
--- a/crates/sidevm/host-runtime/src/env.rs
+++ b/crates/sidevm/host-runtime/src/env.rs
@@ -336,6 +336,17 @@ impl Env {
     pub fn is_stifled(&self, store: &mut impl AsStoreMut) -> bool {
         self.inner.lock().unwrap().is_stifled(store)
     }
+
+    pub fn memory(&self) -> Memory {
+        self.inner
+            .lock()
+            .unwrap()
+            .memory
+            .0
+            .as_ref()
+            .expect("BUG: missing memory in env")
+            .clone()
+    }
 }
 
 impl<'a, 'b> env::OcallEnv for FnEnvMut<'a, &'b mut EnvInner> {

--- a/crates/sidevm/host-runtime/src/env/wasi_env.rs
+++ b/crates/sidevm/host-runtime/src/env/wasi_env.rs
@@ -37,7 +37,7 @@ macro_rules! wasi_try {
 }
 
 /// Like the `try!` macro or `?` syntax: returns the value if the computation
-/// succeeded or returns the error value. Results are wrapped in an Ok
+/// succeeded or returns the error value. Results are wrapped as an `Ok(errno)`.
 macro_rules! wasi_try_ok {
     ($expr:expr) => {{
         let res: Result<_, Errno> = $expr;
@@ -57,7 +57,7 @@ macro_rules! wasi_try_mem_ok {
     }};
 }
 
-/// Like `wasi_try` but converts a `MemoryAccessError` to a `wasi::Errno`.
+/// Like `wasi_try` but allow the inner block to use `?` syntax on a Result<_, Errno>.
 macro_rules! wasi_try_block_ok {
     ($expr:expr) => {{
         wasi_try_ok!(|| -> Result<_, Errno> { Ok($expr) }())

--- a/crates/sidevm/host-runtime/src/env/wasi_env.rs
+++ b/crates/sidevm/host-runtime/src/env/wasi_env.rs
@@ -392,6 +392,7 @@ pub fn fd_tell(
     Errno::Nosys
 }
 
+#[tracing::instrument(skip_all, fields(fd = fd))]
 pub fn fd_write(
     ctx: FunctionEnvMut<WasiEnv>,
     fd: wasi::Fd,
@@ -428,7 +429,11 @@ fn fd_write_stdio(
         };
         let bytes = buf.as_ref();
         for line in String::from_utf8_lossy(&bytes[..bytes.len().min(1024)]).lines() {
-            info!(fd, "guest write: {}", line);
+            if fd == 2 {
+                error!(target: "sidevm", "{}", line);
+            } else {
+                info!(target: "sidevm", "{}", line);
+            }
         }
         written += buf.len();
     }

--- a/crates/sidevm/host/Cargo.toml
+++ b/crates/sidevm/host/Cargo.toml
@@ -10,7 +10,7 @@ sidevm-host-runtime = { path = "../host-runtime", features = [
 ] }
 tokio = { version = "1.17.0", features = ["full"] }
 log = "0.4"
-env_logger = "0.9.0"
+tracing-subscriber = "0.3"
 anyhow = "1.0.69"
 clap = { version = "4.0.32", features = ["derive"] }
 once_cell = "1"

--- a/crates/sidevm/host/src/main.rs
+++ b/crates/sidevm/host/src/main.rs
@@ -17,6 +17,9 @@ pub struct Args {
     workers: usize,
     /// The WASM program to run
     program: Option<String>,
+    /// Max memory pages
+    #[arg(long, default_value_t = 256)]
+    max_memory_pages: u32,
 }
 
 fn simple_cache() -> DynCacheOps {
@@ -56,7 +59,7 @@ fn simple_cache() -> DynCacheOps {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
     if std::env::var("ROCKET_PORT").is_err() {
         std::env::set_var("ROCKET_PORT", "8003");
     }

--- a/crates/sidevm/host/src/web_api.rs
+++ b/crates/sidevm/host/src/web_api.rs
@@ -63,7 +63,7 @@ impl App {
             .spawner
             .start(
                 &wasm_bytes,
-                1024,
+                inner.args.max_memory_pages,
                 vmid,
                 inner.args.gas_per_breath,
                 crate::simple_cache(),


### PR DESCRIPTION
@shelvenzhou recently found that the log_server sometimes panicked with the following error:
<img width="1364" alt="image" src="https://github.com/Phala-Network/phala-blockchain/assets/6442159/0ecf627d-7656-4f61-9179-a6be6a11a208">

The error message is misleading. The error itself was raised from the fn `std::io::Write::write_all`, but there isn't any code in our source call that fn. I've checked the wasm code with `wasm2wat`.

After some investigating, I finally found the error is raised inside the oom_handler [here](https://github.com/rust-lang/rust/blob/7f01f030613fb6ffe06d5f5791a273d384cd6f55/library/std/src/alloc.rs#L343) in the libstd. The oom_handler tries the write some message to stderr rather than panic when targeting wasm, but failed to write to the fd because our runtime doesn't support for writing data to any fd.

This PR allow the guest to write to stdout and stderr, only for showing this kind of errors. It would show the following log message when OOM with this PR:
```
2023-06-26T04:54:25.778793Z ERROR sidevm{id=000000000000}:fd_write{fd=2}: sidevm: memory allocation of 
2023-06-26T04:54:25.778858Z ERROR sidevm{id=000000000000}:fd_write{fd=2}: sidevm: 3594
2023-06-26T04:54:25.778864Z ERROR sidevm{id=000000000000}:fd_write{fd=2}: sidevm:  bytes failed
```
