### PR TITLE
pruntime: Configurable parallelism for query

### DIFF
--- a/crates/phala-scheduler/src/request_scheduler.rs
+++ b/crates/phala-scheduler/src/request_scheduler.rs
@@ -17,6 +17,12 @@ pub struct RequestScheduler<FlowId: FlowIdType> {
     inner: Arc<Mutex<SchedulerInner<FlowId>>>,
 }
 
+impl<Fid: FlowIdType> Default for RequestScheduler<Fid> {
+    fn default() -> Self {
+        Self::new(32, 8)
+    }
+}
+
 pub struct DumpInfo<FlowId> {
     pub backlog: Vec<(FlowId, VirtualTime)>,
     pub flows: Vec<(FlowId, VirtualTime, VirtualTime)>,


### PR DESCRIPTION
Sorry, the parallelism of `query scheduler` was hard coded to `8`.
This PR make it respect to the `--cores` paramenter as the `sidevm scheduler` did.