### PR TITLE
Improved: Logger & Contract Event decoding

### DIFF
--- a/frontend/packages/sdk/src/contracts/PinkLoggerContract.ts
+++ b/frontend/packages/sdk/src/contracts/PinkLoggerContract.ts
@@ -19,12 +19,14 @@ import { isPascalCase, snakeToPascalCase } from '../utils/snakeToPascalCase'
 import { ContractInitialError } from './Errors'
 import { type PinkContractPromise } from './PinkContract'
 
-interface GetLogRequest {
+export type LogTypeLiteral = 'Log' | 'Event' | 'MessageOutput' | 'QueryIn' | 'TooLarge'
+
+export interface GetLogRequest {
   contract?: string
   from: number
   count: number
   block_number?: number
-  type?: 'Log' | 'Event' | 'MessageOutput' | 'QueryIn' | 'TooLarge'
+  type?: LogTypeLiteral | LogTypeLiteral[]
   topic?: LiteralTopic
   abi?: Abi
 }
@@ -419,7 +421,9 @@ export class PinkLoggerContractPromise {
     )
     const result = await this.getLogRaw(request)
     if (type) {
-      if (type === 'Event' && topic) {
+      if (Array.isArray(type)) {
+        result.records = result.records.filter((record) => type.includes(record.type))
+      } else if (type === 'Event' && topic) {
         const topicHash = getTopicHash(topic)
         result.records = result.records.filter((record) => record.type === type && record.topics[0] === topicHash)
       } else {
@@ -446,7 +450,9 @@ export class PinkLoggerContractPromise {
     )
     const result = await this.getLogRaw(request)
     if (type) {
-      if (type === 'Event' && topic) {
+      if (Array.isArray(type)) {
+        result.records = result.records.filter((record) => type.includes(record.type))
+      } else if (type === 'Event' && topic) {
         const topicHash = getTopicHash(topic)
         result.records = result.records.filter((record) => record.type === type && record.topics[0] === topicHash)
       } else {

--- a/frontend/packages/sdk/src/contracts/PinkLoggerContract.ts
+++ b/frontend/packages/sdk/src/contracts/PinkLoggerContract.ts
@@ -368,7 +368,9 @@ export class PinkLoggerContractPromise {
     const unsafeRunSidevmQuery = sidevmQueryWithReader(ctx)
     return await unsafeRunSidevmQuery<{ records: SerInnerMessage[]; next: number }>({
       action: 'GetLog',
-      ...query,
+      from: query.from,
+      count: query.count,
+      contract: query.contract,
     })
   }
 

--- a/frontend/packages/sdk/src/contracts/PinkLoggerContract.ts
+++ b/frontend/packages/sdk/src/contracts/PinkLoggerContract.ts
@@ -340,7 +340,7 @@ export class PinkLoggerContractPromise {
     remotePubkey: string,
     pair: KeyringPair,
     contractId: string | AccountId,
-    systemContractId: string
+    systemContractId?: string
   ) {
     this.#phactory = phactory
     this.#remotePubkey = remotePubkey
@@ -402,7 +402,7 @@ export class PinkLoggerContractPromise {
    */
   async tail(): Promise<GetLogResponse>
   async tail(counts: number): Promise<GetLogResponse>
-  async tail(request: GetLogRequest): Promise<GetLogResponse>
+  async tail(request: Partial<GetLogRequest>): Promise<GetLogResponse>
   async tail(counts: number, from: number): Promise<GetLogResponse>
   async tail(counts: number, request: Omit<GetLogRequest, 'from' | 'count'>): Promise<GetLogResponse>
   async tail(counts: number, from: number, request?: Omit<GetLogRequest, 'from' | 'count'>): Promise<GetLogResponse>
@@ -434,7 +434,7 @@ export class PinkLoggerContractPromise {
    */
   async head(): Promise<GetLogResponse>
   async head(counts: number): Promise<GetLogResponse>
-  async head(request: GetLogRequest): Promise<GetLogResponse>
+  async head(request: Partial<GetLogRequest>): Promise<GetLogResponse>
   async head(counts: number, from: number): Promise<GetLogResponse>
   async head(counts: number, request: Omit<GetLogRequest, 'from' | 'count'>): Promise<GetLogResponse>
   async head(counts: number, from: number, request?: Omit<GetLogRequest, 'from' | 'count'>): Promise<GetLogResponse>

--- a/frontend/packages/sdk/src/contracts/PinkLoggerContract.ts
+++ b/frontend/packages/sdk/src/contracts/PinkLoggerContract.ts
@@ -402,14 +402,10 @@ export class PinkLoggerContractPromise {
    */
   async tail(): Promise<GetLogResponse>
   async tail(counts: number): Promise<GetLogResponse>
-  async tail(request: Pick<GetLogRequest, 'contract' | 'block_number' | 'count'>): Promise<GetLogResponse>
+  async tail(request: GetLogRequest): Promise<GetLogResponse>
   async tail(counts: number, from: number): Promise<GetLogResponse>
-  async tail(counts: number, request: Pick<GetLogRequest, 'contract' | 'block_number'>): Promise<GetLogResponse>
-  async tail(
-    counts: number,
-    from: number,
-    request?: Pick<GetLogRequest, 'contract' | 'block_number'>
-  ): Promise<GetLogResponse>
+  async tail(counts: number, request: Omit<GetLogRequest, 'from' | 'count'>): Promise<GetLogResponse>
+  async tail(counts: number, from: number, request?: Omit<GetLogRequest, 'from' | 'count'>): Promise<GetLogResponse>
   async tail(...params: any[]): Promise<GetLogResponse> {
     const { abi, type, topic, ...request }: GetLogRequest = buildGetLogRequest(
       params,
@@ -438,14 +434,10 @@ export class PinkLoggerContractPromise {
    */
   async head(): Promise<GetLogResponse>
   async head(counts: number): Promise<GetLogResponse>
-  async head(request: Pick<GetLogRequest, 'contract' | 'block_number' | 'count'>): Promise<GetLogResponse>
+  async head(request: GetLogRequest): Promise<GetLogResponse>
   async head(counts: number, from: number): Promise<GetLogResponse>
-  async head(counts: number, request: Pick<GetLogRequest, 'contract' | 'block_number'>): Promise<GetLogResponse>
-  async head(
-    counts: number,
-    from: number,
-    request?: Pick<GetLogRequest, 'contract' | 'block_number'>
-  ): Promise<GetLogResponse>
+  async head(counts: number, request: Omit<GetLogRequest, 'from' | 'count'>): Promise<GetLogResponse>
+  async head(counts: number, from: number, request?: Omit<GetLogRequest, 'from' | 'count'>): Promise<GetLogResponse>
   async head(...params: any[]): Promise<GetLogResponse> {
     const { abi, type, topic, ...request }: GetLogRequest = buildGetLogRequest(
       params,

--- a/frontend/packages/sdk/src/factory_functions.ts
+++ b/frontend/packages/sdk/src/factory_functions.ts
@@ -1,7 +1,11 @@
-import { ApiPromise, WsProvider } from '@polkadot/api'
+import { ApiPromise, Keyring, WsProvider } from '@polkadot/api'
+import type { AccountId } from '@polkadot/types/interfaces'
+import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { PinkContractPromise } from './contracts/PinkContract'
+import { PinkLoggerContractPromise } from './contracts/PinkLoggerContract'
 import { type CreateOptions, OnChainRegistry } from './OnChainRegistry'
 import { options } from './options'
+import createPruntimeClient from './pruntime/createPruntimeClient'
 import type { AbiLike } from './types'
 
 export type GetClientOptions = {
@@ -25,4 +29,34 @@ export async function getContract(options: GetContractOptions): Promise<PinkCont
   const { client, contractId, abi } = options
   const contractKey = await client.getContractKeyOrFail(contractId)
   return new PinkContractPromise(client.api, client, abi, contractId, contractKey)
+}
+
+export type GetLoggerOptions =
+  | GetClientOptions
+  | {
+      contractId: string | AccountId
+      pruntimeURL: string
+      systemContract?: string | AccountId
+    }
+
+export async function getLogger(options: GetLoggerOptions): Promise<PinkLoggerContractPromise> {
+  if ('transport' in options) {
+    const client = await getClient(options)
+    if (!client.loggerContract) {
+      throw new Error('Logger contract not found in the cluster.')
+    }
+    return client.loggerContract
+  }
+  // This is off-chain only mode.
+  else if ('contractId' in options && 'pruntimeURL' in options) {
+    await cryptoWaitReady()
+    const keyring = new Keyring({ type: 'sr25519' })
+    const alice = keyring.addFromUri('//Alice')
+    const { contractId, pruntimeURL } = options
+    const phactory = createPruntimeClient(pruntimeURL)
+    const info = await phactory.getInfo({})
+    return new PinkLoggerContractPromise(phactory, info.publicKey!, alice, contractId, options.systemContract)
+  } else {
+    throw new Error('Invalid options.')
+  }
 }

--- a/frontend/packages/sdk/src/utils/snakeToPascalCase.ts
+++ b/frontend/packages/sdk/src/utils/snakeToPascalCase.ts
@@ -1,0 +1,14 @@
+export function snakeToPascalCase(snakeStr: string): string {
+  return snakeStr
+    .toLowerCase()
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('')
+}
+
+// a regex that detect the string is pascal case style or not.
+const regex_pascal_case = /^[A-Z][a-zA-Z0-9]*$/
+
+export function isPascalCase(str: string): boolean {
+  return regex_pascal_case.test(str)
+}

--- a/frontend/packages/sdk/tests/contracts/PinkLoggerContract.test.ts
+++ b/frontend/packages/sdk/tests/contracts/PinkLoggerContract.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from 'vitest'
-import { buildGetLogRequest, getTopicHash } from '../../src/contracts/PinkLoggerContract'
+import Keyring from '@polkadot/keyring'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  PinkLoggerContractPromise,
+  type SerMessageEvent,
+  buildGetLogRequest,
+  getTopicHash,
+} from '../../src/contracts/PinkLoggerContract'
+import createPruntimeClient from '../../src/pruntime/createPruntimeClient'
 
 function buildGetLogRequestTail(...params: any[]) {
   return buildGetLogRequest(
@@ -119,5 +126,158 @@ describe('getTopicHash should convert literal topic to hash', () => {
   it('should throw error if topic is not valid', () => {
     // @ts-ignore
     expect(() => getTopicHash('system')).toThrow()
+  })
+})
+
+describe('the client-side filter type & topic should works', () => {
+  it('the type filter should works', async ({ expect }) => {
+    const keyring = new Keyring()
+    const logger = new PinkLoggerContractPromise(
+      createPruntimeClient('http://localhost:8080'),
+      '',
+      keyring.addFromUri('//Alice'),
+      ''
+    )
+    // @ts-ignore
+    vi.spyOn(logger, 'getLogRaw').mockImplementation(() => {
+      return Promise.resolve({
+        records: [
+          {
+            sequence: 6625,
+            type: 'Log',
+            blockNumber: 1821442,
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            entry: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            execMode: 'estimating',
+            timestamp: 1701717261053,
+            level: 1,
+            message: 'contract call reverted',
+          },
+          {
+            sequence: 6626,
+            type: 'QueryIn',
+            user: '0xe11964fe773024fb',
+          },
+          {
+            sequence: 6627,
+            type: 'QueryIn',
+            user: '0x6aefdee5248bcfaf',
+          },
+          {
+            sequence: 6628,
+            type: 'QueryIn',
+            user: '0x6aefdee5248bcfaf',
+          },
+          {
+            sequence: 6629,
+            type: 'MessageOutput',
+            blockNumber: 1821449,
+            origin: '0x4613e7b5fdf418fe5472071e81dcf34195805ffd2f7f68a97f7710ff7e3c3a46',
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            nonce: '0x517492b3a5e0497281a56c915a0e31c329faf93614986ca996162b31282c187f',
+            output: '0x03d905cbed3a130600070000807e120200800000ff3f597307000000000000000000000000000000000008000000',
+          },
+          {
+            sequence: 6630,
+            type: 'Event',
+            blockNumber: 1821449,
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            topics: ['0x2397e37a88ffc850c2bbc863df83cbb459c20fb30c190667330e625531370491'],
+            payload: '0x02d41f763cb3326a5dc04f09c6eeab35ca809c756ea7e8c3fb1a9a89fc4d41c03d',
+          },
+        ],
+        next: 0,
+      })
+    })
+
+    const result = await logger.tail({ type: 'Event' })
+    expect(result.records.length).toEqual(1)
+    expect(result.records[0].type).toEqual('Event')
+  })
+
+  it('the topic filter should works', async ({ expect }) => {
+    const keyring = new Keyring()
+    const logger = new PinkLoggerContractPromise(
+      createPruntimeClient('http://localhost:8080'),
+      '',
+      keyring.addFromUri('//Alice'),
+      ''
+    )
+    // @ts-ignore
+    vi.spyOn(logger, 'getLogRaw').mockImplementation(() => {
+      return Promise.resolve({
+        records: [
+          {
+            sequence: 6597,
+            type: 'Event',
+            blockNumber: 1821016,
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            topics: ['0xcf4b5a8f1631c6ee65f065cb4b426df487b9aec41615da6799315093117a7a7b'],
+            payload: '0x01edab8c49dcab658c859a89f9edba627d80b22c95e48e4b6c352041e71d002223',
+          },
+          {
+            sequence: 6598,
+            type: 'Event',
+            blockNumber: 1821016,
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            topics: ['0xcf4b5a8f1631c6ee65f065cb4b426df487b9aec41615da6799315093117a7a7b'],
+            payload: '0x01d41f763cb3326a5dc04f09c6eeab35ca809c756ea7e8c3fb1a9a89fc4d41c03d',
+          },
+          {
+            sequence: 6625,
+            type: 'Log',
+            blockNumber: 1821442,
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            entry: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            execMode: 'estimating',
+            timestamp: 1701717261053,
+            level: 1,
+            message: 'contract call reverted',
+          },
+          {
+            sequence: 6626,
+            type: 'QueryIn',
+            user: '0xe11964fe773024fb',
+          },
+          {
+            sequence: 6627,
+            type: 'QueryIn',
+            user: '0x6aefdee5248bcfaf',
+          },
+          {
+            sequence: 6628,
+            type: 'QueryIn',
+            user: '0x6aefdee5248bcfaf',
+          },
+          {
+            sequence: 6629,
+            type: 'MessageOutput',
+            blockNumber: 1821449,
+            origin: '0x4613e7b5fdf418fe5472071e81dcf34195805ffd2f7f68a97f7710ff7e3c3a46',
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            nonce: '0x517492b3a5e0497281a56c915a0e31c329faf93614986ca996162b31282c187f',
+            output: '0x03d905cbed3a130600070000807e120200800000ff3f597307000000000000000000000000000000000008000000',
+          },
+          {
+            sequence: 6630,
+            type: 'Event',
+            blockNumber: 1821449,
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            topics: ['0x2397e37a88ffc850c2bbc863df83cbb459c20fb30c190667330e625531370491'],
+            payload: '0x02d41f763cb3326a5dc04f09c6eeab35ca809c756ea7e8c3fb1a9a89fc4d41c03d',
+          },
+        ],
+        next: 0,
+      })
+    })
+
+    const result = await logger.tail({ type: 'Event', topic: 'PhalaFaucet::QuestScriptRegistered' })
+    expect(result.records.length).toEqual(2)
+    expect((result.records[0] as SerMessageEvent).topics[0]).toEqual(
+      '0xcf4b5a8f1631c6ee65f065cb4b426df487b9aec41615da6799315093117a7a7b'
+    )
+    expect((result.records[1] as SerMessageEvent).topics[0]).toEqual(
+      '0xcf4b5a8f1631c6ee65f065cb4b426df487b9aec41615da6799315093117a7a7b'
+    )
   })
 })

--- a/frontend/packages/sdk/tests/contracts/PinkLoggerContract.test.ts
+++ b/frontend/packages/sdk/tests/contracts/PinkLoggerContract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildGetLogRequest } from '../../src/contracts/PinkLoggerContract'
+import { buildGetLogRequest, getTopicHash } from '../../src/contracts/PinkLoggerContract'
 
 function buildGetLogRequestTail(...params: any[]) {
   return buildGetLogRequest(
@@ -105,5 +105,19 @@ describe('buildGetLogRequest can handle variants shortcut of parameters for head
       block_number: 100,
     })
     expect(buildGetLogRequestHead([20, 40, 60])).toEqual({ from: 40, count: 20 })
+  })
+})
+
+describe('getTopicHash should convert literal topic to hash', () => {
+  it('should works as expected', () => {
+    const shortTopic = getTopicHash('System::Log')
+    expect(shortTopic).toEqual('0x0053797374656d3a3a4c6f670000000000000000000000000000000000000000')
+    const longTopic = getTopicHash('System::ALongEventThatCouldNotBeStoredInTheTopic')
+    expect(longTopic).toEqual('0xc195a2d447cc68a2902771a7242347233b1665662a47d52ac760922671dc1fb4')
+  })
+
+  it('should throw error if topic is not valid', () => {
+    // @ts-ignore
+    expect(() => getTopicHash('system')).toThrow()
   })
 })

--- a/frontend/packages/sdk/tests/contracts/PinkLoggerContract.test.ts
+++ b/frontend/packages/sdk/tests/contracts/PinkLoggerContract.test.ts
@@ -195,6 +195,73 @@ describe('the client-side filter type & topic should works', () => {
     expect(result.records[0].type).toEqual('Event')
   })
 
+  it('the type filter can be array', async ({ expect }) => {
+    const keyring = new Keyring()
+    const logger = new PinkLoggerContractPromise(
+      createPruntimeClient('http://localhost:8080'),
+      '',
+      keyring.addFromUri('//Alice'),
+      ''
+    )
+    // @ts-ignore
+    vi.spyOn(logger, 'getLogRaw').mockImplementation(() => {
+      return Promise.resolve({
+        records: [
+          {
+            sequence: 6625,
+            type: 'Log',
+            blockNumber: 1821442,
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            entry: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            execMode: 'estimating',
+            timestamp: 1701717261053,
+            level: 1,
+            message: 'contract call reverted',
+          },
+          {
+            sequence: 6626,
+            type: 'QueryIn',
+            user: '0xe11964fe773024fb',
+          },
+          {
+            sequence: 6627,
+            type: 'QueryIn',
+            user: '0x6aefdee5248bcfaf',
+          },
+          {
+            sequence: 6628,
+            type: 'QueryIn',
+            user: '0x6aefdee5248bcfaf',
+          },
+          {
+            sequence: 6629,
+            type: 'MessageOutput',
+            blockNumber: 1821449,
+            origin: '0x4613e7b5fdf418fe5472071e81dcf34195805ffd2f7f68a97f7710ff7e3c3a46',
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            nonce: '0x517492b3a5e0497281a56c915a0e31c329faf93614986ca996162b31282c187f',
+            output: '0x03d905cbed3a130600070000807e120200800000ff3f597307000000000000000000000000000000000008000000',
+          },
+          {
+            sequence: 6630,
+            type: 'Event',
+            blockNumber: 1821449,
+            contract: '0xc5dfcc7fff77f29ac5194d7280bfe6f6f0fb4978af7e209ef89eef590d483537',
+            topics: ['0x2397e37a88ffc850c2bbc863df83cbb459c20fb30c190667330e625531370491'],
+            payload: '0x02d41f763cb3326a5dc04f09c6eeab35ca809c756ea7e8c3fb1a9a89fc4d41c03d',
+          },
+        ],
+        next: 0,
+      })
+    })
+
+    const result = await logger.tail({ type: ['Log', 'Event'] })
+    expect(result.records.length).toEqual(2)
+    const types = result.records.map((x) => x.type)
+    expect(types).toContain('Log')
+    expect(types).toContain('Event')
+  })
+
   it('the topic filter should works', async ({ expect }) => {
     const keyring = new Keyring()
     const logger = new PinkLoggerContractPromise(

--- a/frontend/packages/sdk/tests/utils/snakeToPascalCase.test.ts
+++ b/frontend/packages/sdk/tests/utils/snakeToPascalCase.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'vitest'
+import { snakeToPascalCase } from '../../src/utils/snakeToPascalCase'
+
+describe('snake to pascal case', () => {
+  it('should convert snake case to pascal case', ({ expect }) => {
+    const snakeCaseString = 'this_is_a_snake_case_string'
+    const upperCamelCaseString = snakeToPascalCase(snakeCaseString)
+    expect(upperCamelCaseString).toBe('ThisIsASnakeCaseString')
+  })
+
+  it('should convert snake case to pascal case and case insentive', ({ expect }) => {
+    const snakeCaseString = 'This_is_a_snaKe_cAse_string'
+    const upperCamelCaseString = snakeToPascalCase(snakeCaseString)
+    expect(upperCamelCaseString).toBe('ThisIsASnakeCaseString')
+  })
+})


### PR DESCRIPTION
This PR intent to added follow up features to `PinkLoggerContractPromise`:

- Specify the type filter to only return messages that match the specified type. The available types are: `Log`, `Event`, `MessageOutput`, `QueryIn`, and `TooLarge`.
- If you have selected the "Event" filter type, you can also add an optional topic filter. The topic filter should be in a human-readable format like "System::getLog".
- Use the custom Abi for decoding events.

[The `tail.js` script in the cookbook](https://github.com/Leechael/phat-contract-sdk-cookbook/blob/main/tail.js) can be enabled to have follow features:

1. Only show latest contract event:

```bash
node tail.js --type Event
```

2. Only show latest contract event from specified `contractId`:

```bash
node tail.js <contract_id> --type Event
```

3. Only show matched topic:

```bash
node tail.js <contract_id> --topic "PhalaFaucet::FaucetCreated"
```

4. Decode all contract events with specified ABI file (silent if decoded failed):

```bash
node tail.js <contract_id> --abi ./path/to/abi.json
```

5. Combine all:

```
node tail.js <contract_id> --topic "PhalaFaucet::FaucetCreated" --abi ./path/to/abi.json
```

Addition: added `getLogger` helper which fit for get the `PinkLoggerContractPromise` instance in one-line, also support get an `offchain-only` instance without any WebSocket connection to the chain.

```ts
const withWsLogger = await getLogger({ transport: 'wss://poc6.phala.network/ws' })

const offchainOnlyLogger = await getLogger({
  pruntimeURL: 'https://poc6.phala.network/pruntime/0x923462b4',
  contractId: '0x1c825d94cdacab15de009d169e0f4893b5fd33743fba010fee277a9e529431ed',
})
```