### PR TITLE
pherry: Fix missing handover proofs

### DIFF
--- a/crates/phaxt/src/chain_api.rs
+++ b/crates/phaxt/src/chain_api.rs
@@ -171,4 +171,22 @@ impl ChainApi {
         };
         Ok(endpoints)
     }
+
+    pub async fn storage_keys(&self, prefix: &[u8], hash: Option<Hash>) -> Result<Vec<Vec<u8>>> {
+        let page = 100;
+        let mut keys: Vec<Vec<u8>> = vec![];
+
+        loop {
+            let start_key = keys.last().map(|k| &k[..]);
+            let result = self
+                .rpc()
+                .storage_keys_paged(prefix, page, start_key, hash)
+                .await?;
+            if result.is_empty() {
+                break;
+            }
+            result.into_iter().for_each(|key| keys.push(key.0));
+        }
+        Ok(keys)
+    }
 }

--- a/standalone/pherry/src/chain_client.rs
+++ b/standalone/pherry/src/chain_client.rs
@@ -34,10 +34,15 @@ pub async fn read_proof(
 pub async fn read_proofs(
     api: &RelaychainApi,
     hash: Option<Hash>,
-    storage_keys: Vec<&[u8]>,
+    storage_keys: impl IntoIterator<Item = &[u8]>,
 ) -> Result<StorageProof> {
+    let mut keys = vec![];
+    for prefix in storage_keys {
+        let full_keys = api.storage_keys(prefix, hash).await?;
+        keys.extend(full_keys);
+    }
     api.rpc()
-        .read_proof(storage_keys, hash)
+        .read_proof(keys.iter().map(|k| &k[..]), hash)
         .await
         .map(raw_proof)
         .map_err(Into::into)

--- a/standalone/pherry/src/chain_client.rs
+++ b/standalone/pherry/src/chain_client.rs
@@ -37,6 +37,7 @@ pub async fn read_proofs(
     storage_keys: impl IntoIterator<Item = &[u8]>,
 ) -> Result<StorageProof> {
     let mut keys = vec![];
+    // Retrieve the actual storage keys in case they are prefixed
     for prefix in storage_keys {
         let full_keys = api.storage_keys(prefix, hash).await?;
         keys.extend(full_keys);

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -431,6 +431,9 @@ async fn try_load_handover_proof(pr: &PrClient, api: &ParachainApi) -> Result<()
     .await
     .context("Failed to get handover proof")?;
     info!("Loading handover proof at {current_block}");
+    for p in &proof {
+        info!("key=0x{}", hex::encode(sp_core::blake2_256(p)));
+    }
     pr.load_storage_proof(prpc::StorageProof { proof }).await?;
     Ok(())
 }


### PR DESCRIPTION
Some proofs were missing when pherry loading proofs with `--load-handover-proof` to a pRuntime with `--safe-mode-level=2`.
I remember we have tested this feature before. Not sure whether it is because of a behavior change in the phala-node.

cc @jasl 