### PR TITLE
Merge deposit() and contract call() into a single call

### DIFF
--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -641,15 +641,13 @@ impl Cluster {
                     context::using(&mut ctx, move || {
                         context::using_entry_contract(contract_id.clone(), || {
                             let mut runtime = self.runtime_mut(log_handler);
-                            if deposit > 0 {
-                                runtime.deposit(origin.clone(), deposit);
-                            }
                             let args = TransactionArguments {
                                 origin,
                                 transfer,
                                 gas_limit: WEIGHT_REF_TIME_PER_SECOND * 10,
                                 gas_free: true,
                                 storage_deposit_limit: None,
+                                deposit,
                             };
                             let ink_result = runtime.call(contract_id, input_data, mode, args);
                             let effects = if mode.is_estimating() {
@@ -721,15 +719,13 @@ impl Cluster {
                 let log_handler = context.log_handler.clone();
                 context::using(&mut ctx, move || {
                     let mut runtime = self.runtime_mut(log_handler);
-                    if deposit > 0 {
-                        runtime.deposit(origin.clone(), deposit);
-                    }
                     let args = TransactionArguments {
                         origin,
                         transfer,
                         gas_limit: WEIGHT_REF_TIME_PER_SECOND * 10,
                         gas_free: true,
                         storage_deposit_limit: None,
+                        deposit,
                     };
                     let ink_result = runtime.instantiate(
                         code_hash,
@@ -778,6 +774,7 @@ impl Cluster {
                     gas_limit,
                     gas_free,
                     storage_deposit_limit,
+                    deposit: 0,
                 };
 
                 let mut runtime = self.runtime_mut(context.log_handler.clone());

--- a/crates/phactory/src/contracts/support.rs
+++ b/crates/phactory/src/contracts/support.rs
@@ -209,6 +209,7 @@ impl Contract {
             gas_free: false,
             storage_deposit_limit: None,
             gas_limit,
+            deposit: 0,
         };
         let mut handle = env.contract_cluster.runtime_mut(env.log_handler.clone());
         _ = handle.call(

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -1293,6 +1293,7 @@ impl<Platform: pal::Platform> System<Platform> {
                             gas_limit,
                             gas_free: false,
                             storage_deposit_limit,
+                            deposit: 0,
                         };
                         let mut runtime = cluster.runtime_mut(log_handler.clone());
                         let _result = runtime.instantiate(

--- a/crates/pink/capi/src/v1/mod.rs
+++ b/crates/pink/capi/src/v1/mod.rs
@@ -48,6 +48,7 @@ pub mod ecall {
         pub gas_limit: Weight,
         pub gas_free: bool,
         pub storage_deposit_limit: Option<Balance>,
+        pub deposit: Balance,
     }
 
     #[derive(Encode, Decode, Clone, Debug)]

--- a/crates/pink/runner/tests/test_pink_contract.rs
+++ b/crates/pink/runner/tests/test_pink_contract.rs
@@ -20,6 +20,7 @@ fn tx_args() -> TransactionArguments {
         gas_limit: Weight::MAX,
         gas_free: true,
         storage_deposit_limit: None,
+        deposit: 0,
     }
 }
 

--- a/crates/pink/runtime/src/contract.rs
+++ b/crates/pink/runtime/src/contract.rs
@@ -152,6 +152,7 @@ pub fn instantiate(
         gas_limit,
         storage_deposit_limit,
         gas_free,
+        deposit: _,
     } = args;
     let gas_limit = Weight::from_parts(gas_limit, 0).set_proof_size(u64::MAX);
     let result = contract_tx(origin.clone(), gas_limit, gas_free, move || {
@@ -193,6 +194,7 @@ pub fn bare_call(
         gas_limit,
         gas_free,
         storage_deposit_limit,
+        deposit: _,
     } = tx_args;
     let gas_limit = Weight::from_parts(gas_limit, 0).set_proof_size(u64::MAX);
     let determinism = if mode.deterministic_required() {


### PR DESCRIPTION
This change is picked from #1265. Since #1265 would not be released in pruntime v2.0.2, we may want to pick this runtime ABI breaking change out to release in advance.

In pink query, caller can optionally fill an arbitrary number the the arg `deposit` which would be deposited to the caller account before calling the contract so that the runtime can finish the gas estimation even the caller doesn't have enough balance in the cluster to pay the execution.

So there were two call to the pink runtime if non-zero deposit was given:
- `runtime.deposit(amout)`
- `runtime.call(contract_id)`

There is no problem with in memory trie storage. However,  for kvdb backend in #1265 we don't implement an extra cache layer for the DB, the effect of the first call `runtime.deposit()` would be dropped at the time calling `runtime.call()`.

The simplest solution for this issue it merge the to runtime calls into one, that's what this PR does.