### PR TITLE
prb: Support for Dcap

### DIFF
--- a/crates/phactory/api/src/proto_generated/mod.rs
+++ b/crates/phactory/api/src/proto_generated/mod.rs
@@ -26,6 +26,7 @@ pub struct Info<'a> {
     pub whdr: bool,
     pub cluster: u64,
     pub gblk: u32,
+    pub ras: &'a str,
 }
 
 impl PhactoryInfo {
@@ -52,6 +53,11 @@ impl PhactoryInfo {
                 .map(|s| s.number_of_clusters)
                 .unwrap_or_default(),
             gblk: self.system.as_ref().map(|s| s.genesis_block).unwrap_or(0),
+            ras: self
+                .supported_attestation_methods
+                .last()
+                .map(|s| s.as_str())
+                .unwrap_or_default(),
         }
     }
 }

--- a/crates/phactory/pal/src/lib.rs
+++ b/crates/phactory/pal/src/lib.rs
@@ -29,6 +29,7 @@ pub trait RA {
     ) -> Result<Vec<u8>, Self::Error>;
     fn quote_test(&self, provider: Option<AttestationProvider>) -> Result<(), Self::Error>;
     fn measurement(&self) -> Option<Vec<u8>>;
+    fn supported_attestation_methods(&self) -> Vec<String>;
 }
 
 pub trait MemoryStats {

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -159,6 +159,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
                 let (major, minor) = ::pink::runtimes::max_supported_version();
                 format!("{major}.{minor}")
             },
+            supported_attestation_methods: self.platform.supported_attestation_methods(),
         }
     }
 

--- a/crates/sgx-attestation/src/dcap.rs
+++ b/crates/sgx-attestation/src/dcap.rs
@@ -165,7 +165,10 @@ pub fn verify(
     let mut advisory_ids = Vec::<String>::new();
     for tcb_level in &tcb_info.tcb_levels {
         if pce_svn >= tcb_level.tcb.pce_svn {
-            let selected = !cpu_svn.iter().zip(&tcb_level.tcb.components).any(|(a, b)| a < &b.svn);
+            let selected = cpu_svn
+                .iter()
+                .zip(&tcb_level.tcb.components)
+                .all(|(a, b)| a >= &b.svn);
             if !selected {
                 continue;
             }

--- a/standalone/prb/src/cli.rs
+++ b/standalone/prb/src/cli.rs
@@ -33,6 +33,14 @@ pub struct WorkerManagerCliArgs {
     /// URL of webhook endpoint
     #[arg(short = 'w', long, env)]
     pub webhook_url: Option<String>,
+
+    /// URL of PCCS server to get collateral
+    #[arg(long, env, default_value = "")]
+    pub pccs_url: String,
+
+    /// Timeout of PCCS server to get collateral
+    #[arg(long, env, default_value = "10")]
+    pub pccs_timeout: u64,
 }
 
 pub async fn start_wm() {

--- a/standalone/prb/src/cli.rs
+++ b/standalone/prb/src/cli.rs
@@ -38,7 +38,7 @@ pub struct WorkerManagerCliArgs {
     #[arg(long, env, default_value = "")]
     pub pccs_url: String,
 
-    /// Timeout of PCCS server to get collateral
+    /// Timeout in seconds of PCCS server to get collateral
     #[arg(long, env, default_value = "10")]
     pub pccs_timeout: u64,
 }

--- a/standalone/prb/src/lifecycle.rs
+++ b/standalone/prb/src/lifecycle.rs
@@ -29,8 +29,6 @@ pub struct WorkerLifecycleManager {
     pub fast_sync_semaphore: Arc<Semaphore>,
     pub webhook_url: Option<String>,
     pub reqwest: Client,
-    pub pccs_url: String,
-    pub pccs_timeout_secs: u64,
 }
 pub type WrappedWorkerLifecycleManager = Arc<WorkerLifecycleManager>;
 
@@ -45,8 +43,6 @@ impl WorkerLifecycleManager {
         fast_sync_enabled: bool,
         webhook_url: Option<String>,
         txm: Arc<TxManager>,
-        pccs_url: String,
-        pccs_timeout_secs: u64,
     ) -> WrappedWorkerLifecycleManager {
         let workers =
             get_all_workers(inv_db.clone()).expect("Failed to load workers from local database");
@@ -110,8 +106,6 @@ impl WorkerLifecycleManager {
             fast_sync_semaphore,
             webhook_url,
             reqwest: Client::new(),
-            pccs_url,
-            pccs_timeout_secs,
         };
         Arc::new(lm)
     }

--- a/standalone/prb/src/lifecycle.rs
+++ b/standalone/prb/src/lifecycle.rs
@@ -29,6 +29,8 @@ pub struct WorkerLifecycleManager {
     pub fast_sync_semaphore: Arc<Semaphore>,
     pub webhook_url: Option<String>,
     pub reqwest: Client,
+    pub pccs_url: String,
+    pub pccs_timeout_secs: u64,
 }
 pub type WrappedWorkerLifecycleManager = Arc<WorkerLifecycleManager>;
 
@@ -43,6 +45,8 @@ impl WorkerLifecycleManager {
         fast_sync_enabled: bool,
         webhook_url: Option<String>,
         txm: Arc<TxManager>,
+        pccs_url: String,
+        pccs_timeout_secs: u64,
     ) -> WrappedWorkerLifecycleManager {
         let workers =
             get_all_workers(inv_db.clone()).expect("Failed to load workers from local database");
@@ -106,6 +110,8 @@ impl WorkerLifecycleManager {
             fast_sync_semaphore,
             webhook_url,
             reqwest: Client::new(),
+            pccs_url,
+            pccs_timeout_secs,
         };
         Arc::new(lm)
     }
@@ -120,7 +126,7 @@ impl WorkerLifecycleManager {
             state: cc.state.clone(),
             phactory_info: cc.info.clone(),
             last_message: cc.last_message.clone(),
-            session_info: cc.session_info.clone()
+            session_info: cc.session_info.clone(),
         };
         let body = serde_json::to_string(&s)?;
         if let Err(e) = self

--- a/standalone/prb/src/wm.rs
+++ b/standalone/prb/src/wm.rs
@@ -131,7 +131,14 @@ pub async fn wm(args: WorkerManagerCliArgs) {
             loop {
                 let (reload_tx, mut reload_rx) = mpsc::channel::<()>(1);
                 let main_handle =
-                    set_lifecycle_manager(ctx.clone(), reload_tx.clone(), fast_sync_enabled, args.webhook_url.clone());
+                    set_lifecycle_manager(
+                        ctx.clone(),
+                        reload_tx.clone(),
+                        fast_sync_enabled,
+                        args.webhook_url.clone(),
+                        args.pccs_url.clone(),
+                        args.pccs_timeout
+                    );
 
                 tokio::select! {
                     ret = main_handle => {
@@ -155,6 +162,8 @@ pub async fn set_lifecycle_manager(
     reload_tx: WrappedReloadTx,
     fast_sync_enabled: bool,
     webhook_url: Option<String>,
+    pccs_url: String,
+    pccs_timeout_secs: u64,
 ) -> Result<()> {
     let (tx, rx) = mpsc::unbounded_channel::<WorkerManagerCommand>();
 
@@ -166,6 +175,8 @@ pub async fn set_lifecycle_manager(
         fast_sync_enabled,
         webhook_url,
         ctx.txm.clone(),
+        pccs_url,
+        pccs_timeout_secs,
     )
     .await;
 

--- a/standalone/prb/src/worker.rs
+++ b/standalone/prb/src/worker.rs
@@ -718,8 +718,12 @@ impl WorkerContext {
             .attestation
             .ok_or(anyhow!("Worker has no attestation!"))?;
         let v2 = attestation.payload.is_none();
-        let attestation =
-            attestation_to_report(attestation, &lm.pccs_url, lm.pccs_timeout_secs).await?;
+        let attestation = attestation_to_report(
+            attestation,
+            &lm.main_ctx.pccs_url,
+            lm.main_ctx.pccs_timeout_secs,
+        )
+        .await?;
         txm.clone()
             .register_worker(pid, runtime_info.encoded_runtime_info, attestation, v2)
             .await?;

--- a/standalone/pruntime/src/pal_gramine.rs
+++ b/standalone/pruntime/src/pal_gramine.rs
@@ -93,6 +93,14 @@ impl RA for GraminePlatform {
             None
         }
     }
+
+    fn supported_attestation_methods(&self) -> Vec<String> {
+        let mut methods = vec!["none".to_string()];
+        if let Some(t) = attestation_type() {
+            methods.push(t);
+        }
+        methods
+    }
 }
 
 impl Machine for GraminePlatform {
@@ -175,12 +183,15 @@ fn mem_free() -> Option<usize> {
     None
 }
 
+fn attestation_type() -> Option<String> {
+    std::fs::read_to_string("/dev/attestation/attestation_type").ok()
+}
+
 fn ensure_supported(provider: Option<AttestationProvider>) -> anyhow::Result<()> {
     let Some(provider) = provider else {
         return Ok(());
     };
-    let attestation_type =
-        std::fs::read_to_string("/dev/attestation/attestation_type").unwrap_or_default();
+    let attestation_type = attestation_type().unwrap_or_default();
     match (provider, attestation_type.as_str()) {
         (AttestationProvider::Ias, "epid") => Ok(()),
         (AttestationProvider::Dcap, "dcap") => Ok(()),


### PR DESCRIPTION
This PR mainly adds support for Dcap attestation processing in prb.
with two additional changes:
1. fixed a bug in pherry args that doesn't accept `--attestation-provider=dcap`
2. added supported_attestation_methods in get_info so that prb can init pruntime according to it.
