### PR TITLE
sidevm: Remove the 512 bytes chunk size limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13602,7 +13602,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "sidevm"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "derive_more",
  "futures",

--- a/crates/sidevm/sidevm/Cargo.toml
+++ b/crates/sidevm/sidevm/Cargo.toml
@@ -4,7 +4,7 @@ license = "Apache-2.0"
 homepage = "https://github.com/Phala-Network/phala-blockchain"
 edition = "2021"
 name = "sidevm"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 
 [dependencies]
 sidevm-env = { version = "0.2.0-alpha.4", path = "../env" }

--- a/crates/sidevm/sidevm/src/net.rs
+++ b/crates/sidevm/sidevm/src/net.rs
@@ -310,7 +310,7 @@ mod impl_tokio {
             buf: &mut tokio::io::ReadBuf<'_>,
         ) -> Poll<std::io::Result<()>> {
             let result = {
-                let size = buf.remaining().min(512);
+                let size = buf.remaining();
                 let buf = buf.initialize_unfilled_to(size);
                 let waker_id = tasks::intern_waker(cx.waker().clone());
                 ocall::poll_read(waker_id, self.res_id.0, buf)


### PR DESCRIPTION
The small chunk size limit make the net io poor performance. Let the caller decide the chunk size.