### PR TITLE
StakePool and Vault improvements

### DIFF
--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -57,6 +57,14 @@ pub mod pallet {
 		pub nft_id: NftId,
 	}
 
+	/// Current withdrawing stats for a user
+	#[derive(Default)]
+	struct WithdrawEventStats<Balance: Default> {
+		amount: Balance,
+		shares: Balance,
+		burnt_shares: Balance,
+	}
+
 	#[pallet::config]
 	pub trait Config:
 		frame_system::Config
@@ -167,6 +175,7 @@ pub mod pallet {
 			user: T::AccountId,
 			amount: BalanceOf<T>,
 			shares: BalanceOf<T>,
+			burnt_shares: BalanceOf<T>,
 		},
 		/// A pool contribution whitelist is added
 		///
@@ -1027,6 +1036,9 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// Removes the share from the pool total_shares if it's a dust
+		///
+		/// Return true if the dust is removed
 		pub fn maybe_remove_dust(
 			pool_info: &mut BasePool<T::AccountId, BalanceOf<T>>,
 			nft: &NftAttr<BalanceOf<T>>,
@@ -1044,92 +1056,101 @@ pub mod pallet {
 			true
 		}
 
-		/// Removes withdrawing_shares from the nft
-		pub fn do_withdraw_shares(
-			withdrawing_shares: BalanceOf<T>,
-			pool_info: &mut BasePool<T::AccountId, BalanceOf<T>>,
-			nft: &mut NftAttr<BalanceOf<T>>,
-			userid: T::AccountId,
-		) {
-			// Overflow warning: remove_stake is carefully written to avoid precision error.
-			// (I hope so)
-			let (reduced, withdrawn_shares) =
-				Self::remove_stake_from_nft(pool_info, withdrawing_shares, nft, &userid)
-					.expect("There are enough withdrawing_shares; qed.");
-			Self::deposit_event(Event::<T>::Withdrawal {
-				pid: pool_info.pid,
-				user: userid,
-				amount: reduced,
-				shares: withdrawn_shares,
-			});
-		}
-
 		/// Tries to fulfill the withdraw queue with the newly freed stake
 		pub fn try_process_withdraw_queue(pool_info: &mut BasePool<T::AccountId, BalanceOf<T>>) {
+			use sp_std::collections::btree_map::BTreeMap;
 			// The share price shouldn't change at any point in this function. So we can calculate
 			// only once at the beginning.
 			let price = match pool_info.share_price() {
 				Some(price) => price,
 				None => return,
 			};
-
 			let wpha_min = wrapped_balances::Pallet::<T>::min_balance();
+			// Note: This function aggregates all the withdrawal stats and emit the events at the
+			// end. It's supposed the withdrawal process won't be interrupted by any error.
+			let mut withdrawing = BTreeMap::<T::AccountId, WithdrawEventStats<BalanceOf<T>>>::new();
 			while pool_info.get_free_stakes::<T>() > wpha_min {
-				if let Some(withdraw) = pool_info.withdraw_queue.front().cloned() {
-					// Must clear the pending reward before any stake change
-					let mut withdraw_nft_guard =
-						Self::get_nft_attr_guard(pool_info.cid, withdraw.nft_id)
-							.expect("get nftattr should always success; qed.");
-					let mut withdraw_nft = withdraw_nft_guard.attr.clone();
-					if Self::maybe_remove_dust(pool_info, &withdraw_nft) {
-						pool_info.withdraw_queue.pop_front();
-						Self::burn_nft(&pallet_id(), pool_info.cid, withdraw.nft_id)
-							.expect("burn nft should always success");
-						continue;
-					}
-					// Try to fulfill the withdraw requests as much as possible
-					let free_shares = if price == fp!(0) {
-						withdraw_nft.shares // 100% slashed
-					} else {
-						bdiv(pool_info.get_free_stakes::<T>(), &price)
-					};
-					// This is the shares to withdraw immedately. It should NOT contain any dust
-					// because we ensure (1) `free_shares` is not dust earlier, and (2) the shares
-					// in any withdraw request mustn't be dust when inserting and updating it.
-					let withdrawing_shares = free_shares.min(withdraw_nft.shares);
-					debug_assert!(
-						is_nondust_balance(withdrawing_shares),
-						"withdrawing_shares must be positive"
-					);
-					// Actually remove the fulfilled withdraw request. Dust in the user shares is
-					// considered but it in the request is ignored.
-					Self::do_withdraw_shares(
-						withdrawing_shares,
-						pool_info,
-						&mut withdraw_nft,
-						withdraw.user.clone(),
-					);
-					withdraw_nft_guard.attr = withdraw_nft.clone();
-					withdraw_nft_guard
-						.save()
-						.expect("save nft should always success");
-					// Update if the withdraw is partially fulfilled, otherwise pop it out of the
-					// queue
-					if withdraw_nft.shares == Zero::zero()
-						|| Self::maybe_remove_dust(pool_info, &withdraw_nft)
-					{
-						pool_info.withdraw_queue.pop_front();
-						Self::burn_nft(&pallet_id(), pool_info.cid, withdraw.nft_id)
-							.expect("burn nft should always success");
-					} else {
-						*pool_info
-							.withdraw_queue
-							.front_mut()
-							.expect("front exists as just checked; qed.") = withdraw;
-					}
-				} else {
+				let Some(withdraw) = pool_info.withdraw_queue.front().cloned() else {
+					// Stop if the queue is already empty
 					break;
+				};
+				let mut nft = Self::get_nft_attr_guard(pool_info.cid, withdraw.nft_id)
+					.expect("get nftattr should always success; qed.");
+				// Fast track to remove existing dust in the queue
+				if Self::maybe_remove_dust(pool_info, &nft.attr) {
+					// Account the burning NFT to emit events
+					withdrawing
+						.entry(withdraw.user.clone())
+						.or_default()
+						.burnt_shares += nft.attr.shares;
+					nft.unlock();
+					// Actually burn the NFT
+					pool_info.withdraw_queue.pop_front();
+					Self::burn_nft(&pallet_id(), pool_info.cid, withdraw.nft_id)
+						.expect("burn nft should always success");
+					continue;
 				}
+				// Try to fulfill the withdraw requests as much as possible
+				let free_shares = if price == fp!(0) {
+					nft.attr.shares // 100% slashed
+				} else {
+					bdiv(pool_info.get_free_stakes::<T>(), &price)
+				};
+				// This is the shares to withdraw immedately. It should NOT contain any dust
+				// because we ensure (1) `free_shares` is not dust earlier, and (2) the shares
+				// in any withdraw request mustn't be dust when inserting and updating it.
+				let withdrawing_shares = free_shares.min(nft.attr.shares);
+				debug_assert!(
+					is_nondust_balance(withdrawing_shares),
+					"withdrawing_shares must be positive"
+				);
+				// Actually remove the fulfilled withdraw request. Dust in the user shares is
+				// considered but it in the request is ignored.
+				let (reduced, withdrawn_shares) = Self::remove_stake_from_nft(
+					pool_info,
+					withdrawing_shares,
+					&mut nft.attr,
+					&withdraw.user,
+				)
+				.expect("There are enough withdrawing_shares; qed.");
+				// Account the withdrawn NFT to emit events
+				let event = withdrawing.entry(withdraw.user.clone()).or_default();
+				event.amount += reduced;
+				event.shares += withdrawn_shares;
+				// Update the withdraw NFT shares
+				let processed_nft = nft.attr.clone();
+				nft.save().expect("save nft should always success");
+				// Update if the withdraw is partially fulfilled, otherwise pop it out of the
+				// queue
+				if processed_nft.shares == Zero::zero()
+					|| Self::maybe_remove_dust(pool_info, &processed_nft)
+				{
+					if processed_nft.shares != Zero::zero() {
+						// Account the burning NFT to emit events
+						withdrawing
+							.entry(withdraw.user.clone())
+							.or_default()
+							.burnt_shares += processed_nft.shares;
+					}
+					pool_info.withdraw_queue.pop_front();
+					Self::burn_nft(&pallet_id(), pool_info.cid, withdraw.nft_id)
+						.expect("burn nft should always success");
+				} else {
+					*pool_info
+						.withdraw_queue
+						.front_mut()
+						.expect("front exists as just checked; qed.") = withdraw;
+				}
+			}
+			// Emit the aggregated withdrawal events
+			for (user, stats) in withdrawing.into_iter() {
+				Self::deposit_event(Event::<T>::Withdrawal {
+					pid: pool_info.pid,
+					user,
+					amount: stats.amount,
+					shares: stats.shares,
+					burnt_shares: stats.burnt_shares,
+				})
 			}
 		}
 	}

--- a/pallets/phala/src/compute/vault.rs
+++ b/pallets/phala/src/compute/vault.rs
@@ -119,7 +119,7 @@ pub mod pallet {
 		ForceShutdown {
 			pid: u64,
 			reason: ForceShutdownReason,
-		}
+		},
 	}
 
 	#[derive(PartialEq, Eq, Clone, Debug, Encode, Decode, scale_info::TypeInfo)]
@@ -370,7 +370,7 @@ pub mod pallet {
 			// Trigger force withdrawal and lock if there's any expired withdrawal.
 			// If already locked, we don't need to trigger it again.
 			if VaultLocks::<T>::contains_key(vault_pid) {
-				return Ok(())
+				return Ok(());
 			}
 			// Case 1: There's a request over 3x GracePeriod old, the pool must be shutdown.
 			let mut shutdown_reason: Option<ForceShutdownReason> = None;
@@ -421,7 +421,7 @@ pub mod pallet {
 			}
 			let Some(shutdown_reason) = shutdown_reason else {
 				// No need to shutdown.
-				return Ok(())
+				return Ok(());
 			};
 			// Try to withdraw from the upstream stake pools
 			for pid in vault.invest_pools.iter() {
@@ -446,11 +446,9 @@ pub mod pallet {
 					&vault.basepool.pool_account_id,
 				)
 				.for_each(|nftid| {
-					let property_guard = base_pool::Pallet::<T>::get_nft_attr_guard(
-						stake_pool.basepool.cid,
-						nftid,
-					)
-					.expect("get nft should not fail: qed.");
+					let property_guard =
+						base_pool::Pallet::<T>::get_nft_attr_guard(stake_pool.basepool.cid, nftid)
+							.expect("get nft should not fail: qed.");
 					let property = &property_guard.attr;
 					if !base_pool::is_nondust_balance(property.shares) {
 						let _ = base_pool::Pallet::<T>::burn_nft(

--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -10,9 +10,7 @@ use frame_support::{
 	ord_parameter_types,
 	pallet_prelude::ConstU32,
 	parameter_types,
-	traits::{
-		AsEnsureOriginWithArg, ConstU128, ConstU64, EqualPrivilegeOnly, SortedMembers,
-	},
+	traits::{AsEnsureOriginWithArg, ConstU128, ConstU64, EqualPrivilegeOnly, SortedMembers},
 };
 use frame_support_test::TestRandomness;
 use frame_system::{self as system, EnsureRoot, EnsureSigned, EnsureSignedBy};
@@ -426,7 +424,9 @@ impl AttestationValidator for MockValidator {
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	let mut t = frame_system::GenesisConfig::<Test>::default()
+		.build_storage()
+		.unwrap();
 
 	// Inject genesis storage
 	let zero_pubkey = sp_core::sr25519::Public::from_raw([0u8; 32]);

--- a/pallets/phala/src/snapshots/phala_pallets__test__vault_force_withdraw_after_3x_grace_period.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__vault_force_withdraw_after_3x_grace_period.snap
@@ -1,0 +1,172 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Uniques(
+        Event::Issued {
+            collection: 10000,
+            item: 1,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NftMinted {
+            owner: AccountId(
+                7813586407040180578,
+            ),
+            collection_id: 10000,
+            nft_id: 1,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                1,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    128,
+                    244,
+                    32,
+                    230,
+                    181,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                1,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    49,
+                    56,
+                    49,
+                    52,
+                    52,
+                    48,
+                    49,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::NftCreated {
+            pid: 0,
+            cid: 10000,
+            nft_id: 1,
+            owner: 7813586407040180578,
+            shares: 200000000000000,
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::WithdrawalQueued {
+            pid: 0,
+            user: 13009150994509951074,
+            shares: 200000000000000,
+            nft_id: 0,
+            as_vault: Some(
+                1,
+            ),
+            withdrawing_nft_id: 1,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                0,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaVault(
+        Event::ForceShutdown {
+            pid: 1,
+            reason: Waiting3xGracePeriod,
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__vault_partial_force_withdraw-2.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__vault_partial_force_withdraw-2.snap
@@ -1,0 +1,72 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::System(
+        Event::KilledAccount {
+            account: 13009150994509951074,
+        },
+    ),
+    RuntimeEvent::Assets(
+        Event::Transferred {
+            asset_id: 1,
+            from: 13009150994509951074,
+            to: 1,
+            amount: 100000000000000,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10001,
+            maybe_nft_id: Some(
+                1,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    64,
+                    122,
+                    16,
+                    243,
+                    90,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::Withdrawal {
+            pid: 1,
+            user: 1,
+            amount: 100000000000000,
+            shares: 100000000000000,
+            burnt_shares: 0,
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__vault_partial_force_withdraw.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__vault_partial_force_withdraw.snap
@@ -1,0 +1,171 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Uniques(
+        Event::Issued {
+            collection: 10000,
+            item: 1,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NftMinted {
+            owner: AccountId(
+                7813586407040180578,
+            ),
+            collection_id: 10000,
+            nft_id: 1,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                1,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    128,
+                    244,
+                    32,
+                    230,
+                    181,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                1,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    54,
+                    48,
+                    52,
+                    56,
+                    48,
+                    49,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::NftCreated {
+            pid: 0,
+            cid: 10000,
+            nft_id: 1,
+            owner: 7813586407040180578,
+            shares: 200000000000000,
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::WithdrawalQueued {
+            pid: 0,
+            user: 13009150994509951074,
+            shares: 200000000000000,
+            nft_id: 0,
+            as_vault: Some(
+                1,
+            ),
+            withdrawing_nft_id: 1,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                0,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaVault(
+        Event::ForceShutdown {
+            pid: 1,
+            reason: NoEnoughReleasingStake,
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__withdraw1.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__withdraw1.snap
@@ -1,0 +1,224 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Uniques(
+        Event::Issued {
+            collection: 10000,
+            item: 3,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NftMinted {
+            owner: AccountId(
+                7813586407040180578,
+            ),
+            collection_id: 10000,
+            nft_id: 3,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                3,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    192,
+                    110,
+                    49,
+                    217,
+                    16,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                3,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    48,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::NftCreated {
+            pid: 0,
+            cid: 10000,
+            nft_id: 3,
+            owner: 7813586407040180578,
+            shares: 300000000000000,
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::WithdrawalQueued {
+            pid: 0,
+            user: 2,
+            shares: 300000000000000,
+            nft_id: 0,
+            as_vault: None,
+            withdrawing_nft_id: 3,
+        },
+    ),
+    RuntimeEvent::System(
+        Event::KilledAccount {
+            account: 16637257129592320098,
+        },
+    ),
+    RuntimeEvent::Assets(
+        Event::Transferred {
+            asset_id: 1,
+            from: 16637257129592320098,
+            to: 2,
+            amount: 200000000000000,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                3,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    64,
+                    122,
+                    16,
+                    243,
+                    90,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::Withdrawal {
+            pid: 0,
+            user: 2,
+            amount: 200000000000000,
+            shares: 200000000000000,
+            burnt_shares: 0,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                0,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__withdraw2.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__withdraw2.snap
@@ -1,0 +1,232 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Uniques(
+        Event::Issued {
+            collection: 10000,
+            item: 4,
+            owner: 99,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NftMinted {
+            owner: AccountId(
+                99,
+            ),
+            collection_id: 10000,
+            nft_id: 4,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                4,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    192,
+                    110,
+                    49,
+                    217,
+                    16,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                4,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    48,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::NftCreated {
+            pid: 0,
+            cid: 10000,
+            nft_id: 4,
+            owner: 99,
+            shares: 300000000000000,
+        },
+    ),
+    RuntimeEvent::System(
+        Event::NewAccount {
+            account: 16637257129592320098,
+        },
+    ),
+    RuntimeEvent::Assets(
+        Event::Transferred {
+            asset_id: 1,
+            from: 99,
+            to: 16637257129592320098,
+            amount: 300000000000000,
+        },
+    ),
+    RuntimeEvent::Assets(
+        Event::Transferred {
+            asset_id: 1,
+            from: 16637257129592320098,
+            to: 2,
+            amount: 100000000000000,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                3,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertiesRemoved {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                3,
+            ),
+        },
+    ),
+    RuntimeEvent::Uniques(
+        Event::Burned {
+            collection: 10000,
+            item: 3,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NFTBurned {
+            owner: 7813586407040180578,
+            collection_id: 10000,
+            nft_id: 3,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertyRemoved {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                3,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::Withdrawal {
+            pid: 0,
+            user: 2,
+            amount: 100000000000000,
+            shares: 100000000000000,
+            burnt_shares: 0,
+        },
+    ),
+    RuntimeEvent::PhalaStakePoolv2(
+        Event::Contribution {
+            pid: 0,
+            user: 99,
+            amount: 300000000000000,
+            shares: 300000000000000,
+            as_vault: None,
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__withdraw3.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__withdraw3.snap
@@ -1,0 +1,269 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Uniques(
+        Event::Issued {
+            collection: 10000,
+            item: 5,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NftMinted {
+            owner: AccountId(
+                7813586407040180578,
+            ),
+            collection_id: 10000,
+            nft_id: 5,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                5,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    128,
+                    244,
+                    32,
+                    230,
+                    181,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                5,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    48,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::NftCreated {
+            pid: 0,
+            cid: 10000,
+            nft_id: 5,
+            owner: 7813586407040180578,
+            shares: 200000000000000,
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::WithdrawalQueued {
+            pid: 0,
+            user: 1,
+            shares: 200000000000000,
+            nft_id: 1,
+            as_vault: None,
+            withdrawing_nft_id: 5,
+        },
+    ),
+    RuntimeEvent::System(
+        Event::KilledAccount {
+            account: 16637257129592320098,
+        },
+    ),
+    RuntimeEvent::Assets(
+        Event::Transferred {
+            asset_id: 1,
+            from: 16637257129592320098,
+            to: 1,
+            amount: 200000000000000,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                5,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertiesRemoved {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                5,
+            ),
+        },
+    ),
+    RuntimeEvent::Uniques(
+        Event::Burned {
+            collection: 10000,
+            item: 5,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NFTBurned {
+            owner: 7813586407040180578,
+            collection_id: 10000,
+            nft_id: 5,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertyRemoved {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                5,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::Withdrawal {
+            pid: 0,
+            user: 1,
+            amount: 200000000000000,
+            shares: 200000000000000,
+            burnt_shares: 0,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                1,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    64,
+                    122,
+                    16,
+                    243,
+                    90,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__withdraw4.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__withdraw4.snap
@@ -1,0 +1,224 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Uniques(
+        Event::Issued {
+            collection: 10001,
+            item: 2,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NftMinted {
+            owner: AccountId(
+                7813586407040180578,
+            ),
+            collection_id: 10001,
+            nft_id: 2,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10001,
+            maybe_nft_id: Some(
+                2,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    128,
+                    244,
+                    32,
+                    230,
+                    181,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10001,
+            maybe_nft_id: Some(
+                2,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    48,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::NftCreated {
+            pid: 1,
+            cid: 10001,
+            nft_id: 2,
+            owner: 7813586407040180578,
+            shares: 200000000000000,
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::WithdrawalQueued {
+            pid: 1,
+            user: 1,
+            shares: 200000000000000,
+            nft_id: 0,
+            as_vault: None,
+            withdrawing_nft_id: 2,
+        },
+    ),
+    RuntimeEvent::System(
+        Event::KilledAccount {
+            account: 13009150994509951074,
+        },
+    ),
+    RuntimeEvent::Assets(
+        Event::Transferred {
+            asset_id: 1,
+            from: 13009150994509951074,
+            to: 1,
+            amount: 100000000000000,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10001,
+            maybe_nft_id: Some(
+                2,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    64,
+                    122,
+                    16,
+                    243,
+                    90,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::Withdrawal {
+            pid: 1,
+            user: 1,
+            amount: 100000000000000,
+            shares: 100000000000000,
+            burnt_shares: 0,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10001,
+            maybe_nft_id: Some(
+                0,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    64,
+                    122,
+                    16,
+                    243,
+                    90,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__withdraw5.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__withdraw5.snap
@@ -1,0 +1,264 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Uniques(
+        Event::Issued {
+            collection: 10000,
+            item: 7,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NftMinted {
+            owner: AccountId(
+                7813586407040180578,
+            ),
+            collection_id: 10000,
+            nft_id: 7,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                7,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    128,
+                    244,
+                    32,
+                    230,
+                    181,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                7,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    48,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::NftCreated {
+            pid: 0,
+            cid: 10000,
+            nft_id: 7,
+            owner: 7813586407040180578,
+            shares: 200000000000000,
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::WithdrawalQueued {
+            pid: 0,
+            user: 3,
+            shares: 200000000000000,
+            nft_id: 2,
+            as_vault: None,
+            withdrawing_nft_id: 7,
+        },
+    ),
+    RuntimeEvent::Assets(
+        Event::Transferred {
+            asset_id: 1,
+            from: 16637257129592320098,
+            to: 3,
+            amount: 200000000000000,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                7,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertiesRemoved {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                7,
+            ),
+        },
+    ),
+    RuntimeEvent::Uniques(
+        Event::Burned {
+            collection: 10000,
+            item: 7,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NFTBurned {
+            owner: 7813586407040180578,
+            collection_id: 10000,
+            nft_id: 7,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertyRemoved {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                7,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::Withdrawal {
+            pid: 0,
+            user: 3,
+            amount: 200000000000000,
+            shares: 200000000000000,
+            burnt_shares: 0,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                2,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    64,
+                    122,
+                    16,
+                    243,
+                    90,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__withdraw6.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__withdraw6.snap
@@ -1,0 +1,231 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Uniques(
+        Event::Issued {
+            collection: 10000,
+            item: 8,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NftMinted {
+            owner: AccountId(
+                7813586407040180578,
+            ),
+            collection_id: 10000,
+            nft_id: 8,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                8,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    0,
+                    233,
+                    65,
+                    204,
+                    107,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                8,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    48,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::NftCreated {
+            pid: 0,
+            cid: 10000,
+            nft_id: 8,
+            owner: 7813586407040180578,
+            shares: 400000000000000,
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::WithdrawalQueued {
+            pid: 0,
+            user: 13009150994509951074,
+            shares: 400000000000000,
+            nft_id: 6,
+            as_vault: Some(
+                1,
+            ),
+            withdrawing_nft_id: 8,
+        },
+    ),
+    RuntimeEvent::System(
+        Event::KilledAccount {
+            account: 16637257129592320098,
+        },
+    ),
+    RuntimeEvent::System(
+        Event::NewAccount {
+            account: 13009150994509951074,
+        },
+    ),
+    RuntimeEvent::Assets(
+        Event::Transferred {
+            asset_id: 1,
+            from: 16637257129592320098,
+            to: 13009150994509951074,
+            amount: 300000000000000,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                8,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    64,
+                    122,
+                    16,
+                    243,
+                    90,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::Withdrawal {
+            pid: 0,
+            user: 13009150994509951074,
+            amount: 300000000000000,
+            shares: 300000000000000,
+            burnt_shares: 0,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10000,
+            maybe_nft_id: Some(
+                6,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    64,
+                    122,
+                    16,
+                    243,
+                    90,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__withdraw7.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__withdraw7.snap
@@ -1,0 +1,212 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Uniques(
+        Event::Issued {
+            collection: 10002,
+            item: 1,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NftMinted {
+            owner: AccountId(
+                7813586407040180578,
+            ),
+            collection_id: 10002,
+            nft_id: 1,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10002,
+            maybe_nft_id: Some(
+                1,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    160,
+                    134,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10002,
+            maybe_nft_id: Some(
+                1,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    48,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::NftCreated {
+            pid: 2,
+            cid: 10002,
+            nft_id: 1,
+            owner: 7813586407040180578,
+            shares: 100000,
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::WithdrawalQueued {
+            pid: 2,
+            user: 99,
+            shares: 100000,
+            nft_id: 0,
+            as_vault: None,
+            withdrawing_nft_id: 1,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertiesRemoved {
+            collection_id: 10002,
+            maybe_nft_id: Some(
+                1,
+            ),
+        },
+    ),
+    RuntimeEvent::Uniques(
+        Event::Burned {
+            collection: 10002,
+            item: 1,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NFTBurned {
+            owner: 7813586407040180578,
+            collection_id: 10002,
+            nft_id: 1,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertyRemoved {
+            collection_id: 10002,
+            maybe_nft_id: Some(
+                1,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::Withdrawal {
+            pid: 2,
+            user: 99,
+            amount: 0,
+            shares: 0,
+            burnt_shares: 100000,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10002,
+            maybe_nft_id: Some(
+                0,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    192,
+                    110,
+                    49,
+                    217,
+                    16,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__withdraw8.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__withdraw8.snap
@@ -3,6 +3,13 @@ source: pallets/phala/src/test.rs
 expression: take_events()
 ---
 [
+    RuntimeEvent::PhalaVault(
+        Event::OwnerSharesGained {
+            pid: 2,
+            shares: 100,
+            checkout_price: 1000000000333,
+        },
+    ),
     RuntimeEvent::Uniques(
         Event::Issued {
             collection: 10002,

--- a/pallets/phala/src/snapshots/phala_pallets__test__withdraw8.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__withdraw8.snap
@@ -1,0 +1,224 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Uniques(
+        Event::Issued {
+            collection: 10002,
+            item: 2,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NftMinted {
+            owner: AccountId(
+                7813586407040180578,
+            ),
+            collection_id: 10002,
+            nft_id: 2,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10002,
+            maybe_nft_id: Some(
+                2,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    192,
+                    110,
+                    49,
+                    217,
+                    16,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10002,
+            maybe_nft_id: Some(
+                2,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    48,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::NftCreated {
+            pid: 2,
+            cid: 10002,
+            nft_id: 2,
+            owner: 7813586407040180578,
+            shares: 300000000000000,
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::WithdrawalQueued {
+            pid: 2,
+            user: 99,
+            shares: 300000000000000,
+            nft_id: 0,
+            as_vault: None,
+            withdrawing_nft_id: 2,
+        },
+    ),
+    RuntimeEvent::System(
+        Event::KilledAccount {
+            account: 615996557710291042,
+        },
+    ),
+    RuntimeEvent::Assets(
+        Event::Transferred {
+            asset_id: 1,
+            from: 615996557710291042,
+            to: 99,
+            amount: 10000099999,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10002,
+            maybe_nft_id: Some(
+                2,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    100,
+                    85,
+                    97,
+                    221,
+                    214,
+                    16,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::Withdrawal {
+            pid: 2,
+            user: 99,
+            amount: 10000099999,
+            shares: 10000099996,
+            burnt_shares: 0,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10002,
+            maybe_nft_id: Some(
+                0,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+]

--- a/pallets/phala/src/snapshots/phala_pallets__test__withdraw9.snap
+++ b/pallets/phala/src/snapshots/phala_pallets__test__withdraw9.snap
@@ -1,0 +1,112 @@
+---
+source: pallets/phala/src/test.rs
+expression: take_events()
+---
+[
+    RuntimeEvent::Assets(
+        Event::Transferred {
+            asset_id: 1,
+            from: 13009150994509951074,
+            to: 1,
+            amount: 100000000000000,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertySet {
+            collection_id: 10001,
+            maybe_nft_id: Some(
+                2,
+            ),
+            key: BoundedVec(
+                [
+                    115,
+                    116,
+                    97,
+                    107,
+                    101,
+                    45,
+                    105,
+                    110,
+                    102,
+                    111,
+                ],
+                32000,
+            ),
+            value: BoundedVec(
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                512000,
+            ),
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertiesRemoved {
+            collection_id: 10001,
+            maybe_nft_id: Some(
+                2,
+            ),
+        },
+    ),
+    RuntimeEvent::Uniques(
+        Event::Burned {
+            collection: 10001,
+            item: 2,
+            owner: 7813586407040180578,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::NFTBurned {
+            owner: 7813586407040180578,
+            collection_id: 10001,
+            nft_id: 2,
+        },
+    ),
+    RuntimeEvent::RmrkCore(
+        Event::PropertyRemoved {
+            collection_id: 10001,
+            maybe_nft_id: Some(
+                2,
+            ),
+            key: BoundedVec(
+                [
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    116,
+                    105,
+                    109,
+                    101,
+                ],
+                32000,
+            ),
+        },
+    ),
+    RuntimeEvent::PhalaBasePool(
+        Event::Withdrawal {
+            pid: 1,
+            user: 1,
+            amount: 100000000000000,
+            shares: 100000000000000,
+            burnt_shares: 0,
+        },
+    ),
+]

--- a/pallets/phala/src/test.rs
+++ b/pallets/phala/src/test.rs
@@ -1680,6 +1680,7 @@ fn test_withdraw() {
 		set_block_1();
 		setup_workers(2);
 		setup_stake_pool_with_workers(1, &[1, 2]); // pid = 0
+		// Contribute 300 x3 and use 700 to compute
 		assert_ok!(PhalaStakePoolv2::contribute(
 			RuntimeOrigin::signed(2),
 			0,
@@ -1710,12 +1711,15 @@ fn test_withdraw() {
 			worker_pubkey(2),
 			300 * DOLLARS
 		));
+		// Partial withdraw 300 PHA. 200 withdrawn and 100 left in the queue.
+		let _ = take_events();
 		assert_ok!(PhalaStakePoolv2::withdraw(
 			RuntimeOrigin::signed(2),
 			0,
 			300 * DOLLARS,
 			None
 		));
+		insta::assert_debug_snapshot!("withdraw1", take_events());
 		let pool = ensure_stake_pool::<Test>(0).unwrap();
 		let item = pool
 			.basepool
@@ -1731,76 +1735,50 @@ fn test_withdraw() {
 					.clone();
 			assert_eq!(nft_attr.shares, 100 * DOLLARS);
 		}
-		let mut nftid_arr: Vec<NftId> =
-			pallet_rmrk_core::Nfts::<Test>::iter_key_prefix(10000).collect();
-		nftid_arr.retain(|x| {
-			let nft = pallet_rmrk_core::Nfts::<Test>::get(10000, x).unwrap();
-			nft.owner == rmrk_traits::AccountIdOrCollectionNftTuple::AccountId(2)
-		});
-		assert_eq!(nftid_arr.len(), 1);
-		{
-			let user_nft_attr = PhalaBasePool::get_nft_attr_guard(pool.basepool.cid, nftid_arr[0])
-				.unwrap()
-				.attr
-				.clone();
-			assert_eq!(user_nft_attr.shares, 0);
-		}
+		// Check account2 has no share in its NFT
+		assert_user_has_share(10000, 2, 0);
 		assert_eq!(get_balance(2), 400 * DOLLARS);
+		// Add another 300 PHA, expect 100 PHA queued withdrawal being fulfilled.
+		let _ = take_events();
 		assert_ok!(PhalaStakePoolv2::contribute(
 			RuntimeOrigin::signed(99),
 			0,
 			300 * DOLLARS,
 			None
 		));
+		insta::assert_debug_snapshot!("withdraw2", take_events());
 		let pool = ensure_stake_pool::<Test>(0).unwrap();
 		assert_eq!(pool.basepool.withdraw_queue.len(), 0);
 		assert_eq!(get_balance(2), 500 * DOLLARS);
-		let mut nftid_arr: Vec<NftId> =
-			pallet_rmrk_core::Nfts::<Test>::iter_key_prefix(10000).collect();
-		nftid_arr.retain(|x| {
-			let nft = pallet_rmrk_core::Nfts::<Test>::get(10000, x).unwrap();
-			nft.owner == rmrk_traits::AccountIdOrCollectionNftTuple::AccountId(2)
-		});
-		assert_eq!(nftid_arr.len(), 1);
-		{
-			let user_nft_attr = PhalaBasePool::get_nft_attr_guard(pool.basepool.cid, nftid_arr[0])
-				.unwrap()
-				.attr
-				.clone();
-			assert_eq!(user_nft_attr.shares, 0);
-		}
+		// Account 2 has no share in the NFT
+		assert_user_has_share(10000, 2, 0);
+		// Account 1 can withdraw 200 PHA with free stake
+		let _ = take_events();
 		assert_ok!(PhalaStakePoolv2::withdraw(
 			RuntimeOrigin::signed(1),
 			0,
 			200 * DOLLARS,
 			None
 		));
+		insta::assert_debug_snapshot!("withdraw3", take_events());
 		let pool = ensure_stake_pool::<Test>(0).unwrap();
 		assert_eq!(pool.basepool.withdraw_queue.len(), 0);
 		assert_eq!(get_balance(1), 400 * DOLLARS);
-		let mut nftid_arr: Vec<NftId> =
-			pallet_rmrk_core::Nfts::<Test>::iter_key_prefix(10000).collect();
-		nftid_arr.retain(|x| {
-			let nft = pallet_rmrk_core::Nfts::<Test>::get(10000, x).unwrap();
-			nft.owner == rmrk_traits::AccountIdOrCollectionNftTuple::AccountId(1)
-		});
-		assert_eq!(nftid_arr.len(), 1);
-		{
-			let user_nft_attr = PhalaBasePool::get_nft_attr_guard(pool.basepool.cid, nftid_arr[0])
-				.unwrap()
-				.attr
-				.clone();
-			assert_eq!(user_nft_attr.shares, 100 * DOLLARS);
-		}
-		let _pid = setup_vault(99);
+		// Account 1 has 100 shares left
+		assert_user_has_share(10000, 1, 100 * DOLLARS);
+		// Vault 1 tests case:
+		// - 300 x2 PHA contribution to vault1
+		// - 500 from vault1 to sp0
+		let vault1 = setup_vault(99);
+		assert_eq!(vault1, 1);
 		assert_ok!(PhalaVault::contribute(
 			RuntimeOrigin::signed(1),
-			1,
+			vault1,
 			300 * DOLLARS,
 		));
 		assert_ok!(PhalaVault::contribute(
 			RuntimeOrigin::signed(99),
-			1,
+			vault1,
 			300 * DOLLARS,
 		));
 		assert_ok!(PhalaStakePoolv2::contribute(
@@ -1809,12 +1787,15 @@ fn test_withdraw() {
 			500 * DOLLARS,
 			Some(1)
 		));
+		// Account1 can withdraw 100 now and left 100 in the queue from vault1
+		let _ = take_events();
 		assert_ok!(PhalaVault::withdraw(
 			RuntimeOrigin::signed(1),
-			1,
+			vault1,
 			200 * DOLLARS,
 		));
-		let pool = ensure_vault::<Test>(1).unwrap();
+		insta::assert_debug_snapshot!("withdraw4", take_events());
+		let pool = ensure_vault::<Test>(vault1).unwrap();
 		let item = pool
 			.basepool
 			.withdraw_queue
@@ -1829,37 +1810,30 @@ fn test_withdraw() {
 					.clone();
 			assert_eq!(nft_attr.shares, 100 * DOLLARS);
 		}
-		let mut nftid_arr: Vec<NftId> =
-			pallet_rmrk_core::Nfts::<Test>::iter_key_prefix(10001).collect();
-		nftid_arr.retain(|x| {
-			let nft = pallet_rmrk_core::Nfts::<Test>::get(10001, x).unwrap();
-			nft.owner == rmrk_traits::AccountIdOrCollectionNftTuple::AccountId(1)
-		});
-		assert_eq!(nftid_arr.len(), 1);
-		{
-			let user_nft_attr = PhalaBasePool::get_nft_attr_guard(pool.basepool.cid, nftid_arr[0])
-				.unwrap()
-				.attr
-				.clone();
-			assert_eq!(user_nft_attr.shares, 100 * DOLLARS);
-		}
+		assert_user_has_share(10001, 1, 100 * DOLLARS);
 		assert_eq!(get_balance(1), 200 * DOLLARS);
+		// Account3 withdraw 200 with 500 contribution from vault1
+		let _ = take_events();
 		assert_ok!(PhalaStakePoolv2::withdraw(
 			RuntimeOrigin::signed(3),
 			0,
 			200 * DOLLARS,
 			None
 		));
+		insta::assert_debug_snapshot!("withdraw5", take_events());
 		let pool = ensure_stake_pool::<Test>(0).unwrap();
 		assert_eq!(get_balance(pool.basepool.pool_account_id), 300 * DOLLARS);
+		// Vault1 withdraw 400, only get 300, left 100 in the queue and 100 in share
+		let _ = take_events();
 		assert_ok!(PhalaStakePoolv2::withdraw(
 			RuntimeOrigin::signed(99),
 			0,
 			400 * DOLLARS,
 			Some(1)
 		));
+		insta::assert_debug_snapshot!("withdraw6", take_events());
 		let pool = ensure_stake_pool::<Test>(0).unwrap();
-		let vault = ensure_vault::<Test>(1).unwrap();
+		let vault = ensure_vault::<Test>(vault1).unwrap();
 		let item = pool
 			.basepool
 			.withdraw_queue
@@ -1874,61 +1848,44 @@ fn test_withdraw() {
 					.clone();
 			assert_eq!(nft_attr.shares, 100 * DOLLARS);
 		}
-		let mut nftid_arr: Vec<NftId> =
-			pallet_rmrk_core::Nfts::<Test>::iter_key_prefix(10000).collect();
-		nftid_arr.retain(|x| {
-			let nft = pallet_rmrk_core::Nfts::<Test>::get(10000, x).unwrap();
-			nft.owner
-				== rmrk_traits::AccountIdOrCollectionNftTuple::AccountId(
-					vault.basepool.pool_account_id,
-				)
-		});
-		assert_eq!(nftid_arr.len(), 1);
-		{
-			let user_nft_attr = PhalaBasePool::get_nft_attr_guard(pool.basepool.cid, nftid_arr[0])
-				.unwrap()
-				.attr
-				.clone();
-			assert_eq!(user_nft_attr.shares, 100 * DOLLARS);
-		}
+		assert_user_has_share(10000, vault.basepool.pool_account_id, 100 * DOLLARS);
 		assert_eq!(get_balance(vault.basepool.pool_account_id), 300 * DOLLARS);
-		let mut nftid_arr: Vec<NftId> =
-			pallet_rmrk_core::Nfts::<Test>::iter_key_prefix(10001).collect();
-		nftid_arr.retain(|x| {
-			let nft = pallet_rmrk_core::Nfts::<Test>::get(10001, x).unwrap();
-			nft.owner == rmrk_traits::AccountIdOrCollectionNftTuple::AccountId(1)
-		});
-		assert_eq!(nftid_arr.len(), 1);
-		{
-			let user_nft_attr = PhalaBasePool::get_nft_attr_guard(vault.basepool.cid, nftid_arr[0])
-				.unwrap()
-				.attr
-				.clone();
-			assert_eq!(user_nft_attr.shares, 100 * DOLLARS);
-		}
-		let _pid = setup_vault(99);
+		// Vault 2 test case:
+		// - Account99 contribute (300 + eps), eps = 1e5 pico PHA
+		let vault2 = setup_vault(99);
 		assert_ok!(PhalaVault::contribute(
 			RuntimeOrigin::signed(99),
-			2,
+			vault2,
 			300000000100000,
 		));
-		assert_ok!(PhalaVault::withdraw(RuntimeOrigin::signed(99), 2, 100000,));
+		// Account99 withdraw eps from vault2
+		// Note: 100000 shares were burnt because the amount to withdraw is smaller than WPHA min.
+		let _ = take_events();
+		assert_ok!(PhalaVault::withdraw(RuntimeOrigin::signed(99), vault2, 100000));
+		insta::assert_debug_snapshot!("withdraw7", take_events());
+		// Vault2 can contribute 299.99 to pool0
 		assert_ok!(PhalaStakePoolv2::contribute(
 			RuntimeOrigin::signed(99),
 			0,
 			299990000000000,
 			Some(2)
 		));
+		// Account 99 withdraw 300 PHA from vault2
+		// ~(0.01 + eps) PHA can be withdrawn, leaving the rest in the queue
+		let _ = take_events();
 		assert_ok!(PhalaVault::withdraw(
 			RuntimeOrigin::signed(99),
-			2,
+			vault2,
 			300 * DOLLARS,
 		));
-		let pool = ensure_vault::<Test>(1).unwrap();
+		insta::assert_debug_snapshot!("withdraw8", take_events());
+		// With 299.99 contribution from vault2, vault1 can clear its queue
+		let _ = take_events();
 		assert_ok!(PhalaVault::check_and_maybe_force_withdraw(
 			RuntimeOrigin::signed(4),
-			pool.basepool.pid
+			vault1,
 		));
+		insta::assert_debug_snapshot!("withdraw9", take_events());
 	});
 }
 
@@ -2178,4 +2135,20 @@ fn set_balance_proposal(value: u128) -> BoundedCallOf<Test> {
 	};
 	let outer = RuntimeCall::Balances(inner);
 	Preimage::bound(outer).unwrap()
+}
+
+fn assert_user_has_share(cid: u32, owner: u64, shares: u128) {
+	let mut nftid_arr: Vec<NftId> = pallet_rmrk_core::Nfts::<Test>::iter_key_prefix(cid).collect();
+	nftid_arr.retain(|x| {
+		let nft = pallet_rmrk_core::Nfts::<Test>::get(cid, x).unwrap();
+		nft.owner == rmrk_traits::AccountIdOrCollectionNftTuple::AccountId(owner)
+	});
+	assert_eq!(nftid_arr.len(), 1, "owner not found");
+	assert_eq!(
+		PhalaBasePool::get_nft_attr_guard(cid, nftid_arr[0])
+			.unwrap()
+			.attr
+			.shares,
+		shares
+	);
 }

--- a/pallets/phala/src/test.rs
+++ b/pallets/phala/src/test.rs
@@ -2131,7 +2131,10 @@ fn vault_partial_force_withdraw() {
 		elapse_cool_down();
 		elapse_seconds(1);
 		let _ = take_events();
-		assert_ok!(PhalaVault::check_and_maybe_force_withdraw(RuntimeOrigin::signed(1), 1));
+		assert_ok!(PhalaVault::check_and_maybe_force_withdraw(
+			RuntimeOrigin::signed(1),
+			1
+		));
 		insta::assert_debug_snapshot!(take_events());
 		assert!(vault::VaultLocks::<Test>::contains_key(vault1));
 		// Pool0 stop first worker first
@@ -2148,7 +2151,10 @@ fn vault_partial_force_withdraw() {
 		));
 		// Partial fill 100 PHA (out of 200)
 		let _ = take_events();
-		assert_ok!(PhalaVault::check_and_maybe_force_withdraw(RuntimeOrigin::signed(1), 1));
+		assert_ok!(PhalaVault::check_and_maybe_force_withdraw(
+			RuntimeOrigin::signed(1),
+			1
+		));
 		insta::assert_debug_snapshot!(take_events());
 		assert!(vault::VaultLocks::<Test>::contains_key(vault1));
 	});
@@ -2197,7 +2203,10 @@ fn vault_force_withdraw_after_3x_grace_period() {
 		elapse_cool_down();
 		elapse_seconds(1);
 		let _ = take_events();
-		assert_ok!(PhalaVault::check_and_maybe_force_withdraw(RuntimeOrigin::signed(1), 1));
+		assert_ok!(PhalaVault::check_and_maybe_force_withdraw(
+			RuntimeOrigin::signed(1),
+			1
+		));
 		insta::assert_debug_snapshot!(take_events());
 		assert!(vault::VaultLocks::<Test>::contains_key(vault1));
 	});

--- a/pallets/phala/src/test.rs
+++ b/pallets/phala/src/test.rs
@@ -1680,6 +1680,7 @@ fn test_withdraw() {
 		set_block_1();
 		setup_workers(2);
 		setup_stake_pool_with_workers(1, &[1, 2]); // pid = 0
+
 		// Contribute 300 x3 and use 700 to compute
 		assert_ok!(PhalaStakePoolv2::contribute(
 			RuntimeOrigin::signed(2),
@@ -1861,7 +1862,11 @@ fn test_withdraw() {
 		// Account99 withdraw eps from vault2
 		// Note: 100000 shares were burnt because the amount to withdraw is smaller than WPHA min.
 		let _ = take_events();
-		assert_ok!(PhalaVault::withdraw(RuntimeOrigin::signed(99), vault2, 100000));
+		assert_ok!(PhalaVault::withdraw(
+			RuntimeOrigin::signed(99),
+			vault2,
+			100000
+		));
 		insta::assert_debug_snapshot!("withdraw7", take_events());
 		// Vault2 can contribute 299.99 to pool0
 		assert_ok!(PhalaStakePoolv2::contribute(


### PR DESCRIPTION
A few security and accounting improvements:

- Allow a vault force withdraw requests to be partially filled whenever there's available stake in stake pool by calling `check_and_maybe_force_withdraw`
- Trigger fall safe vault force withdraw when there's a request with 3x grace period (21 days)
- Trigger vault owner reward settle at the beginning of `contribute()` and `withdraw()`
- Add precise burnt shares to the `Withdrawal` event
- Add withdrawing NFT id to the `WithdrawalQueued` event