### PR TITLE
Fix the OOM in log_server

### DIFF
--- a/crates/pink-drivers/log_server/sideprog/Cargo.toml
+++ b/crates/pink-drivers/log_server/sideprog/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 log = "0.4.16"
 once_cell = "1.10.0"
 sidevm = { version = "0.1", path = "../../../sidevm/sidevm" }
+phala-allocator = { version = "0.1", path = "../../../phala-allocator" }
 tokio = { version = "1", features = ["macros", "io-util"] }
 futures = "0.3"
 log_buffer = "1.0"

--- a/crates/pink-drivers/log_server/sideprog/src/buffer.rs
+++ b/crates/pink-drivers/log_server/sideprog/src/buffer.rs
@@ -218,7 +218,7 @@ impl Buffer {
             message = SerMessage::TooLarge;
             size = message.size();
         }
-        while self.capacity < self.current_size + size {
+        while self.capacity < crate::allocator::mem_usage() + size {
             self.pop();
         }
         self.current_size += size;

--- a/crates/pink-drivers/log_server/sideprog/src/buffer.rs
+++ b/crates/pink-drivers/log_server/sideprog/src/buffer.rs
@@ -279,10 +279,11 @@ mod tests {
         buffer.push(SystemMessage::PinkLog {
             block_number: 0,
             contract: [1u8; 32],
-            in_query: true,
             timestamp_ms: 1,
             level: 0,
             message: "hello".into(),
+            entry: [1u8; 32],
+            exec_mode: "query".into(),
         });
         buffer.push(SystemMessage::PinkEvent {
             block_number: 1,

--- a/crates/pink-drivers/log_server/sideprog/src/buffer.rs
+++ b/crates/pink-drivers/log_server/sideprog/src/buffer.rs
@@ -5,7 +5,7 @@ pub struct Buffer {
     next_sequence: u64,
     capacity: usize,
     current_size: usize,
-    records: VecDeque<Record>,
+    records: VecDeque<Box<Record>>,
 }
 
 struct Record {
@@ -222,20 +222,20 @@ impl Buffer {
             self.pop();
         }
         self.current_size += size;
-        self.records.push_back(Record {
+        self.records.push_back(Box::new(Record {
             contract_id,
             entry_contract,
             message: Message::Origin(message),
             size,
             sequence: self.next_sequence,
-        });
+        }));
         self.next_sequence += 1;
     }
 
     fn pop(&mut self) -> Option<Record> {
         let rec = self.records.pop_front()?;
         self.current_size -= rec.size;
-        Some(rec)
+        Some(*rec)
     }
 
     pub fn get_records(&mut self, contract: &str, from: u64, count: u64) -> String {

--- a/crates/pink-drivers/log_server/sideprog/src/lib.rs
+++ b/crates/pink-drivers/log_server/sideprog/src/lib.rs
@@ -96,3 +96,15 @@ async fn main() {
         app.log_buffer.borrow_mut().push(message);
     }
 }
+
+mod allocator {
+    use phala_allocator::StatSizeAllocator;
+    use std::alloc::System;
+
+    #[global_allocator]
+    pub static ALLOC: StatSizeAllocator<System> = StatSizeAllocator::new(System);
+
+    pub fn mem_usage() -> usize {
+        ALLOC.stats().current
+    }
+}


### PR DESCRIPTION
As @shelvenzhou reported, the sidevm of the contract `log_server` panics due to OOM. 
<img width="1364" alt="image" src="https://github.com/Phala-Network/phala-blockchain/assets/6442159/0ecf627d-7656-4f61-9179-a6be6a11a208">
See #1325 for the misleading of the error message.

I've checked it with random test logs and didn't see memory leak in the sidevm program.

The size of logs was limited with a soft bound of 8MB. However, we **under-estimated** the current log size with a rough formula.
Counting in the overhead, the actual memory cost was **far more than 8MB**. And a large tmp memory blob is required when a query requests all log records. This could make the guest run out of memory.

This PR makes 2 improvements:
- Using the metric reported from the memory allocator as the records size bounds. This should be more accurate than the estimated one before.
- Boxing each single log record. This could reduce the overhead of the VecDeque container.