### PR TITLE
prpc: Add system contract and so on

### DIFF
--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -322,7 +322,8 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
     }
 
     fn maybe_apply_cluster_state(&mut self) {
-        let (Some(system), Some(runtime_state)) = (&mut self.system, &mut self.runtime_state) else {
+        let (Some(system), Some(runtime_state)) = (&mut self.system, &mut self.runtime_state)
+        else {
             // unreachable
             return;
         };
@@ -876,7 +877,12 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
     }
 
     pub fn get_cluster_info(&self) -> RpcResult<pb::GetClusterInfoResponse> {
-        let Some(System{ contract_cluster: Some(cluster), contracts, .. }) = &self.system else {
+        let Some(System {
+            contract_cluster: Some(cluster),
+            contracts,
+            ..
+        }) = &self.system
+        else {
             return Ok(Default::default());
         };
         let ver = cluster.config.runtime_version;
@@ -886,8 +892,15 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             info: Some(pb::ClusterInfo {
                 id: hex(cluster.id),
                 state_root: cluster.storage.root().map(hex).unwrap_or_default(),
-                contracts: contracts.keys().map(hex).collect(),
                 runtime_version,
+                number_of_contracts: contracts.len() as _,
+                system_contract: cluster.system_contract().map(hex).unwrap_or_default(),
+                logger_contract: cluster
+                    .config
+                    .log_handler
+                    .as_ref()
+                    .map(hex)
+                    .unwrap_or_default(),
             }),
         })
     }

--- a/e2e/src/fullstack.js
+++ b/e2e/src/fullstack.js
@@ -852,7 +852,7 @@ describe('A full stack', function () {
             await sleep(1000);
             const clusterInfo = await pruntime[0].rpc.getClusterInfo({});
             assert.equal(clusterInfo?.info?.id, clusterId);
-            assert.isTrue(clusterInfo?.info?.contracts.length > 0);
+            assert.isTrue(clusterInfo?.info?.numberOfContracts > 0);
         });
 
         it('can destory cluster', async function () {


### PR DESCRIPTION
This PR add two fields `system_contract` and `logger_contract` to the resposne of `/prpc/PhactoryAPI.GetClusterInfo`. This allows the external tools to be conveniant to query some info from pruntime without touch the chain state.

The field `contracts` is removed as it is a bit heavy and redudant to the API `GetContractInfo`.