### PR TITLE
Upgrade to Rustc 1.72 & cargo-contract 3.2

### DIFF
--- a/.github/actions/build-contracts/action.yml
+++ b/.github/actions/build-contracts/action.yml
@@ -8,7 +8,7 @@ runs:
       run: sudo bash dockerfile.d/01_apt.sh
       shell: bash
     - name: Install cargo-contract
-      run: cargo install --locked cargo-contract --version =3.0.1
+      run: cargo install --locked cargo-contract --version =3.2.0
       shell: bash
     - name: Install rust components
       run: rustup component add rust-src && rustup target add wasm32-wasi

--- a/.github/actions/install_toolchain/action.yml
+++ b/.github/actions/install_toolchain/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Install latest stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.69.0
+        toolchain: 1.72.0
         override: true
         target: wasm32-unknown-unknown
         components: cargo, clippy, rust-analyzer, rust-src, rust-std, rustc-dev, rustc, rustfmt

--- a/dockerfile.d/05_rust.sh
+++ b/dockerfile.d/05_rust.sh
@@ -1,4 +1,4 @@
-RUST_TOOLCHAIN=1.69
+RUST_TOOLCHAIN=1.72.0
 cd /root && \
 curl 'https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init' --output /root/rustup-init && \
 chmod +x /root/rustup-init && \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.72.0"
 components = [
     "cargo",
     "clippy",


### PR DESCRIPTION
Cargo contract 3.2 support Rust version later than 1.69. It no longer emit signext instructions, so lets update.