### PR TITLE
pruntime: Fix incorrect code_hash in prpc::GetContractInfo

### DIFF
--- a/crates/phactory/src/contracts/support.rs
+++ b/crates/phactory/src/contracts/support.rs
@@ -147,7 +147,6 @@ pub struct Contract {
     address: AccountId,
     pub sidevm_info: Option<SidevmInfo>,
     weight: u32,
-    code_hash: Option<H256>,
     on_block_end: Option<OnBlockEnd>,
 }
 
@@ -164,7 +163,6 @@ impl Contract {
         ecdh_key: KeyPair,
         cluster_id: phala_mq::ContractClusterId,
         address: AccountId,
-        code_hash: Option<H256>,
     ) -> Self {
         Contract {
             send_mq,
@@ -174,7 +172,6 @@ impl Contract {
             address,
             sidevm_info: None,
             weight: 0,
-            code_hash,
             on_block_end: None,
         }
     }
@@ -461,11 +458,14 @@ impl Contract {
         self.weight
     }
 
-    pub fn info(&self) -> pb::ContractInfo {
+    pub fn info(&self, cluster: &Cluster) -> pb::ContractInfo {
         pb::ContractInfo {
             id: hex(&self.address),
             weight: self.weight,
-            code_hash: self.code_hash.as_ref().map(hex).unwrap_or_default(),
+            code_hash: cluster
+                .code_hash(&self.address)
+                .map(hex)
+                .unwrap_or_default(),
             sidevm: self.sidevm_info.as_ref().map(|info| {
                 let handle = info.handle.lock().unwrap().clone();
                 let start_time = info.start_time.clone();

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -848,11 +848,16 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             None => return Ok(Default::default()),
             Some(system) => system,
         };
+        let cluster = system
+            .contract_cluster
+            .as_ref()
+            .ok_or_else(|| from_display("No cluster found"))?;
         let contracts = if contract_ids.is_empty() {
+            // TODO.kevin: reject to query all for performance reason
             system
                 .contracts
                 .iter()
-                .map(|(_, contract)| contract.info())
+                .map(|(_, contract)| contract.info(cluster))
                 .collect()
         } else {
             let mut contracts = vec![];
@@ -867,7 +872,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
                     None => continue,
                     Some(contract) => contract,
                 };
-                contracts.push(contract.info());
+                contracts.push(contract.info(cluster));
             }
             contracts
         };

--- a/crates/phactory/src/snapshots/phactory__show_type_changes_that_affect_the_checkpoint.snap
+++ b/crates/phactory/src/snapshots/phactory__show_type_changes_that_affect_the_checkpoint.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/phactory/src/lib.rs
-assertion_line: 360
+assertion_line: 372
 expression: "travel_types::<Phactory<()>>()"
 ---
 [
@@ -3634,11 +3634,6 @@ expression: "travel_types::<Phactory<()>>()"
               "name": "weight",
               "type": 23,
               "typeName": "u32"
-            },
-            {
-              "name": "code_hash",
-              "type": 41,
-              "typeName": "Option<H256>"
             },
             {
               "name": "on_block_end",

--- a/crates/phactory/src/system/mod.rs
+++ b/crates/phactory/src/system/mod.rs
@@ -1699,11 +1699,9 @@ fn apply_instantiating_events(
         let ecdh_key = contract_key
             .derive_ecdh_key()
             .expect("Derive ecdh_key should not fail");
-        let code_hash = cluster.code_hash(&address);
         let result = install_contract(
             contracts,
             address,
-            code_hash,
             contract_key.clone(),
             ecdh_key.clone(),
             block,
@@ -1922,7 +1920,6 @@ fn apply_ink_side_effects(
 pub fn install_contract(
     contracts: &mut ContractsKeeper,
     address: AccountId,
-    code_hash: Option<crate::H256>,
     contract_key: sr25519::Pair,
     ecdh_key: EcdhKey,
     block: &mut BlockInfo,
@@ -1940,7 +1937,7 @@ pub fn install_contract(
             .into(),
         ecdh_key.clone(),
     );
-    let wrapped = contracts::Contract::new(mq, cmd_mq, ecdh_key, cluster_id, address, code_hash);
+    let wrapped = contracts::Contract::new(mq, cmd_mq, ecdh_key, cluster_id, address);
     contracts.insert(wrapped);
     Ok(())
 }


### PR DESCRIPTION
In the previous implementation, contract code_hashes were stored in memory. Therefore, if a contract upgraded itself using `set_code_hash`, the recorded code_hash wouldn't update. This led to incorrect code_hash returns in subsequent GetContractInfo calls. 
This PR addresses this issue by removing the in-memory storage of code_hashes and instead querying them from storage.