### PR TITLE
pink-runtime: Fix tokio runtime missing in unittest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9763,7 +9763,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension-runtime"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "futures",
  "getrandom 0.2.7",

--- a/crates/pink/pink-extension-runtime/Cargo.toml
+++ b/crates/pink/pink-extension-runtime/Cargo.toml
@@ -3,11 +3,11 @@ description = "Mock pink chain extension for Phala pink contract"
 homepage = "https://github.com/Phala-Network/phala-blockchain"
 license = "Apache-2.0"
 name = "pink-extension-runtime"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 
 [dependencies]
-pink-extension = { version = "0.4.2", path = "../pink-extension" }
+pink-extension = { version = "0.4.5", path = "../pink-extension" }
 reqwest-env-proxy = { version = "0.1", path = "../../reqwest-env-proxy" }
 sp-core = { version = "21", features = ["full_crypto"] }
 sp-runtime-interface = { version = "17", features = ["disable_target_static_assertions"] }

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension-runtime"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "futures",
  "getrandom 0.2.10",


### PR DESCRIPTION
When the `tokio::time::timeout` called outside of a tokio runtime context, it complains:
```
panicked at 'there is no reactor running, must be called from the context of a Tokio 1.x runtime'
```
The PR fix it by moving it into the Future.