### PR TITLE
Update phat_js to 0.1.5 for check_system

### DIFF
--- a/e2e/contracts/check_system/Cargo.toml
+++ b/e2e/contracts/check_system/Cargo.toml
@@ -15,7 +15,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 pink-extension = { version = "0.4", default-features = false, path = "../../../crates/pink/pink-extension" }
-phat_js = { version = "0.1.1", default-features = false }
+phat_js = { version = "0.1.5", default-features = false }
 
 [dependencies.indeterministic_functions]
 version = "0.1"


### PR DESCRIPTION
Or it would cause some problem due to the ink 4.2.0 -> 4.2.1 breaking change.