### PR TITLE
headers-cache: Check headers hash chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "headers-cache"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/phaxt/src/chain_api.rs
+++ b/crates/phaxt/src/chain_api.rs
@@ -121,9 +121,10 @@ impl ChainApi {
             .await?
             .fetch(&address)
             .await
-            .context("Failed to get worker info")? else {
-                return Ok(None);
-            };
+            .context("Failed to get worker info")?
+        else {
+            return Ok(None);
+        };
         let block_number = block
             .to_value()?
             .as_u128()
@@ -149,9 +150,10 @@ impl ChainApi {
             .await?
             .fetch(&address)
             .await
-            .context("Failed to get worker endpoints")? else {
-                return Ok(None);
-            };
+            .context("Failed to get worker endpoints")?
+        else {
+            return Ok(None);
+        };
         Ok(Some(Decode::decode(&mut &data.encoded()[..])?))
     }
 
@@ -167,7 +169,7 @@ impl ChainApi {
             .fetch("PhalaRegistry", "Endpoints", Some(worker))
             .await?;
         let Some(VersionedWorkerEndpoints::V1(endpoints)) = result else {
-            return Ok(vec![])
+            return Ok(vec![]);
         };
         Ok(endpoints)
     }
@@ -188,5 +190,21 @@ impl ChainApi {
             result.into_iter().for_each(|key| keys.push(key.0));
         }
         Ok(keys)
+    }
+
+    pub async fn latest_finalized_block_number(&self) -> Result<BlockNumber> {
+        let latest_block_hash = self
+            .rpc()
+            .finalized_head()
+            .await
+            .context("Failed to get finalized head")?;
+        let block = self
+            .rpc()
+            .header(Some(latest_block_hash))
+            .await
+            .context("Failed to get block number")?
+            .ok_or(anyhow::anyhow!("Block number not found"))?
+            .number;
+        Ok(block)
     }
 }

--- a/crates/phaxt/src/rpc.rs
+++ b/crates/phaxt/src/rpc.rs
@@ -1,4 +1,4 @@
-use phala_node_rpc_ext_types::GetStorageChangesResponse;
+use phala_node_rpc_ext_types::{GetStorageChangesResponse, GetStorageChangesResponseWithRoot};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::to_value as to_json_value;
 use subxt::{
@@ -38,6 +38,19 @@ impl<'a, T: Config> ExtraRpcClient<'a, T> {
         let params = rpc_params![to_json_value(from)?, to_json_value(to)?];
         self.client
             .request("pha_getStorageChanges", params)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Query storage changes with root
+    pub async fn get_storage_changes_with_root(
+        &self,
+        from: &T::Hash,
+        to: &T::Hash,
+    ) -> Result<GetStorageChangesResponseWithRoot, Error> {
+        let params = rpc_params![to_json_value(from)?, to_json_value(to)?];
+        self.client
+            .request("pha_getStorageChangesWithRoot", params)
             .await
             .map_err(Into::into)
     }

--- a/standalone/headers-cache/Cargo.toml
+++ b/standalone/headers-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headers-cache"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/standalone/headers-cache/src/db.rs
+++ b/standalone/headers-cache/src/db.rs
@@ -18,6 +18,8 @@ pub struct Metadata {
     pub genesis: Vec<BlockNumber>,
     pub recent_imported: Counters,
     pub higest: Counters,
+    #[serde(default)]
+    pub checked: Counters,
 }
 
 macro_rules! update_field {

--- a/standalone/headers-cache/src/grab.rs
+++ b/standalone/headers-cache/src/grab.rs
@@ -265,6 +265,7 @@ impl<'c> Crawler<'c> {
                     changes_start,
                     Some(changes_end),
                     None,
+                    config.allow_empty_state_root,
                 )
                 .await
                 .context("Failed to check storage changes")?;
@@ -361,6 +362,7 @@ pub(crate) async fn check_and_fix_storages_changes(
     from: BlockNumber,
     to: Option<BlockNumber>,
     count: Option<BlockNumber>,
+    allow_empty_root: bool,
 ) -> Result<u32> {
     let api = match api {
         Some(api) => api,
@@ -382,6 +384,9 @@ pub(crate) async fn check_and_fix_storages_changes(
         let actual_root = decode_header(&changes)
             .map(|h| h.state_root)
             .unwrap_or_default();
+        if allow_empty_root && actual_root == Default::default() {
+            continue;
+        }
         let expected_root = header.state_root;
         if expected_root != actual_root {
             info!("Storage changes {block} mismatch, expected={expected_root} actual={actual_root}, trying to regrab");

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -117,7 +117,7 @@ enum Grab {
         output: String,
     },
 }
-#[derive(Args)]
+#[derive(Args, Clone)]
 struct Serve {
     /// The database file to use
     #[arg(long, default_value = "cache.db")]
@@ -157,6 +157,9 @@ struct Serve {
     /// Token for uploading APIs.
     #[arg(long)]
     token: Option<String>,
+    /// The max batch size to check headers
+    #[clap(long, default_value_t = 100000)]
+    check_batch: BlockNumber,
 }
 
 #[derive(Subcommand)]
@@ -268,6 +271,7 @@ async fn serve(config: Serve) -> anyhow::Result<()> {
         });
     } else if config.grab_headers {
         let db = db.clone();
+        let config = config.clone();
         tokio::spawn(async move {
             let result = grab::run(db, config).await;
             if let Err(err) = result {
@@ -276,7 +280,7 @@ async fn serve(config: Serve) -> anyhow::Result<()> {
             std::process::exit(1);
         });
     }
-    web_api::serve(db, token).await?;
+    web_api::serve(db, config, token).await?;
     Ok(())
 }
 

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -222,6 +222,8 @@ enum Action {
         para_header: Option<BlockNumber>,
         #[arg(long)]
         storage_changes: Option<BlockNumber>,
+        #[arg(long)]
+        checked: bool,
     },
 }
 
@@ -247,7 +249,8 @@ async fn main() -> anyhow::Result<()> {
             header,
             para_header,
             storage_changes,
-        } => reset(db, header, para_header, storage_changes)?,
+            checked,
+        } => reset(db, header, para_header, storage_changes, checked)?,
     }
     Ok(())
 }
@@ -374,6 +377,7 @@ fn reset(
     header: Option<u32>,
     para_header: Option<u32>,
     storage_changes: Option<u32>,
+    checked: bool,
 ) -> anyhow::Result<()> {
     let cache = db::CacheDB::open(&db)?;
     let mut metadata = cache.get_metadata()?.unwrap_or_default();
@@ -388,6 +392,9 @@ fn reset(
     if let Some(storage_changes) = storage_changes {
         metadata.higest.storage_changes = Some(storage_changes);
         metadata.recent_imported.storage_changes = Some(storage_changes);
+    }
+    if checked {
+        metadata.checked = Default::default();
     }
     cache
         .put_metadata(&metadata)

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -160,6 +160,9 @@ struct Serve {
     /// The max batch size to check headers
     #[clap(long, default_value_t = 100000)]
     check_batch: BlockNumber,
+    /// Don't check state root for each storage changes
+    #[clap(long)]
+    no_state_root: bool,
 }
 
 #[derive(Subcommand)]

--- a/standalone/headers-cache/src/main.rs
+++ b/standalone/headers-cache/src/main.rs
@@ -163,6 +163,9 @@ struct Serve {
     /// Don't check state root for each storage changes
     #[clap(long)]
     no_state_root: bool,
+    /// Skip blocks with empty state root while checking storage changes
+    #[clap(long)]
+    allow_empty_state_root: bool,
 }
 
 #[derive(Subcommand)]

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -202,16 +202,16 @@ async fn put_storage_changes(
     .await
 }
 
-#[get("/check?<what>&<from>&<to>&<count>")]
+#[get("/check?<chain>&<from>&<to>&<count>")]
 async fn api_check_blocks(
     _auth: Authorized,
     app: &State<App>,
-    what: &str,
+    chain: &str,
     from: BlockNumber,
     to: Option<BlockNumber>,
     count: Option<BlockNumber>,
 ) -> Result<String, String> {
-    crate::grab::check_and_fix_headers(&app.db, &app.config, what, from, to, count)
+    crate::grab::check_and_fix_headers(&app.db, &app.config, chain, from, to, count)
         .await
         .map_err(|e| e.to_string())
 }
@@ -246,7 +246,7 @@ pub(crate) async fn serve(db: CacheDB, config: ServeConfig, token: Option<String
         )
         .attach(phala_rocket_middleware::TimeMeter)
         .launch()
-        .await;
+        .await?;
     Ok(())
 }
 

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -219,6 +219,7 @@ async fn api_check_blocks(
             from,
             to,
             count,
+            false,
         )
         .await
         .map_err(|e| e.to_string())?;

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -212,10 +212,16 @@ async fn api_check_blocks(
     count: Option<BlockNumber>,
 ) -> Result<String, String> {
     if chain == "state" {
-        let mismatches =
-            crate::grab::check_and_fix_storages_changes(&app.db, &app.config, from, to, count)
-                .await
-                .map_err(|e| e.to_string())?;
+        let mismatches = crate::grab::check_and_fix_storages_changes(
+            &app.db,
+            None,
+            &app.config,
+            from,
+            to,
+            count,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
         if mismatches == 0 {
             Ok("No mismatches".into())
         } else {

--- a/standalone/headers-cache/src/web_api.rs
+++ b/standalone/headers-cache/src/web_api.rs
@@ -2,27 +2,30 @@ use std::pin::pin;
 
 use anyhow::{bail, Context, Result};
 use log::{debug, error, info};
-use pherry::headers_cache::{read_items_stream, BlockInfo};
+use pherry::{
+    headers_cache::{read_items_stream, BlockInfo},
+    types::Header,
+};
 use rand::Rng;
 use rocket::{
     data::ToByteUnit,
     futures::StreamExt,
-    get,
+    get, put,
     response::status::{BadRequest, NotFound},
-    routes, State,
+    routes, Data, State,
 };
-use rocket::{put, Data};
 
 use scale::{Decode, Encode};
 
-use crate::db::CacheDB;
-use crate::BlockNumber;
+use super::Serve as ServeConfig;
+use crate::{db::CacheDB, BlockNumber};
 use auth::Authorized;
 
 mod auth;
 
 struct App {
     db: CacheDB,
+    config: ServeConfig,
 }
 
 #[get("/state")]
@@ -94,7 +97,6 @@ fn get_parachain_headers(
     for block in start..start + count {
         match app.db.get_para_header(block) {
             Some(data) => {
-                use pherry::types::Header;
                 let header =
                     Header::decode(&mut &data[..]).map_err(|_| NotFound("Codec error".into()))?;
                 headers.push(header);
@@ -200,15 +202,32 @@ async fn put_storage_changes(
     .await
 }
 
-pub(crate) async fn serve(db: CacheDB, token: Option<String>) -> Result<()> {
+#[get("/check?<what>&<from>&<to>&<count>")]
+async fn api_check_blocks(
+    _auth: Authorized,
+    app: &State<App>,
+    what: &str,
+    from: BlockNumber,
+    to: Option<BlockNumber>,
+    count: Option<BlockNumber>,
+) -> Result<String, String> {
+    crate::grab::check_and_fix_headers(&app.db, &app.config, what, from, to, count)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+pub(crate) async fn serve(db: CacheDB, config: ServeConfig, token: Option<String>) -> Result<()> {
     let token = token.unwrap_or_else(|| {
         let token: [u8; 16] = rand::thread_rng().gen();
         let token = hex::encode(token);
         log::warn!("No token provided, generated a random one: {}", token);
         token
     });
-    let _rocket = rocket::build()
-        .manage(App { db })
+    let _ = rocket::build()
+        .manage(App {
+            db: db.clone(),
+            config: config.clone(),
+        })
         .manage(auth::Token { value: token })
         .mount(
             "/",
@@ -222,11 +241,12 @@ pub(crate) async fn serve(db: CacheDB, token: Option<String>) -> Result<()> {
                 put_headers,
                 put_parachain_headers,
                 put_storage_changes,
+                api_check_blocks,
             ],
         )
         .attach(phala_rocket_middleware::TimeMeter)
         .launch()
-        .await?;
+        .await;
     Ok(())
 }
 

--- a/standalone/pherry/src/chain_client.rs
+++ b/standalone/pherry/src/chain_client.rs
@@ -123,14 +123,7 @@ pub async fn search_suitable_genesis_for_worker(
 ) -> Result<(BlockNumber, Vec<(Vec<u8>, Vec<u8>)>)> {
     let ceil = match prefer {
         Some(ceil) => ceil,
-        None => {
-            let node_state = api
-                .extra_rpc()
-                .system_sync_state()
-                .await
-                .context("Failed to get system state")?;
-            node_state.current_block as _
-        }
+        None => api.latest_finalized_block_number().await?,
     };
     let block = get_worker_unregistered_block(api, pubkey, ceil)
         .await

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -234,7 +234,7 @@ pub async fn grap_storage_changes_to_file(
     batch_size: BlockNumber,
     mut output: impl Write,
 ) -> Result<BlockNumber> {
-    grab_storage_changes(api, start_at, count, batch_size, |changes| {
+    grab_storage_changes(api, start_at, count, batch_size, true, |changes| {
         if changes.block_header.number % 1000 == 0 {
             info!("Got storage changes at {}", changes.block_header.number);
         }
@@ -391,6 +391,7 @@ pub async fn grab_storage_changes(
     start_at: BlockNumber,
     count: BlockNumber,
     batch_size: BlockNumber,
+    with_root: bool,
     mut f: impl FnMut(BlockHeaderWithChanges) -> Result<()>,
 ) -> Result<BlockNumber> {
     if count == 0 {
@@ -402,15 +403,10 @@ pub async fn grab_storage_changes(
 
     for from in (start_at..=to).step_by(batch_size as _) {
         let to = to.min(from.saturating_add(batch_size - 1));
-        let headers =
-            match crate::fetch_storage_changes_with_root_or_not(api, None, from, to, true).await {
-                Err(e) if e.to_string().contains("not found") => {
-                    break;
-                }
-                other => other?,
-            };
-        for header in headers {
-            f(header)?;
+        let changes =
+            crate::fetch_storage_changes_with_root_or_not(api, None, from, to, with_root).await?;
+        for blk in changes {
+            f(blk)?;
             grabbed += 1;
         }
     }

--- a/standalone/pherry/src/headers_cache.rs
+++ b/standalone/pherry/src/headers_cache.rs
@@ -402,12 +402,13 @@ pub async fn grab_storage_changes(
 
     for from in (start_at..=to).step_by(batch_size as _) {
         let to = to.min(from.saturating_add(batch_size - 1));
-        let headers = match crate::fetch_storage_changes(api, None, from, to).await {
-            Err(e) if e.to_string().contains("not found") => {
-                break;
-            }
-            other => other?,
-        };
+        let headers =
+            match crate::fetch_storage_changes_with_root_or_not(api, None, from, to, true).await {
+                Err(e) if e.to_string().contains("not found") => {
+                    break;
+                }
+                other => other?,
+            };
         for header in headers {
             f(header)?;
             grabbed += 1;

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -333,7 +333,7 @@ pub async fn fetch_storage_changes_with_root_or_not(
     to: BlockNumber,
     with_root: bool,
 ) -> Result<Vec<BlockHeaderWithChanges>> {
-    log::info!("fetch_storage_changes ({from}-{to})");
+    log::info!("fetch_storage_changes with_root={with_root}, ({from}-{to})");
     if to < from {
         return Ok(vec![]);
     }

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -1,7 +1,10 @@
 use anyhow::{anyhow, Context, Result};
 use log::{debug, error, info, warn};
-use sp_core::crypto::AccountId32;
+use phala_node_rpc_ext::MakeInto;
+use phala_trie_storage::ser::StorageChanges;
+use sp_core::{crypto::AccountId32, H256};
 use std::cmp;
+use std::convert::TryFrom;
 use std::str::FromStr;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -320,6 +323,16 @@ pub async fn fetch_storage_changes(
     from: BlockNumber,
     to: BlockNumber,
 ) -> Result<Vec<BlockHeaderWithChanges>> {
+    fetch_storage_changes_with_root_or_not(client, cache, from, to, false).await
+}
+
+pub async fn fetch_storage_changes_with_root_or_not(
+    client: &RpcClient,
+    cache: Option<&CacheClient>,
+    from: BlockNumber,
+    to: BlockNumber,
+    with_root: bool,
+) -> Result<Vec<BlockHeaderWithChanges>> {
     log::info!("fetch_storage_changes ({from}-{to})");
     if to < from {
         return Ok(vec![]);
@@ -336,21 +349,47 @@ pub async fn fetch_storage_changes(
     }
     let from_hash = get_header_hash(client, Some(from)).await?;
     let to_hash = get_header_hash(client, Some(to)).await?;
-    let storage_changes = chain_client::fetch_storage_changes(client, &from_hash, &to_hash)
-        .await?
+
+    let changes = if with_root {
+        client
+            .extra_rpc()
+            .get_storage_changes_with_root(&from_hash, &to_hash)
+            .await?
+            .into_iter()
+            .map(|changes| {
+                Ok((changes.changes, {
+                    let raw: [u8; 32] = TryFrom::try_from(&changes.state_root[..])
+                        .or(Err(anyhow!("Invalid state root")))?;
+                    H256::from(raw)
+                }))
+            })
+            .collect::<Result<Vec<_>>>()?
+    } else {
+        client
+            .extra_rpc()
+            .get_storage_changes(&from_hash, &to_hash)
+            .await?
+            .into_iter()
+            .map(|changes| (changes, Default::default()))
+            .collect::<Vec<_>>()
+    };
+    let storage_changes = changes
         .into_iter()
         .enumerate()
-        .map(|(offset, storage_changes)| {
+        .map(|(offset, (storage_changes, state_root))| {
             BlockHeaderWithChanges {
                 // Headers are synced separately. Only the `number` is used in pRuntime while syncing blocks.
                 block_header: BlockHeader {
                     number: from + offset as BlockNumber,
                     parent_hash: Default::default(),
-                    state_root: Default::default(),
+                    state_root,
                     extrinsics_root: Default::default(),
                     digest: Default::default(),
                 },
-                storage_changes,
+                storage_changes: StorageChanges {
+                    main_storage_changes: storage_changes.main_storage_changes.into_(),
+                    child_storage_changes: storage_changes.child_storage_changes.into_(),
+                },
             }
         })
         .collect();

--- a/standalone/pherry/src/prefetcher.rs
+++ b/standalone/pherry/src/prefetcher.rs
@@ -59,7 +59,8 @@ impl PrefetchClient {
             to: next_to,
             handle: tokio::spawn(async move {
                 log::info!("prefetching ({next_from}-{next_to})");
-                crate::fetch_storage_changes(&client, cache.as_ref(), next_from, next_to).await
+                crate::fetch_storage_changes(&client, cache.as_ref(), next_from, next_to)
+                    .await
             }),
         });
         Ok(result)


### PR DESCRIPTION
It may encounter a `HeaderHashMismatch` error during block synchronization with headers-cache if it is configured to automatically fetch blocks from the node. This issue may arise due to the node temporarily returning incorrect block data. 

This pull request adds:
-  Automated checking for to the header hash chain and re-fetching the header data from the node in case of a hash mismatch.

- Additionally, an external web API is exposed at `/check` to manually invoke these checks, for example:
```bash
#!/bin/bash

FROM=15000000
TO=17353475
BATCH=100000
CHAIN=relay # or para or state

for (( i=$FROM; i<=$TO; i+=$BATCH )); do
    NEXT=$((i + BATCH - 1))
    if [ $NEXT -gt $TO ]; then
        NEXT=$TO
    fi
    curl "localhost:8003/check?chain=$CHAIN&from=$i&to=$NEXT"
    echo
done
```

The storage changes could not be checked by this way as the stored data is diff and can not be directly compared to the state root hash.

