### PR TITLE
pink: Enlarge storage value limit to 1MB

### DIFF
--- a/crates/pink/runtime/src/runtime.rs
+++ b/crates/pink/runtime/src/runtime.rs
@@ -128,6 +128,7 @@ parameter_types! {
         schedule.limits.memory_pages = 4 * MB;
         schedule.instruction_weights.fallback = 8000;
         schedule.limits.runtime_memory = 2048 * 1024 * 1024; // For unittests
+        schedule.limits.payload_len = 1024 * 1024; // Max size for storage value
         schedule
     };
 }

--- a/crates/pink/runtime/src/snapshots/pink__runtime__detect_parameter_changes.snap
+++ b/crates/pink/runtime/src/snapshots/pink__runtime__detect_parameter_changes.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pink/runtime/src/runtime.rs
-assertion_line: 157
+assertion_line: 160
 expression: "(<PinkRuntime as frame_system::Config>::BlockWeights::get(),\n    <PinkRuntime as Config>::Schedule::get(),\n    <PinkRuntime as Config>::DefaultDepositLimit::get(),\n    <PinkRuntime as Config>::MaxCodeLen::get(),\n    <PinkRuntime as Config>::MaxStorageKeyLen::get())"
 ---
 (
@@ -83,7 +83,7 @@ expression: "(<PinkRuntime as frame_system::Config>::BlockWeights::get(),\n    <
             table_size: 4096,
             br_table_size: 256,
             subject_len: 32,
-            payload_len: 16384,
+            payload_len: 1048576,
             runtime_memory: 2147483648,
         },
         instruction_weights: InstructionWeights {


### PR DESCRIPTION
The default value is 16K. So it couldn't store larger things such as JS code blobs.