### PR TITLE
Example for testing with drink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10099,7 +10099,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "dlmalloc",
  "ink",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "fflonk"
 version = "0.1.0"
-source = "git+https://github.com/w3f/fflonk#26a5045b24e169cffc1f9328ca83d71061145c40"
+source = "git+https://github.com/w3f/fflonk#e141d4b6f42fb481aefe1b479788694945b6940d"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -10099,7 +10099,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "dlmalloc",
  "ink",
@@ -10129,7 +10129,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension-runtime"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "futures",
  "getrandom 0.2.7",
@@ -10202,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "pink-s3"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base16",
  "chrono",
@@ -10216,7 +10216,7 @@ dependencies = [
 
 [[package]]
 name = "pink-subrpc"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "base58",
  "hex",
@@ -10236,7 +10236,7 @@ dependencies = [
 
 [[package]]
 name = "pink-utils"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "hex",
  "ink",
@@ -16316,7 +16316,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/crates/pink-drivers/log_server/Cargo.toml
+++ b/crates/pink-drivers/log_server/Cargo.toml
@@ -11,7 +11,7 @@ ink = { version = "4", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 
-pink-extension = { version = "0.4", default-features = false, path = "../../pink/pink-extension", features = ["ink-as-dependency"] }
+pink-extension = { version = "0.4", default-features = false, path = "../../pink/pink-extension" }
 this-crate = { path = "../../this-crate" }
 
 [build-dependencies]

--- a/crates/pink-drivers/log_server/Cargo.toml
+++ b/crates/pink-drivers/log_server/Cargo.toml
@@ -11,7 +11,7 @@ ink = { version = "4", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 
-pink-extension = { version = "0.4", default-features = false, path = "../../pink/pink-extension" }
+pink-extension = { default-features = false, path = "../../pink/pink-extension" }
 this-crate = { path = "../../this-crate" }
 
 [build-dependencies]

--- a/crates/pink-drivers/sidevm_deployer/Cargo.toml
+++ b/crates/pink-drivers/sidevm_deployer/Cargo.toml
@@ -10,8 +10,8 @@ ink = { version = "4", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 
-pink-extension = { version = "0.4", default-features = false, path = "../../pink/pink-extension", features = ["ink-as-dependency"] }
-system = { version = "1.0", default-features = false, path = "../system", features = ["ink-as-dependency"] }
+pink-extension = { version = "0.4", default-features = false, path = "../../pink/pink-extension" }
+system = { version = "1.0", default-features = false, path = "../system" }
 this-crate = { path = "../../this-crate" }
 
 [lib]

--- a/crates/pink-drivers/sidevm_deployer/Cargo.toml
+++ b/crates/pink-drivers/sidevm_deployer/Cargo.toml
@@ -10,7 +10,7 @@ ink = { version = "4", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 
-pink-extension = { version = "0.4", default-features = false, path = "../../pink/pink-extension" }
+pink-extension = { default-features = false, path = "../../pink/pink-extension" }
 system = { version = "1.0", default-features = false, path = "../system" }
 this-crate = { path = "../../this-crate" }
 

--- a/crates/pink-drivers/system/Cargo.toml
+++ b/crates/pink-drivers/system/Cargo.toml
@@ -9,7 +9,7 @@ ink = { version = "4", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 
-pink-extension = { version = "0.4", default-features = false, path = "../../pink/pink-extension" }
+pink-extension = { default-features = false, path = "../../pink/pink-extension" }
 this-crate = { path = "../../this-crate" }
 
 [lib]

--- a/crates/pink-drivers/tokenomic/Cargo.toml
+++ b/crates/pink-drivers/tokenomic/Cargo.toml
@@ -15,7 +15,7 @@ ink = { version = "4", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 
-pink-extension = { version = "0.4", default-features = false, path = "../../../crates/pink/pink-extension" }
+pink-extension = { default-features = false, path = "../../../crates/pink/pink-extension" }
 this-crate = { path = "../../this-crate" }
 
 [build-dependencies]

--- a/crates/pink-libs/s3/Cargo.toml
+++ b/crates/pink-libs/s3/Cargo.toml
@@ -3,12 +3,12 @@ description = "Simple S3 client for Phala's pink"
 homepage = "https://github.com/Phala-Network/phala-blockchain"
 license = "Apache-2.0"
 name = "pink-s3"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 keywords = ["phat-contract", "pink", "ink", "S3"]
 
 [dependencies]
-pink-extension = { version = "0.4.0", default-features = false, path = "../../pink/pink-extension" }
+pink-extension = { version = "0.5.0", default-features = false, path = "../../pink/pink-extension" }
 scale = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 sha2 = { version = "0.10.2", default-features = false }

--- a/crates/pink-libs/subrpc/Cargo.toml
+++ b/crates/pink-libs/subrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pink-subrpc"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Phala Network"]
 edition = "2021"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ hex-literal = "0.4.1"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 impl-serde = { version = "0.4.0", optional = true }
 
-pink-extension = { version = "0.4", path = "../../pink/pink-extension", default-features = false, features = ["ink-as-dependency"] }
+pink-extension = { version = "0.4", path = "../../pink/pink-extension", default-features = false }
 sp-core-hashing = { version = "9", default-features = false }
 
 serde = { version = "1.0.140", default-features = false, features = ["derive", "alloc"]}

--- a/crates/pink-libs/subrpc/Cargo.toml
+++ b/crates/pink-libs/subrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pink-subrpc"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["Phala Network"]
 edition = "2021"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ hex-literal = "0.4.1"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 impl-serde = { version = "0.4.0", optional = true }
 
-pink-extension = { version = "0.4", path = "../../pink/pink-extension", default-features = false }
+pink-extension = { version = "0.5", path = "../../pink/pink-extension", default-features = false }
 sp-core-hashing = { version = "9", default-features = false }
 
 serde = { version = "1.0.140", default-features = false, features = ["derive", "alloc"]}
@@ -31,7 +31,7 @@ ss58-registry = { version = "1.33.0", default-features = false }
 base58 = { version = "0.2.0", default-features = false }
 
 [dev-dependencies]
-pink-extension-runtime = { version = "0.4", path = "../../pink/pink-extension-runtime" }
+pink-extension-runtime = { path = "../../pink/pink-extension-runtime" }
 xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.2.0", default-features = false, features = ["std"] }
 
 [features]

--- a/crates/pink-libs/utils/Cargo.toml
+++ b/crates/pink-libs/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pink-utils"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Useful utilities for pink"
 homepage = "https://github.com/Phala-Network/phala-blockchain"
@@ -13,7 +13,7 @@ ink = { version = "4", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 
-pink-extension = { version = "0.4.0", default-features = false, path = "../../pink/pink-extension" }
+pink-extension = { version = "0.5.0", default-features = false, path = "../../pink/pink-extension" }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/crates/pink/pink-extension-runtime/Cargo.toml
+++ b/crates/pink/pink-extension-runtime/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.4.6"
 edition = "2021"
 
 [dependencies]
-pink-extension = { version = "0.4.5", path = "../pink-extension" }
+pink-extension = { version = "0.4.7", path = "../pink-extension" }
 reqwest-env-proxy = { version = "0.1", path = "../../reqwest-env-proxy" }
 sp-core = { version = "21", features = ["full_crypto"] }
 sp-runtime-interface = { version = "17", features = ["disable_target_static_assertions"] }

--- a/crates/pink/pink-extension-runtime/Cargo.toml
+++ b/crates/pink/pink-extension-runtime/Cargo.toml
@@ -3,11 +3,11 @@ description = "Mock pink chain extension for Phala pink contract"
 homepage = "https://github.com/Phala-Network/phala-blockchain"
 license = "Apache-2.0"
 name = "pink-extension-runtime"
-version = "0.4.6"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]
-pink-extension = { version = "0.4.7", path = "../pink-extension" }
+pink-extension = { version = "0.5.0", path = "../pink-extension" }
 reqwest-env-proxy = { version = "0.1", path = "../../reqwest-env-proxy" }
 sp-core = { version = "21", features = ["full_crypto"] }
 sp-runtime-interface = { version = "17", features = ["disable_target_static_assertions"] }

--- a/crates/pink/pink-extension/Cargo.toml
+++ b/crates/pink/pink-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pink-extension"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2018"
 description = "Phala's ink! for writing phat contracts"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ num_enum = { version = "0.6", default-features = false }
 insta = "1.7.2"
 
 [features]
-default = ["std", "runtime_utils", "ink-as-dependency"]
+default = ["std", "runtime_utils"]
 std = [
     "ink/std",
     "scale/std",
@@ -29,4 +29,3 @@ std = [
 ]
 runtime_utils = ["std"]
 dlmalloc = ["ink/no-allocator", "dep:dlmalloc"]
-ink-as-dependency = []

--- a/crates/pink/pink-extension/Cargo.toml
+++ b/crates/pink/pink-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pink-extension"
-version = "0.4.7"
+version = "0.5.0"
 edition = "2018"
 description = "Phala's ink! for writing phat contracts"
 license = "Apache-2.0"

--- a/crates/pink/pink-extension/README.md
+++ b/crates/pink/pink-extension/README.md
@@ -11,7 +11,7 @@ To get started with Pink!, add the following dependency to your `Cargo.toml`:
 ```toml
 [dependencies]
 ink = { version = "4", default-features = false }
-pink = { package = "pink-extension", version = "0.4", default-features = false }
+pink = { package = "pink-extension", version = "0.5", default-features = false }
 
 [features]
 std = [

--- a/crates/pink/pink-extension/src/lib.rs
+++ b/crates/pink/pink-extension/src/lib.rs
@@ -10,7 +10,7 @@ use ink::env::{emit_event, topics::state::HasRemainingTopics, Environment, Topic
 use ink::EnvAccess;
 use scale::{Decode, Encode};
 
-pub use pink_extension_macro::contract;
+pub use pink_extension_macro::{contract, driver};
 
 pub mod chain_extension;
 pub use chain_extension::pink_extension_instance as ext;

--- a/e2e/contracts/check_system/Cargo.toml
+++ b/e2e/contracts/check_system/Cargo.toml
@@ -23,8 +23,12 @@ default-features = false
 path = "../indeterministic_functions"
 features = ["ink-as-dependency"]
 
+[dev-dependencies]
+drink = "0.6.0"
+drink-pink-runtime = "1"
+
 [build-dependencies]
-sp-core = "7"
+sp-core = "25"
 
 [lib]
 name = "check_system"
@@ -41,3 +45,6 @@ std = [
     "indeterministic_functions/std",
 ]
 ink-as-dependency = []
+
+[patch.crates-io]
+drink = { git = "https://github.com/kvinwang/drink-for-pink.git" }

--- a/e2e/contracts/check_system/Cargo.toml
+++ b/e2e/contracts/check_system/Cargo.toml
@@ -25,7 +25,7 @@ features = ["ink-as-dependency"]
 
 [dev-dependencies]
 drink = "0.6.0"
-drink-pink-runtime = "1"
+drink-pink-runtime = "1.2.2"
 
 [build-dependencies]
 sp-core = "25"

--- a/e2e/contracts/check_system/Cargo.toml
+++ b/e2e/contracts/check_system/Cargo.toml
@@ -24,8 +24,8 @@ path = "../indeterministic_functions"
 features = ["ink-as-dependency"]
 
 [dev-dependencies]
-drink = "0.6.0"
-drink-pink-runtime = "1.2.3"
+drink = "0.8.0"
+drink-pink-runtime = "1.2.5"
 
 [build-dependencies]
 sp-core = "25"
@@ -45,6 +45,3 @@ std = [
     "indeterministic_functions/std",
 ]
 ink-as-dependency = []
-
-[patch.crates-io]
-drink = { git = "https://github.com/kvinwang/drink-for-pink.git" }

--- a/e2e/contracts/check_system/Cargo.toml
+++ b/e2e/contracts/check_system/Cargo.toml
@@ -14,7 +14,7 @@ ink = { version = "4", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 
-pink-extension = { version = "0.4", default-features = false, path = "../../../crates/pink/pink-extension" }
+pink-extension = { default-features = false, path = "../../../crates/pink/pink-extension" }
 phat_js = { version = "0.1.5", default-features = false }
 
 [dependencies.indeterministic_functions]

--- a/e2e/contracts/check_system/Cargo.toml
+++ b/e2e/contracts/check_system/Cargo.toml
@@ -15,7 +15,7 @@ scale = { package = "parity-scale-codec", version = "3.6.5", default-features = 
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 
 pink-extension = { default-features = false, path = "../../../crates/pink/pink-extension" }
-phat_js = { version = "0.1.5", default-features = false }
+phat_js = { version = "0.2.0", default-features = false }
 
 [dependencies.indeterministic_functions]
 version = "0.1"
@@ -25,7 +25,7 @@ features = ["ink-as-dependency"]
 
 [dev-dependencies]
 drink = "0.6.0"
-drink-pink-runtime = "1.2.2"
+drink-pink-runtime = "1.2.3"
 
 [build-dependencies]
 sp-core = "25"

--- a/e2e/contracts/check_system/lib.rs
+++ b/e2e/contracts/check_system/lib.rs
@@ -184,13 +184,16 @@ mod check_system {
         #[drink::test]
         fn deploy_and_call_http_get() -> Result<(), Box<dyn std::error::Error>> {
             use drink_pink_runtime::{ExecMode, PinkRuntime};
-            let checker_bundle = BundleProvider::local()?;
+
             let mut session = Session::<PinkRuntime>::new()?;
             session.execute_with(|| {
                 PinkRuntime::setup_cluster().expect("Failed to setup cluster");
             });
+
+            let checker_bundle = BundleProvider::local()?;
             let checker =
                 session.deploy_bundle(checker_bundle, "default", NO_ARGS, vec![], None)?;
+
             let ver: (u16, u16, u16) = session.call_with_address(
                 checker.clone(),
                 "system_contract_version",
@@ -198,6 +201,7 @@ mod check_system {
                 None,
             )??;
             assert_eq!(ver, (1, 0, 0));
+
             let (status, _body): (u16, String) = session.call_with_address(
                 checker.clone(),
                 "http_get",
@@ -205,6 +209,7 @@ mod check_system {
                 None,
             )??;
             assert_eq!(status, 200);
+
             PinkRuntime::execute_in_mode(ExecMode::Transaction, move || {
                 let (status, _body): (u16, String) = session.call_with_address(
                     checker,

--- a/e2e/contracts/check_system/lib.rs
+++ b/e2e/contracts/check_system/lib.rs
@@ -187,6 +187,7 @@ mod check_system {
     #[cfg(test)]
     mod tests {
         use drink::session::Session;
+        use drink::chain_api::ChainApi;
         use drink_pink_runtime::{ExecMode, PinkRuntime};
         use ink::codegen::TraitCallBuilder;
 
@@ -199,7 +200,7 @@ mod check_system {
         #[drink::test]
         fn it_works() -> Result<(), Box<dyn std::error::Error>> {
             let mut session = Session::<PinkRuntime>::new()?;
-            session.execute_with(|| {
+            session.chain_api().execute_with(|| {
                 PinkRuntime::setup_cluster().expect("Failed to setup cluster");
             });
 
@@ -254,7 +255,10 @@ mod check_system {
             },
             primitives::Hash,
         };
-        use drink::{errors::MessageResult, runtime::Runtime, session::Session, ContractBundle};
+        use drink::{
+            chain_api::ChainApi, errors::MessageResult, runtime::Runtime, session::Session,
+            ContractBundle,
+        };
         use drink_pink_runtime::PinkRuntime;
         use pink_extension::{Balance, ConvertTo};
         use scale::{Decode, Encode};
@@ -281,7 +285,7 @@ mod check_system {
             Args: Encode,
             Env::AccountId: From<[u8; 32]>,
         {
-            session.execute_with(move || {
+            session.chain_api().execute_with(move || {
                 let caller = PinkRuntime::default_actor();
                 let code_hash = PinkRuntime::upload_code(caller.clone(), bundle.wasm, true)?;
                 let constructor = constructor
@@ -318,7 +322,7 @@ mod check_system {
             Args: Encode,
             Ret: Decode,
         {
-            session.execute_with(move || {
+            session.chain_api().execute_with(move || {
                 let origin = PinkRuntime::default_actor();
                 let params = call_builder.params();
                 let data = params.exec_input().encode();

--- a/e2e/contracts/check_system/lib.rs
+++ b/e2e/contracts/check_system/lib.rs
@@ -176,47 +176,140 @@ mod check_system {
 
     #[cfg(test)]
     mod tests {
-        use drink::session::{Session, NO_ARGS};
+        use ::ink::env::call::{
+            utils::{ReturnType, Set, Unset},
+            Call, ExecutionInput,
+        };
+        use drink::{errors::MessageResult, runtime::Runtime, session::Session, ContractBundle};
+        use drink_pink_runtime::{ExecMode, PinkRuntime};
+        use ink::codegen::TraitCallBuilder;
+        use ink::env::{
+            call::{CallBuilder, CreateBuilder, FromAccountId},
+            Environment,
+        };
+        use ink::primitives::Hash;
+        use pink_extension::ConvertTo;
+        use scale::{Decode, Encode};
+
+        use super::{Balance, CheckSystemRef};
+
+        const DEFAULT_GAS_LIMIT: u64 = 1_000_000_000_000_000;
 
         #[drink::contract_bundle_provider]
         enum BundleProvider {}
 
+        fn deploy_bundle<Env, Contract, Args>(
+            session: &mut Session<PinkRuntime>,
+            bundle: ContractBundle,
+            constructor: CreateBuilder<
+                Env,
+                Contract,
+                Unset<Hash>,
+                Unset<u64>,
+                Unset<Balance>,
+                Set<ExecutionInput<Args>>,
+                Set<Vec<u8>>,
+                Set<ReturnType<Contract>>,
+            >,
+        ) -> Result<Contract, String>
+        where
+            Env: Environment<Hash = Hash, Balance = Balance>,
+            Contract: FromAccountId<Env>,
+            Args: Encode,
+            Env::AccountId: From<[u8; 32]>,
+        {
+            session.execute_with(move || {
+                let caller = PinkRuntime::default_actor();
+                let code_hash = PinkRuntime::upload_code(caller.clone(), bundle.wasm, true)?;
+                let constructor = constructor
+                    .code_hash(code_hash.0.into())
+                    .endowment(0)
+                    .gas_limit(DEFAULT_GAS_LIMIT);
+                let params = constructor.params();
+                let input_data = params.exec_input().encode();
+                let account_id = PinkRuntime::instantiate(
+                    caller,
+                    0,
+                    params.gas_limit(),
+                    None,
+                    code_hash,
+                    input_data,
+                    params.salt_bytes().clone(),
+                )?;
+                Ok(Contract::from_account_id(account_id.convert_to()))
+            })
+        }
+
+        fn call<Env, Args, Ret>(
+            session: &mut Session<PinkRuntime>,
+            call_builder: CallBuilder<
+                Env,
+                Set<Call<Env>>,
+                Set<ExecutionInput<Args>>,
+                Set<ReturnType<Ret>>,
+            >,
+            deterministic: bool,
+        ) -> Result<Ret, String>
+        where
+            Env: Environment<Hash = Hash, Balance = Balance>,
+            Args: Encode,
+            Ret: Decode,
+        {
+            session.execute_with(move || {
+                let origin = PinkRuntime::default_actor();
+                let params = call_builder.params();
+                let data = params.exec_input().encode();
+                let callee = params.callee();
+                let address: [u8; 32] = callee.as_ref().try_into().or(Err("Invalid callee"))?;
+                let result = PinkRuntime::call(
+                    origin,
+                    address.into(),
+                    0,
+                    DEFAULT_GAS_LIMIT,
+                    None,
+                    data,
+                    deterministic,
+                )?;
+                let ret = MessageResult::<Ret>::decode(&mut &result[..])
+                    .map_err(|e| format!("Failed to decode result: {}", e))?
+                    .map_err(|e| format!("Failed to execute call: {}", e))?;
+                Ok(ret)
+            })
+        }
+
         #[drink::test]
         fn deploy_and_call_http_get() -> Result<(), Box<dyn std::error::Error>> {
-            use drink_pink_runtime::{ExecMode, PinkRuntime};
-
             let mut session = Session::<PinkRuntime>::new()?;
             session.execute_with(|| {
                 PinkRuntime::setup_cluster().expect("Failed to setup cluster");
             });
 
             let checker_bundle = BundleProvider::local()?;
-            let checker =
-                session.deploy_bundle(checker_bundle, "default", NO_ARGS, vec![], None)?;
-
-            let ver: (u16, u16, u16) = session.call_with_address(
-                checker.clone(),
-                "system_contract_version",
-                NO_ARGS,
-                None,
-            )??;
+            let checker = deploy_bundle(
+                &mut session,
+                checker_bundle,
+                CheckSystemRef::default().salt_bytes(vec![]),
+            )?;
+            let ver = call(
+                &mut session,
+                checker.call().system_contract_version(),
+                false,
+            )?;
             assert_eq!(ver, (1, 0, 0));
 
-            let (status, _body): (u16, String) = session.call_with_address(
-                checker.clone(),
-                "http_get",
-                &["\"https://httpbin.org/get\""],
-                None,
-            )??;
+            let (status, _body) = call(
+                &mut session,
+                checker.call().http_get("https://httpbin.org/get".into()),
+                false,
+            )?;
             assert_eq!(status, 200);
 
             PinkRuntime::execute_in_mode(ExecMode::Transaction, move || {
-                let (status, _body): (u16, String) = session.call_with_address(
-                    checker,
-                    "http_get",
-                    &["\"https://httpbin.org/get\""],
-                    None,
-                )??;
+                let (status, _body) = call(
+                    &mut session,
+                    checker.call().http_get("https://httpbin.org/get".into()),
+                    false,
+                )?;
                 assert_eq!(status, 523);
                 Ok(())
             })

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "ink",
  "log",
@@ -6087,7 +6087,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension-runtime"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "futures",
  "getrandom 0.2.10",

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "pink-extension"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "ink",
  "log",


### PR DESCRIPTION
I've made a [drink](https://github.com/inkdevhub/drink) runtime for pink [here](https://github.com/Phala-Network/drink-pink-runtime).
This PR show an example for how to do quasi-E2E test using it, and makes some changes to pink-extention to make the framework work.

There are 2 issue I encountered (Both has been resolved):
- [x] We need to patch the drink, so that we can do some extra setup for pink runtime. I've submitted a [PR](https://github.com/inkdevhub/drink/pull/81) there.
- [x] Drink currently doesn't support to upload or call Indeterministic codes. So, we can not use it to test JS codes so far. I've submitted an [issue](https://github.com/inkdevhub/drink/issues/80) there.