### PR TITLE
pruntime: Fix crash due to HTTP ABI incompatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8780,7 +8780,7 @@ dependencies = [
 
 [[package]]
 name = "pink-subrpc"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base58",
  "hex",


### PR DESCRIPTION
pruntime crashed on PoC5:
![image](https://github.com/Phala-Network/phala-blockchain/assets/6442159/f9b04d75-e03f-4992-8cbd-c8a282aa4254)
That was because we added some variants in the `enum HttpReqeustError` but the `libpink.so.1.0` is compiled using the old definition which can not decode the new variants. That's what the ABI incompatibility means.

This PR converts the new variants to HttpResponse before passing it the to pink runtime.