### PR TITLE
pallet-phat: Fix phat migration error

### DIFF
--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -143,7 +143,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 1,
+    spec_version: 101,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
This  PR fixes a bug in the pallet-phat migration code where removed workers weren't being deleted from `Cluster::workers`, leading to their erroneous re-addition to `ClusterWorkers` during migration.

The PR excludes these removed workers in the migration process. Additionally, a new sudo API, `cleanup_removed_workers`, is added for cleaning up any workers mistakenly added due to this bug.