### PR TITLE
pruntime: Reject old version of checkpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9385,7 +9385,7 @@ dependencies = [
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-trie",
- "this-crate 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "this-crate",
  "thiserror",
  "tokio",
  "tracing",
@@ -10144,7 +10144,7 @@ dependencies = [
  "parity-scale-codec",
  "pink-extension-macro",
  "scale-info",
- "this-crate 0.1.0",
+ "this-crate",
 ]
 
 [[package]]
@@ -15633,12 +15633,6 @@ version = "0.1.0"
 dependencies = [
  "konst",
 ]
-
-[[package]]
-name = "this-crate"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c3dac231fac5770597ae4670029b06ea5adab46e2fd192838e9a77007ec656"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
+name = "const_panic"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6051f239ecec86fde3410901ab7860d458d160371533842974fc61f96d15879b"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6264,6 +6270,33 @@ dependencies = [
  "hash256-std-hasher",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "konst"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030400e39b2dff8beaa55986a17e0014ad657f569ca92426aafcb5e8e71faee7"
+dependencies = [
+ "const_panic",
+ "konst_kernel",
+ "konst_proc_macros",
+ "typewit",
+]
+
+[[package]]
+name = "konst_kernel"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3376133edc39f027d551eb77b077c2865a0ef252b2e7d0dd6b6dc303db95d8b5"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e28ab1dc35e09d60c2b8c90d12a9a8d9666c876c10a3739a3196db0103b6043"
 
 [[package]]
 name = "kv-log-macro"
@@ -15596,6 +15629,9 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 [[package]]
 name = "this-crate"
 version = "0.1.0"
+dependencies = [
+ "konst",
+]
 
 [[package]]
 name = "thiserror"
@@ -16326,6 +16362,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "typewit"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5cee357cc77d1e02f10a3e6c4e13b8462fafab05998b62d331b7d9485589ff"
 
 [[package]]
 name = "ubyte"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9317,7 +9317,7 @@ dependencies = [
 
 [[package]]
 name = "phactory"
-version = "0.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9385,6 +9385,7 @@ dependencies = [
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-trie",
+ "this-crate 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
  "tracing",
@@ -10143,7 +10144,7 @@ dependencies = [
  "parity-scale-codec",
  "pink-extension-macro",
  "scale-info",
- "this-crate",
+ "this-crate 0.1.0",
 ]
 
 [[package]]
@@ -15632,6 +15633,12 @@ version = "0.1.0"
 dependencies = [
  "konst",
 ]
+
+[[package]]
+name = "this-crate"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c3dac231fac5770597ae4670029b06ea5adab46e2fd192838e9a77007ec656"
 
 [[package]]
 name = "thiserror"

--- a/crates/phactory/Cargo.toml
+++ b/crates/phactory/Cargo.toml
@@ -81,7 +81,7 @@ environmental = "1"
 once_cell = "1"
 im = "15"
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-this-crate = "0.1"
+this-crate = { path = "../this-crate" }
 
 [dev-dependencies]
 insta = "1.7.2"

--- a/crates/phactory/Cargo.toml
+++ b/crates/phactory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phactory"
-version = "0.0.1"
+version = "2.1.0"
 edition = "2018"
 resolver = "2"
 
@@ -81,6 +81,7 @@ environmental = "1"
 once_cell = "1"
 im = "15"
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+this-crate = "0.1"
 
 [dev-dependencies]
 insta = "1.7.2"

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -905,3 +905,7 @@ fn try_decode_hex(hex_str: &str) -> Result<Vec<u8>, hex::FromHexError> {
 pub fn public_data_dir(storage_path: impl AsRef<Path>) -> PathBuf {
     storage_path.as_ref().to_path_buf().join("public")
 }
+
+pub const fn version_str() -> &'static str {
+    this_crate::version_str!()
+}

--- a/crates/this-crate/Cargo.toml
+++ b/crates/this-crate/Cargo.toml
@@ -8,3 +8,4 @@ repository = "https://github.com/Phala-Network/phala-blockchain"
 authors = ["Kevin Wang <wy721@qq.com>"]
 
 [dependencies]
+konst = "0.3"

--- a/crates/this-crate/src/lib.rs
+++ b/crates/this-crate/src/lib.rs
@@ -19,6 +19,7 @@
 //! the Rust standard library.
 //!
 #![no_std]
+pub use konst;
 
 /// A tuple representing the version of the crate as (major, minor, patch).
 pub type VersionTuple = (u16, u16, u16);
@@ -52,10 +53,11 @@ macro_rules! version_str {
 #[macro_export]
 macro_rules! version_tuple {
     () => {{
-        let major = env!("CARGO_PKG_VERSION_MAJOR").parse::<u16>().unwrap_or(0);
-        let minor = env!("CARGO_PKG_VERSION_MINOR").parse::<u16>().unwrap_or(0);
-        let patch = env!("CARGO_PKG_VERSION_PATCH").parse::<u16>().unwrap_or(0);
-        (major, minor, patch)
+        use $crate::konst::{primitive::parse_u16, unwrap_ctx};
+        const MAJOR: u16 = unwrap_ctx!(parse_u16(env!("CARGO_PKG_VERSION_MAJOR")));
+        const MINOR: u16 = unwrap_ctx!(parse_u16(env!("CARGO_PKG_VERSION_MINOR")));
+        const PATCH: u16 = unwrap_ctx!(parse_u16(env!("CARGO_PKG_VERSION_PATCH")));
+        (MAJOR, MINOR, PATCH)
     }};
 }
 

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -1158,6 +1158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
+name = "const_panic"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6051f239ecec86fde3410901ab7860d458d160371533842974fc61f96d15879b"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3832,6 +3838,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030400e39b2dff8beaa55986a17e0014ad657f569ca92426aafcb5e8e71faee7"
+dependencies = [
+ "const_panic",
+ "konst_kernel",
+ "konst_proc_macros",
+ "typewit",
+]
+
+[[package]]
+name = "konst_kernel"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3376133edc39f027d551eb77b077c2865a0ef252b2e7d0dd6b6dc303db95d8b5"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e28ab1dc35e09d60c2b8c90d12a9a8d9666c876c10a3739a3196db0103b6043"
+
+[[package]]
 name = "lalrpop"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5572,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "phactory"
-version = "0.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5635,6 +5668,7 @@ dependencies = [
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-trie",
+ "this-crate 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
  "tracing",
@@ -6064,7 +6098,7 @@ dependencies = [
  "parity-scale-codec",
  "pink-extension-macro",
  "scale-info",
- "this-crate",
+ "this-crate 0.1.0",
 ]
 
 [[package]]
@@ -6471,6 +6505,7 @@ dependencies = [
  "base64 0.13.0",
  "clap",
  "hex_fmt",
+ "konst",
  "lazy_static",
  "libc",
  "num_cpus",
@@ -6491,6 +6526,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sgx-api-lite",
+ "this-crate 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "urlencoding",
  "version",
@@ -8918,6 +8954,15 @@ dependencies = [
 [[package]]
 name = "this-crate"
 version = "0.1.0"
+dependencies = [
+ "konst",
+]
+
+[[package]]
+name = "this-crate"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c3dac231fac5770597ae4670029b06ea5adab46e2fd192838e9a77007ec656"
 
 [[package]]
 name = "thiserror"
@@ -9465,6 +9510,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "typewit"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5cee357cc77d1e02f10a3e6c4e13b8462fafab05998b62d331b7d9485589ff"
 
 [[package]]
 name = "ubyte"

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -5668,7 +5668,7 @@ dependencies = [
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-trie",
- "this-crate 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "this-crate 0.1.0",
  "thiserror",
  "tokio",
  "tracing",

--- a/standalone/pruntime/Cargo.toml
+++ b/standalone/pruntime/Cargo.toml
@@ -42,6 +42,8 @@ phala-clap-parsers = { path = "../../crates/phala-clap-parsers" }
 sgx-api-lite = { path = "../../crates/sgx-api-lite" }
 tracing = "0.1"
 hex_fmt = "0.3.0"
+this-crate = "0.1"
+konst = "0.3"
 
 [patch.crates-io]
 # TODO.kevin: Move back to crates.io once it released 1.0

--- a/standalone/pruntime/src/main.rs
+++ b/standalone/pruntime/src/main.rs
@@ -16,6 +16,11 @@ use phala_clap_parsers::parse_duration;
 mod handover;
 use phala_sanitized_logger as logger;
 
+const _: () = {
+    // Make sure the version is consistent with phatory.
+    konst::assertc_eq!(this_crate::version_str!(), phactory::version_str());
+};
+
 #[derive(Parser, Debug, Clone)]
 #[clap(about = "The Phala TEE worker app.", version, author)]
 struct Args {


### PR DESCRIPTION
We never want older version of pruntime to load checkpoints saved from newer version of pruntime, as it could lead to security risks.
We currently save a version number in the checkpoint and verify its compatibility. However, this version number requires manual updating in the source code, which can be easily overlooked. 
This PR links the storage version number to phactory's crate version number and synchronizes the versions of phactory and pruntime.
