### PR TITLE
node-rpc: Add pha_getStorageChangesWithRoot

### DIFF
--- a/crates/phala-node-rpc-ext/types/src/lib.rs
+++ b/crates/phala-node-rpc-ext/types/src/lib.rs
@@ -27,6 +27,16 @@ pub struct StorageChanges {
 /// Response for the `pha_getStorageChanges` RPC.
 pub type GetStorageChangesResponse = Vec<StorageChanges>;
 
+#[derive(Serialize, Deserialize, Clone, Debug, Encode, Decode, TypeInfo)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageChangesWithRoot {
+    pub changes: StorageChanges,
+    pub state_root: Vec<u8>,
+}
+
+/// Response for the `pha_getStorageChangesWithRoot` RPC.
+pub type GetStorageChangesResponseWithRoot = Vec<StorageChangesWithRoot>;
+
 // Stuffs to convert ChildStorageCollection and StorageCollection types,
 // in order to dump the keys values into hex strings instead of list of dec numbers.
 pub trait MakeInto<T>: Sized {


### PR DESCRIPTION
This PR adds a new phala-node RPC `pha_getStorageChangesWithRoot` which returns storage changes with the corresponding `state root`.
This gives the `headers-cache` ability to validate the storage changes with the block headers.