### PR TITLE
pRuntime: Fix sidevm stucks at restart

### DIFF
--- a/crates/phala-scheduler/src/task_scheduler.rs
+++ b/crates/phala-scheduler/src/task_scheduler.rs
@@ -37,6 +37,10 @@ impl<TaskId: TaskIdType> TaskScheduler<TaskId> {
         self.inner.lock().unwrap().poll_resume(cx, task_id, weight)
     }
 
+    pub fn reset(&self, task_id: &TaskId) {
+        self.exit(task_id)
+    }
+
     pub fn exit(&self, task_id: &TaskId) {
         self.inner.lock().unwrap().exit(task_id)
     }

--- a/crates/sidevm/host-runtime/src/run.rs
+++ b/crates/sidevm/host-runtime/src/run.rs
@@ -24,7 +24,8 @@ pub struct WasmRun {
 
 impl Drop for WasmRun {
     fn drop(&mut self) {
-        self.env.cleanup()
+        self.env.cleanup();
+        self.scheduler.exit(&self.id);
     }
 }
 
@@ -73,6 +74,7 @@ impl WasmRun {
         env.set_instance(instance);
         env.set_gas_per_breath(gas_per_breath);
         env.set_weight(weight);
+        scheduler.reset(&id);
         Ok((
             WasmRun {
                 env: env.clone(),


### PR DESCRIPTION
The log server stucked at startup(restart) on PoC5.

The reason is that when a SideVM instance exit, the scheduler state machine wasn't reset, and would be reused in later restart.
That would cause an inconsistent state between the scheduler and the VM itself if the SideVM was stopped at a non-Idle state.

This PR fix it by reset the state at exit and each start.