### PR TITLE
logserver: Support for query with block number and so on

### DIFF
--- a/crates/pink-drivers/log_server/Cargo.toml
+++ b/crates/pink-drivers/log_server/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 [package]
 name = "log_server"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["[your_name] <[your_email]>"]
 edition = "2018"
 resolver = "2"

--- a/crates/pink-drivers/log_server/sideprog/Cargo.toml
+++ b/crates/pink-drivers/log_server/sideprog/Cargo.toml
@@ -6,7 +6,7 @@ strip = true
 [package]
 edition = "2021"
 name = "sideprog"
-version = "0.1.0"
+version = "0.1.2"
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/pink-drivers/log_server/sideprog/Cargo.toml
+++ b/crates/pink-drivers/log_server/sideprog/Cargo.toml
@@ -25,6 +25,7 @@ chrono = { version = "0.4.22" }
 scale = { package = "parity-scale-codec", version = "3" }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
+this-crate = "0.1.0"
 
 [dev-dependencies]
 insta = "1.21.0"

--- a/crates/pink-drivers/log_server/sideprog/src/buffer.rs
+++ b/crates/pink-drivers/log_server/sideprog/src/buffer.rs
@@ -253,7 +253,7 @@ impl Buffer {
     pub fn get_records(
         &mut self,
         contract: &str,
-        from: u64,
+        from: i64,
         count: u64,
         block_number: Option<u32>,
     ) -> String {
@@ -261,6 +261,11 @@ impl Buffer {
         let mut result: String = "{\"records\":[".into();
         let mut n = 0_u64;
         let mut next_seq = 0_u64;
+        let from = if from < 0 {
+            self.next_sequence + from as u64
+        } else {
+            from as u64
+        };
         for rec in self.records.iter_mut() {
             next_seq = rec.sequence + 1;
             if rec.sequence < from {

--- a/crates/pink-drivers/log_server/sideprog/src/lib.rs
+++ b/crates/pink-drivers/log_server/sideprog/src/lib.rs
@@ -40,7 +40,9 @@ async fn query_serve(app: AppState) {
             from: u64,
             #[serde(default)]
             count: u64,
-        }
+            #[serde(default, rename="blockNumber")]
+            block_number: Option<u32>,
+        },
     }
 
     loop {
@@ -51,6 +53,7 @@ async fn query_serve(app: AppState) {
                 contract,
                 from,
                 count,
+                block_number,
             } = match serde_json::from_slice(&query.payload) {
                 Err(_) => {
                     info!("Invalid input");
@@ -61,7 +64,7 @@ async fn query_serve(app: AppState) {
             };
             let reply = app.log_buffer
                 .borrow_mut()
-                .get_records(&contract, from, count);
+                .get_records(&contract, from, count, block_number);
             let _ = query.reply_tx.send(reply.as_bytes());
         } else {
             info!("Query channel closed");

--- a/crates/pink-drivers/log_server/sideprog/src/lib.rs
+++ b/crates/pink-drivers/log_server/sideprog/src/lib.rs
@@ -36,8 +36,9 @@ async fn query_serve(app: AppState) {
         GetLog {
             #[serde(default)]
             contract: String,
+            /// Negative value means counting from the end back.
             #[serde(default)]
-            from: u64,
+            from: i64,
             #[serde(default)]
             count: u64,
             #[serde(default, rename="blockNumber")]

--- a/crates/pink-drivers/log_server/sideprog/src/snapshots/sideprog__buffer__tests__it_can_filter_by_contract_id.snap
+++ b/crates/pink-drivers/log_server/sideprog/src/snapshots/sideprog__buffer__tests__it_can_filter_by_contract_id.snap
@@ -1,7 +1,7 @@
 ---
 source: src/buffer.rs
-assertion_line: 297
-expression: "pretty(&buffer.get_records(&hex(&contract), 0, 0))"
+assertion_line: 372
+expression: "pretty(&buffer.get_records(&hex(&contract), 0, 0, None))"
 ---
 {
   "next": 3,
@@ -9,7 +9,8 @@ expression: "pretty(&buffer.get_records(&hex(&contract), 0, 0))"
     {
       "blockNumber": 0,
       "contract": "0x0101010101010101010101010101010101010101010101010101010101010101",
-      "inQuery": true,
+      "entry": "0x0101010101010101010101010101010101010101010101010101010101010101",
+      "execMode": "query",
       "level": 0,
       "message": "hello",
       "sequence": 0,

--- a/crates/pink-drivers/log_server/sideprog/src/snapshots/sideprog__buffer__tests__it_can_query_with_block_number.snap
+++ b/crates/pink-drivers/log_server/sideprog/src/snapshots/sideprog__buffer__tests__it_can_query_with_block_number.snap
@@ -1,0 +1,26 @@
+---
+source: src/buffer.rs
+assertion_line: 415
+expression: "pretty(&buffer.get_records(\"\", 1, 10, Some(42)))"
+---
+{
+  "next": 5,
+  "records": [
+    {
+      "blockNumber": 42,
+      "contract": "0x0101010101010101010101010101010101010101010101010101010101010101",
+      "payload": "0x01",
+      "sequence": 3,
+      "topics": [],
+      "type": "Event"
+    },
+    {
+      "blockNumber": 42,
+      "contract": "0x0202020202020202020202020202020202020202020202020202020202020202",
+      "payload": "0x02",
+      "sequence": 4,
+      "topics": [],
+      "type": "Event"
+    }
+  ]
+}

--- a/crates/pink-drivers/log_server/sideprog/src/snapshots/sideprog__buffer__tests__it_can_query_with_count_limit.snap
+++ b/crates/pink-drivers/log_server/sideprog/src/snapshots/sideprog__buffer__tests__it_can_query_with_count_limit.snap
@@ -1,7 +1,7 @@
 ---
 source: src/buffer.rs
-assertion_line: 310
-expression: "pretty(&buffer.get_records(\"\".into(), 0, 1))"
+assertion_line: 385
+expression: "pretty(&buffer.get_records(\"\".into(), 0, 1, None))"
 ---
 {
   "next": 1,
@@ -9,7 +9,8 @@ expression: "pretty(&buffer.get_records(\"\".into(), 0, 1))"
     {
       "blockNumber": 0,
       "contract": "0x0101010101010101010101010101010101010101010101010101010101010101",
-      "inQuery": true,
+      "entry": "0x0101010101010101010101010101010101010101010101010101010101010101",
+      "execMode": "query",
       "level": 0,
       "message": "hello",
       "sequence": 0,

--- a/crates/pink-drivers/log_server/sideprog/src/snapshots/sideprog__buffer__tests__it_can_query_with_negative_from.snap
+++ b/crates/pink-drivers/log_server/sideprog/src/snapshots/sideprog__buffer__tests__it_can_query_with_negative_from.snap
@@ -1,0 +1,18 @@
+---
+source: src/buffer.rs
+assertion_line: 434
+expression: "pretty(&buffer.get_records(\"\", -1, 10, Some(42)))"
+---
+{
+  "next": 5,
+  "records": [
+    {
+      "blockNumber": 42,
+      "contract": "0x0202020202020202020202020202020202020202020202020202020202020202",
+      "payload": "0x02",
+      "sequence": 4,
+      "topics": [],
+      "type": "Event"
+    }
+  ]
+}

--- a/crates/pink-drivers/log_server/sideprog/src/snapshots/sideprog__buffer__tests__it_works.snap
+++ b/crates/pink-drivers/log_server/sideprog/src/snapshots/sideprog__buffer__tests__it_works.snap
@@ -1,7 +1,7 @@
 ---
 source: src/buffer.rs
-assertion_line: 284
-expression: "pretty(&buffer.get_records(\"\".into(), 0, 0))"
+assertion_line: 359
+expression: "pretty(&buffer.get_records(\"\".into(), 0, 0, None))"
 ---
 {
   "next": 3,
@@ -9,7 +9,8 @@ expression: "pretty(&buffer.get_records(\"\".into(), 0, 0))"
     {
       "blockNumber": 0,
       "contract": "0x0101010101010101010101010101010101010101010101010101010101010101",
-      "inQuery": true,
+      "entry": "0x0101010101010101010101010101010101010101010101010101010101010101",
+      "execMode": "query",
       "level": 0,
       "message": "hello",
       "sequence": 0,


### PR DESCRIPTION
This PR implements the feature requests from @Leechael.
- Setting the start sequence relative-to the `next_sequence`.
    The filter argument `from` now can be negative which means counting back from the end like the list indexing in Python.
    For example given `next_sequence = 100`, when `from = -2` means `from = 98`.
- Filtering records with block number if given.
    A new argument `blockNumber` is added to the `GetLog` action.
- Adding an action named `GetInfo` which returns infomations as shown below:
    ```json
    {
      "currentNumberOfRecords": 4,
      "estimatedCurrentSize": 675,
      "memoryCapacity": 1048576,
      "memoryUsage": 22519,
      "nextSequence": 4,
      "programVersion": [0, 1, 0]
    }
    ```