### PR TITLE
prb: add per-entry expiration for None items instead of no cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7358,22 +7358,20 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.10.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713518e40360e799c7a0b991b63fcd59814b00901ad3acbe8ecfb5daa23723be"
+checksum = "d8017ec3548ffe7d4cef7ac0e12b044c01164a74c0f3119420faeaf13490ad8b"
 dependencies = [
- "async-io",
  "async-lock",
+ "async-trait",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
  "futures-util",
- "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
  "quanta",
  "rustc_version 0.4.0",
- "scheduled-thread-pool",
  "skeptic",
  "smallvec",
  "tagptr",
@@ -13230,15 +13228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
-dependencies = [
- "parking_lot 0.12.1",
-]
-
-[[package]]
 name = "schnellru"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16316,7 +16305,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/standalone/prb/Cargo.toml
+++ b/standalone/prb/Cargo.toml
@@ -43,7 +43,7 @@ parity-scale-codec = "3.6.5"
 phala-pallets = { path = "../../pallets/phala" }
 scale-value = "0.7.0"
 subxt = { path = "../../subxt/subxt", features = ["jsonrpsee-ws"] }
-moka = { version = "0.10.2", features = ["future"] }
+moka = { version = "0.12.1", features = ["future"] }
 moka-cht = "0.5.0"
 async-trait = "0.1.68"
 crossbeam = "0.8.2"


### PR DESCRIPTION
Some prbs may manage hundreds or thousands of workers. For each worker, prb will check the headers every 3 seconds. Since the block producing every 12 seconds, 3/4 of the checks get nothing.

In the old implemention, for None, the cache layer will just invalidate the cache. It causes node connection issue since every worker in the prb connect to node every 3 seconds, even just few milliseconds ago another worker checked there is no new header.

Instead of no cache, we need to cache None but for short expiry for reducing the unnecessary node connection.