### PR TITLE
CI: Use our own maximize space script

### DIFF
--- a/.github/actions/maximize-disk-space/action.yml
+++ b/.github/actions/maximize-disk-space/action.yml
@@ -1,0 +1,24 @@
+name: "Maximize disk space"
+description: "Maximize disk space"
+runs:
+  using: "composite"
+  steps:
+    - name: Remove unused tools
+      run: >
+        df -h &&
+        sudo rm -rf /usr/local/.ghcup
+        /usr/local/share/powershell
+        /usr/local/share/chromium
+        /usr/share/swift
+        /opt/hostedtoolcache/Python
+        /opt/hostedtoolcache/CodeQL
+        /opt/hostedtoolcache/PyPy
+        /opt/hostedtoolcache/Ruby
+        /opt/hostedtoolcache/go
+        /imagegeneration/installers/*.tar.gz
+        /usr/local/lib/android
+        /usr/lib/google-cloud-sdk
+        /usr/lib/jvm
+        /opt/microsoft
+        && df -h
+      shell: bash

--- a/.github/actions/maximize-disk-space/action.yml
+++ b/.github/actions/maximize-disk-space/action.yml
@@ -22,3 +22,15 @@ runs:
         /opt/microsoft
         && df -h
       shell: bash
+    - name: Setup swap
+      run: |
+        SWAP_FILE=/mnt/swapfile
+        sudo swapoff -a
+        sudo rm -f ${SWAP_FILE}
+        sudo fallocate -l 12G ${SWAP_FILE}
+        sudo chmod 600 ${SWAP_FILE}
+        sudo mkswap ${SWAP_FILE}
+        sudo swapon ${SWAP_FILE}
+        sudo swapon --show
+        df -h
+      shell: bash

--- a/.github/workflows/build-nightly-release.yml
+++ b/.github/workflows/build-nightly-release.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - uses: ./.github/actions/maximize-disk-space
       - uses: ./.github/actions/build-core
         with:
           profile: release
@@ -28,6 +29,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - uses: ./.github/actions/maximize-disk-space
       - uses: ./.github/actions/build-pruntime
 
   build-contracts:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,49 +14,24 @@ jobs:
     name: Build core
     runs-on: ubuntu-20.04
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master # https://github.com/easimon/maximize-build-space
-        with:
-          root-reserve-mb: 4096
-          temp-reserve-mb: 1024
-          swap-size-mb: 8192
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
+      - uses: ./.github/actions/maximize-disk-space
       - uses: ./.github/actions/build-core
   build-pruntime:
     name: Build pruntime
     runs-on: ubuntu-20.04
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master # https://github.com/easimon/maximize-build-space
-        with:
-          root-reserve-mb: 4096
-          temp-reserve-mb: 1024
-          swap-size-mb: 8192
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
+      - uses: ./.github/actions/maximize-disk-space
       - uses: ./.github/actions/build-pruntime
   build-prouter:
     name: Build prouter
     runs-on: ubuntu-20.04
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master # https://github.com/easimon/maximize-build-space
-        with:
-          root-reserve-mb: 4096
-          temp-reserve-mb: 1024
-          swap-size-mb: 8192
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
@@ -73,15 +48,6 @@ jobs:
     name: Run E2E tests
     runs-on: ubuntu-20.04
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master # https://github.com/easimon/maximize-build-space
-        with:
-          root-reserve-mb: 4096
-          temp-reserve-mb: 1024
-          swap-size-mb: 8192
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
@@ -130,19 +96,11 @@ jobs:
     name: Run cargo tests
     runs-on: ubuntu-20.04
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master # https://github.com/easimon/maximize-build-space
-        with:
-          root-reserve-mb: 4096
-          temp-reserve-mb: 1024
-          swap-size-mb: 8192
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - uses: ./.github/actions/install_toolchain
+      - uses: ./.github/actions/maximize-disk-space
       - name: Run cargo tests
         run: cargo test --tests --release --workspace --exclude node-executor --exclude phala-node
 
@@ -150,20 +108,12 @@ jobs:
     name: Run cargo clippy
     runs-on: ubuntu-20.04
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master # https://github.com/easimon/maximize-build-space
-        with:
-          root-reserve-mb: 4096
-          temp-reserve-mb: 1024
-          swap-size-mb: 8192
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
       - uses: ./.github/actions/install_toolchain
       - name: Install clippy
         run: rustup component add clippy
+      - uses: ./.github/actions/maximize-disk-space
       - name: Run cargo clippy
         run: cargo clippy --tests -- -D warnings && cd standalone/pruntime && cargo clippy --tests -- -D warnings


### PR DESCRIPTION
The `easimon/maximize-build-space` solution is complicate and has problem cause the CI randomly fail.
Let's use a simple script to remove the unused stuffs.

Now there is 57G available in `/`:
<img width="530" alt="image" src="https://github.com/Phala-Network/phala-blockchain/assets/6442159/19a53171-57f6-498d-82de-f29c3a2a3192">
