### PR TITLE
phat-poller: Support for polling multi workers and delay between flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "abort-on-drop"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd6d700ad9af641490c1f7d67980d2de4d1433016e5b12f819448d3c832142a"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9452,6 +9461,7 @@ dependencies = [
 name = "phat-poller"
 version = "0.1.0"
 dependencies = [
+ "abort-on-drop",
  "anyhow",
  "chrono",
  "clap 4.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,9 +968,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "base64ct"
@@ -1843,7 +1843,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b949a1c63fb7eb591eb7ba438746326aedf0ae843e51ec92ba6bec5bb382c4f"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.3",
  "bech32 0.7.3",
  "bs58",
  "digest 0.10.7",
@@ -3642,7 +3642,7 @@ checksum = "b411b119f1cf0efb69e2190883dee731251882bb21270f893ee9513b3a697c48"
 dependencies = [
  "async-trait",
  "auto_impl",
- "base64 0.21.2",
+ "base64 0.21.3",
  "bytes",
  "enr",
  "ethers-core",
@@ -9467,6 +9467,7 @@ dependencies = [
  "clap 4.3.0",
  "futures",
  "hex",
+ "once_cell",
  "pallet-contracts-primitives",
  "parity-scale-codec",
  "phactory-api",
@@ -10931,7 +10932,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.3",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -16849,7 +16850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c86437fa68626fe896e5afc69234bb2b5894949083586535f200385adfd71213"
 dependencies = [
  "anyhow",
- "base64 0.21.2",
+ "base64 0.21.3",
  "bincode",
  "directories-next",
  "file-per-thread-logger",

--- a/crates/phactory/api/src/contracts.rs
+++ b/crates/phactory/api/src/contracts.rs
@@ -1,0 +1,55 @@
+use alloc::string::String;
+use parity_scale_codec::{Decode, Encode};
+
+#[derive(Debug, Encode, Decode)]
+pub enum QueryError {
+    BadOrigin,
+    RuntimeError(String),
+    SidevmNotFound,
+    NoResponse,
+    ServiceUnavailable,
+    Timeout,
+}
+
+impl std::error::Error for QueryError {}
+impl std::fmt::Display for QueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryError::BadOrigin => write!(f, "Bad origin"),
+            QueryError::RuntimeError(msg) => write!(f, "Runtime error: {}", msg),
+            QueryError::SidevmNotFound => write!(f, "Sidevm not found"),
+            QueryError::NoResponse => write!(f, "No response"),
+            QueryError::ServiceUnavailable => write!(f, "Service unavailable"),
+            QueryError::Timeout => write!(f, "Timeout"),
+        }
+    }
+}
+
+
+#[derive(Debug, Encode, Decode)]
+pub enum Query {
+    InkMessage {
+        payload: Vec<u8>,
+        /// Amount of tokens deposit to the caller.
+        deposit: u128,
+        /// Amount of tokens transfer from the caller to the target contract.
+        transfer: u128,
+        /// Whether to use the gas estimation mode.
+        estimating: bool,
+    },
+    SidevmQuery(Vec<u8>),
+    InkInstantiate {
+        code_hash: sp_core::H256,
+        salt: Vec<u8>,
+        instantiate_data: Vec<u8>,
+        /// Amount of tokens deposit to the caller.
+        deposit: u128,
+        /// Amount of tokens transfer from the caller to the target contract.
+        transfer: u128,
+    },
+}
+
+#[derive(Debug, Encode, Decode)]
+pub enum Response {
+    Payload(Vec<u8>),
+}

--- a/crates/phactory/api/src/lib.rs
+++ b/crates/phactory/api/src/lib.rs
@@ -9,5 +9,6 @@ pub mod prpc;
 #[cfg(feature = "pruntime-client")]
 pub mod pruntime_client;
 pub mod storage_sync;
+pub mod contracts;
 
 mod proto_generated;

--- a/crates/phactory/src/contracts/pink.rs
+++ b/crates/phactory/src/contracts/pink.rs
@@ -5,7 +5,7 @@ use crate::{
     system::{TransactionError, TransactionResult},
 };
 use anyhow::Result;
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::Encode;
 use phala_crypto::sr25519::Persistence;
 use phala_mq::{ContractClusterId, MessageOrigin};
 use phala_types::contract::messaging::ResourceType;
@@ -32,47 +32,10 @@ use ::pink::{
 };
 use tracing::info;
 
+pub use phactory_api::contracts::{Query, QueryError, Response};
 pub use phala_types::contract::InkCommand;
 
 pub(crate) mod http_counters;
-
-#[derive(Debug, Encode, Decode)]
-pub enum Query {
-    InkMessage {
-        payload: Vec<u8>,
-        /// Amount of tokens deposit to the caller.
-        deposit: u128,
-        /// Amount of tokens transfer from the caller to the target contract.
-        transfer: u128,
-        /// Whether to use the gas estimation mode.
-        estimating: bool,
-    },
-    SidevmQuery(Vec<u8>),
-    InkInstantiate {
-        code_hash: sp_core::H256,
-        salt: Vec<u8>,
-        instantiate_data: Vec<u8>,
-        /// Amount of tokens deposit to the caller.
-        deposit: u128,
-        /// Amount of tokens transfer from the caller to the target contract.
-        transfer: u128,
-    },
-}
-
-#[derive(Debug, Encode, Decode)]
-pub enum Response {
-    Payload(Vec<u8>),
-}
-
-#[derive(Debug, Encode, Decode)]
-pub enum QueryError {
-    BadOrigin,
-    RuntimeError(String),
-    SidevmNotFound,
-    NoResponse,
-    ServiceUnavailable,
-    Timeout,
-}
 
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct ClusterConfig {

--- a/crates/phactory/src/contracts/support/keeper.rs
+++ b/crates/phactory/src/contracts/support/keeper.rs
@@ -31,6 +31,7 @@ impl ContractsKeeper {
         self.contracts.get(id)
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.contracts.len()
     }

--- a/crates/phactory/src/lib.rs
+++ b/crates/phactory/src/lib.rs
@@ -65,7 +65,7 @@ pub type PRuntimeLightValidation = LightValidation<chain::Runtime>;
 pub mod benchmark;
 
 mod bin_api_service;
-mod contracts;
+pub mod contracts;
 mod cryptography;
 mod im_helpers;
 mod light_validation;

--- a/standalone/phat-poller/Cargo.toml
+++ b/standalone/phat-poller/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1"
 futures = "0.3"
 rand = "0.8"
 hex = "0.4"
+abort-on-drop = "0.2"
 
 # For our forked legacy ContractResult
 scale-info = { version = "2.5.0", features = ["derive"] }

--- a/standalone/phat-poller/Cargo.toml
+++ b/standalone/phat-poller/Cargo.toml
@@ -29,6 +29,7 @@ futures = "0.3"
 rand = "0.8"
 hex = "0.4"
 abort-on-drop = "0.2"
+once_cell = "1"
 
 # For our forked legacy ContractResult
 scale-info = { version = "2.5.0", features = ["derive"] }

--- a/standalone/phat-poller/src/app.rs
+++ b/standalone/phat-poller/src/app.rs
@@ -9,7 +9,7 @@ use std::{
     collections::{BTreeMap, VecDeque},
     future::Future,
     sync::{
-        atomic::{AtomicI32, Ordering},
+        atomic::{AtomicU32, Ordering},
         Arc, Mutex, Weak,
     },
     time::Duration,
@@ -62,11 +62,11 @@ pub struct State {
 
 #[derive(Default, Debug)]
 struct Stats {
-    contract_polled: AtomicI32,
-    workflow_polled: AtomicI32,
-    workflow_finished: AtomicI32,
-    workflow_succeeded: AtomicI32,
-    workflow_failed: AtomicI32,
+    contract_polled: AtomicU32,
+    workflow_polled: AtomicU32,
+    workflow_finished: AtomicU32,
+    workflow_succeeded: AtomicU32,
+    workflow_failed: AtomicU32,
 }
 
 impl Stats {
@@ -74,7 +74,7 @@ impl Stats {
         self.contract_polled.fetch_add(1, Ordering::Relaxed);
     }
 
-    fn inc_polled(&self) -> i32 {
+    fn inc_polled(&self) -> u32 {
         self.workflow_polled.fetch_add(1, Ordering::Relaxed)
     }
     fn inc_finished(&self) {
@@ -490,7 +490,7 @@ async fn poll_contract_inner(
     let mut inds = (0..count).collect::<Vec<_>>();
     shuffle(&mut inds);
     for i in inds {
-        let ind = stats.inc_polled() as u32;
+        let ind = stats.inc_polled();
         let delay = app.config.workflow_poll_gap * ind;
         let handle = app.spawn(
             "workflow",

--- a/standalone/phat-poller/src/app.rs
+++ b/standalone/phat-poller/src/app.rs
@@ -247,7 +247,7 @@ impl App {
             .map(|uri| {
                 self.spawn(
                     "probe",
-                    &format!(r#""uri":"{uri}"}}"#),
+                    &format!("uri={uri}"),
                     timeout,
                     probe_worker(None, uri.clone()),
                 )
@@ -447,10 +447,7 @@ impl App {
             stats.inc_polled();
             let handle = self.spawn(
                 "poll",
-                &format!(
-                    r#"{{"worker":"{}","contract":"{profile:?}"}}"#,
-                    worker.pubkey
-                ),
+                &format!("worker={},profile={profile:?},ind={ind}", worker.pubkey),
                 self.config.poll_timeout,
                 poll_workflow(
                     worker.clone(),

--- a/standalone/phat-poller/src/app.rs
+++ b/standalone/phat-poller/src/app.rs
@@ -464,10 +464,7 @@ impl App {
         }
         let poll_results = futures::future::join_all(poll_handles).await;
         info!(count = poll_results.len(), "workflows polled");
-        let failed_count = poll_results
-            .into_iter()
-            .filter(|r| !matches!(r, Ok(Ok(_))))
-            .count();
+        let failed_count = poll_results.into_iter().filter(|r| r.is_err()).count();
         if failed_count > 0 {
             info!("{failed_count} workflows failed");
         }

--- a/standalone/phat-poller/src/args.rs
+++ b/standalone/phat-poller/src/args.rs
@@ -58,6 +58,10 @@ pub struct RunArgs {
     #[arg(long, value_parser = parse_duration, default_value = "30s")]
     pub poll_timeout_overall: Duration,
 
+    /// Poll workflows with a unique poll id
+    #[arg(long)]
+    pub with_poll_id: bool,
+
     /// Top n workers to be used to poll
     #[arg(long)]
     pub use_top_workers: Option<usize>,

--- a/standalone/phat-poller/src/args.rs
+++ b/standalone/phat-poller/src/args.rs
@@ -24,7 +24,7 @@ pub struct RunArgs {
 
     /// The worker URL used to development
     #[arg(long)]
-    pub dev_worker_uri: Option<String>,
+    pub dev_worker_uri: Vec<String>,
 
     /// Cluster ID
     #[arg(long, value_parser = parse_hash, default_value = "0x0000000000000000000000000000000000000000000000000000000000000001")]
@@ -46,17 +46,21 @@ pub struct RunArgs {
     #[arg(long, value_parser = parse_duration, default_value = "10s")]
     pub poll_interval: Duration,
 
+    /// The gap between two poll to workflows
+    #[arg(long, value_parser = parse_duration, default_value = "200ms")]
+    pub workflow_poll_gap: Duration,
+
     /// Contract poll timeout
     #[arg(long, value_parser = parse_duration, default_value = "10s")]
     pub poll_timeout: Duration,
 
     /// Contract poll timeout over all contracts
-    #[arg(long, value_parser = parse_duration, default_value = "20s")]
+    #[arg(long, value_parser = parse_duration, default_value = "30s")]
     pub poll_timeout_overall: Duration,
 
     /// Top n workers to be used to poll
-    #[arg(long, default_value_t = 5)]
-    pub use_top_workers: usize,
+    #[arg(long)]
+    pub use_top_workers: Option<usize>,
 
     /// Contract ID for the BricksProfileFactory to poll
     #[arg(long, value_parser = parse_hash)]

--- a/standalone/phat-poller/src/query.rs
+++ b/standalone/phat-poller/src/query.rs
@@ -9,7 +9,7 @@ use phala_types::contract;
 use phala_types::contract::ContractId;
 use scale::{Decode, Encode};
 use sp_core::Pair as _;
-use tracing::warn;
+use tracing::debug;
 use std::convert::TryFrom as _;
 
 #[derive(Debug, Encode, Decode)]
@@ -82,7 +82,7 @@ pub async fn pink_query<I: Encode, O: Decode>(
             .result
             .map_err(|err| anyhow::anyhow!("DispatchError({err:?})"))?;
     if output.did_revert() {
-        warn!("Contract execution reverted, output={:?}", output.data);
+        debug!("Contract execution reverted, output={:?}", output.data);
     }
     let r = Result::<O, LangError>::decode(&mut &output.data[..])??;
     Ok(r)

--- a/standalone/phat-poller/src/query.rs
+++ b/standalone/phat-poller/src/query.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use phactory_api::{
+    contracts::{Query, QueryError, Response},
     crypto::{CertificateBody, EncryptedData},
     prpc,
 };
@@ -9,49 +10,13 @@ use phala_types::contract;
 use phala_types::contract::ContractId;
 use scale::{Decode, Encode};
 use sp_core::Pair as _;
-use tracing::debug;
 use std::convert::TryFrom as _;
-
-#[derive(Debug, Encode, Decode)]
-pub enum Query {
-    InkMessage {
-        payload: Vec<u8>,
-        /// Amount of tokens deposit to the caller.
-        deposit: u128,
-        /// Amount of tokens transfer from the caller to the target contract.
-        transfer: u128,
-        /// Whether to use the gas estimation mode.
-        estimating: bool,
-    },
-    SidevmQuery(Vec<u8>),
-}
+use tracing::debug;
 
 #[derive(Debug, Encode, Decode)]
 pub enum Command {
     InkMessage { nonce: Vec<u8>, message: Vec<u8> },
 }
-
-#[derive(Debug, Encode, Decode)]
-pub enum Response {
-    Payload(Vec<u8>),
-}
-
-#[derive(Debug, Encode, Decode)]
-pub enum QueryError {
-    BadOrigin,
-    RuntimeError(String),
-    SidevmNotFound,
-}
-impl std::fmt::Display for QueryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            QueryError::BadOrigin => write!(f, "Bad origin"),
-            QueryError::RuntimeError(msg) => write!(f, "Runtime error: {}", msg),
-            QueryError::SidevmNotFound => write!(f, "Sidevm not found"),
-        }
-    }
-}
-impl std::error::Error for QueryError {}
 
 #[derive(Debug, Encode, Decode)]
 pub enum LangError {
@@ -77,10 +42,9 @@ pub async fn pink_query<I: Encode, O: Decode>(
 ) -> Result<O> {
     let call_data = (selector.to_be_bytes(), args).encode();
     let payload = pink_query_raw(worker_pubkey, url, id, call_data, key).await??;
-    let output =
-        crate::primitives::ContractExecResult::<u128>::decode(&mut &payload[..])?
-            .result
-            .map_err(|err| anyhow::anyhow!("DispatchError({err:?})"))?;
+    let output = crate::primitives::ContractExecResult::<u128>::decode(&mut &payload[..])?
+        .result
+        .map_err(|err| anyhow::anyhow!("DispatchError({err:?})"))?;
     if output.did_revert() {
         debug!("Contract execution reverted, output={:?}", output.data);
     }


### PR DESCRIPTION
This PR add support for giving multiple worker URIs with multiple `--dev-worker-uri` and add an argument `--workflow-poll-gap` to set a gap between two workflow polling starts.

 for example:
```
./phat-poller run --factory-contract 0x489bb4fa807bbe0f877ed46be8646867a8d16ec58add141977c4bd19b0237091 \
 --dev-worker-uri http://localhost:8002 \
 --dev-worker-uri http://localhost:8001 \
 --workflow-poll-gap 100ms \
 --poll-timeout-overall 60s
```

Additionally, an arg `--with-poll-id` is added in order to poll the profile in https://github.com/Phala-Network/phat-bricks/pull/20