### PR TITLE
Add chain state check & stake update on first run of worker loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,12 +2831,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
- "darling_core 0.20.1",
- "darling_macro 0.20.1",
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -2868,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
@@ -2904,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.1",
  "quote 1.0.33",
@@ -15333,7 +15333,7 @@ dependencies = [
 name = "subxt-macro"
 version = "0.29.0"
 dependencies = [
- "darling 0.20.1",
+ "darling 0.20.3",
  "proc-macro-error",
  "subxt-codegen",
  "syn 2.0.38",

--- a/standalone/prb/src/tx.rs
+++ b/standalone/prb/src/tx.rs
@@ -636,6 +636,24 @@ impl TxManager {
         );
         self.clone().send_to_queue(pid, tx_payload, desc).await
     }
+    pub async fn restart_computing(
+        self: Arc<Self>,
+        pid: u64,
+        worker: Sr25519Public,
+        stake: String,
+    ) -> Result<()> {
+        let desc = format!(
+            "Restart computing for 0x{} with stake of {} in pool #{pid}.",
+            worker.encode_hex::<String>(),
+            &stake
+        );
+        let tx_payload = EncodedPayload::new(
+            "PhalaStakePoolv2",
+            "restart_computing",
+            (pid, Encoded(worker.encode()), stake.parse::<u128>()?).encode(),
+        );
+        self.clone().send_to_queue(pid, tx_payload, desc).await
+    }
     pub async fn stop_computing(self: Arc<Self>, pid: u64, worker: Sr25519Public) -> Result<()> {
         let desc = format!(
             "Stop computing for 0x{} in pool #{pid}.",


### PR DESCRIPTION
This PR adds a on-chain state check by comparing on-chain stake with configured stake and triggers a compute restart call when configured stake in PRB is higher than on-chain.

Any code contribution bounty appreciated to: 42GD3CtQUNhrDb7Yw6pNCMzJr6mZHb5ScGKoUv6XVeTeMJZa