### PR TITLE
Read the validator set from `Grandpa::Authorities` as a fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9354,6 +9354,7 @@ dependencies = [
  "ethers",
  "frame-system",
  "hex",
+ "hex-literal",
  "im",
  "insta",
  "log",

--- a/crates/phactory/api/Cargo.toml
+++ b/crates/phactory/api/Cargo.toml
@@ -34,6 +34,8 @@ serde_json = "1.0.79"
 im = "15"
 ethers = "2.0.8"
 
+hex-literal = "0.4.1"
+
 [dev-dependencies]
 insta = "1.13.0"
 hex = "0.4.3"

--- a/crates/phactory/src/light_validation/mod.rs
+++ b/crates/phactory/src/light_validation/mod.rs
@@ -290,9 +290,15 @@ where
         // with the stuff we get out of storage via `read_value`
         let mut encoded_validator_set = validator_set.encode();
         encoded_validator_set.insert(0, 1); // Add AUTHORITIES_VERISON == 1
-        let actual_validator_set = checker
-            .read_value(b":grandpa_authorities")?
-            .ok_or_else(|| anyhow::Error::msg(Error::StorageValueUnavailable))?;
+        let actual_validator_set =
+            if let Some(authorities) = checker.read_value(b":grandpa_authorities")? {
+                authorities
+            } else {
+                let key = utils::storage_prefix("Grandpa", "Authorities");
+                checker
+                    .read_value(&key)?
+                    .ok_or_else(|| anyhow::Error::msg(Error::StorageValueUnavailable))?
+            };
 
         // TODO: check set_id
         // checker.read_value(grandpa::CurrentSetId.key())
@@ -396,11 +402,34 @@ impl<T: Config> fmt::Debug for BridgeInfo<T> {
 pub mod utils {
     use parity_scale_codec::Encode;
 
-    /// Gets the prefix of a storage item
-    pub fn storage_prefix(module: &str, storage: &str) -> Vec<u8> {
-        let mut bytes = sp_core::twox_128(module.as_bytes()).to_vec();
-        bytes.extend(&sp_core::twox_128(storage.as_bytes())[..]);
-        bytes
+    fn calc_storage_prefix(module: &str, storage_item: &str) -> [u8; 32] {
+        let module_hash = sp_core::twox_128(module.as_bytes());
+        let storage_hash = sp_core::twox_128(storage_item.as_bytes());
+        let mut final_key = [0u8; 32];
+        final_key[..16].copy_from_slice(&module_hash);
+        final_key[16..].copy_from_slice(&storage_hash);
+        final_key
+    }
+
+    #[inline(always)]
+    pub fn storage_prefix(module: &str, storage_item: &str) -> [u8; 32] {
+        use hex_literal::hex;
+        match (module, storage_item) {
+            // Speed up well-known storage items
+            // This let the compiler to optimize `storage_prefix("Grandpa", "Authorities")` to a constant.
+            ("Grandpa", "Authorities") => {
+                hex!("5f9cc45b7a00c5899361e1c6099678dc5e0621c4869aa60c02be9adcc98a0d1d")
+            }
+            _ => calc_storage_prefix(module, storage_item),
+        }
+    }
+
+    #[test]
+    fn well_known_storage_prefix_works() {
+        assert_eq!(
+            storage_prefix("Grandpa", "Authorities"),
+            calc_storage_prefix("Grandpa", "Authorities")
+        );
     }
 
     /// Calculates the Substrate storage key prefix for a StorageMap

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -693,10 +693,7 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             .ok_or_else(|| from_display("Runtime not initialized"))?;
 
         // Dispatch events
-        let messages = state
-            .chain_storage
-            .mq_messages()
-            .map_err(|_| from_display("Can not get mq messages from storage"))?;
+        let messages = state.chain_storage.mq_messages();
 
         state.recv_mq.reset_local_index();
 

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -441,6 +441,7 @@ pub async fn get_authority_with_proof_at(
     let alt_authorities_key = phaxt::dynamic::storage_key("Grandpa", "Authorities");
     let old_authorities_key: &[u8] = b":grandpa_authorities";
 
+    // Try the old grandpa storage key first if true. Otherwise try the new key first.
     static OLD_AUTH_KEY_PRIOR: AtomicBool = AtomicBool::new(true);
     let old_prior = OLD_AUTH_KEY_PRIOR.load(Ordering::Relaxed);
     let authorities_key_candidates = if old_prior {

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -460,9 +460,13 @@ pub async fn get_authority_with_proof_at(
         OLD_AUTH_KEY_PRIOR.store(!old_prior, Ordering::Relaxed);
     }
     let value = value.ok_or_else(|| anyhow!("No grandpa authorities found"))?;
-    let list: AuthorityList = VersionedAuthorityList::decode(&mut value.as_slice())
-        .expect("Failed to decode VersionedAuthorityList")
-        .into();
+    let list: AuthorityList = if authorities_key == old_authorities_key {
+        VersionedAuthorityList::decode(&mut value.as_slice())
+            .expect("Failed to decode VersionedAuthorityList")
+            .into()
+    } else {
+        AuthorityList::decode(&mut value.as_slice()).expect("Failed to decode AuthorityList")
+    };
 
     // Set id
     let id = api.current_set_id(Some(hash)).await?;

--- a/standalone/pherry/src/lib.rs
+++ b/standalone/pherry/src/lib.rs
@@ -7,6 +7,7 @@ use sp_core::{crypto::AccountId32, H256};
 use std::cmp;
 use std::convert::TryFrom;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -19,7 +20,7 @@ use phaxt::{
     subxt::{self, tx::TxPayload},
     RpcClient,
 };
-use sp_consensus_grandpa::{AuthorityList, SetId, VersionedAuthorityList, GRANDPA_AUTHORITIES_KEY};
+use sp_consensus_grandpa::{AuthorityList, SetId, VersionedAuthorityList};
 use subxt::config::{substrate::Era, Header as _};
 
 mod endpoint;
@@ -437,13 +438,27 @@ pub async fn get_authority_with_proof_at(
 ) -> Result<AuthoritySetChange> {
     // Storage
     let id_key = phaxt::dynamic::storage_key("Grandpa", "CurrentSetId");
-    // Authority set
-    let value = api
-        .rpc()
-        .storage(GRANDPA_AUTHORITIES_KEY, Some(hash))
-        .await?
-        .expect("No authority key found")
-        .0;
+    let alt_authorities_key = phaxt::dynamic::storage_key("Grandpa", "Authorities");
+    let old_authorities_key: &[u8] = b":grandpa_authorities";
+
+    static OLD_AUTH_KEY_PRIOR: AtomicBool = AtomicBool::new(true);
+    let old_prior = OLD_AUTH_KEY_PRIOR.load(Ordering::Relaxed);
+    let authorities_key_candidates = if old_prior {
+        [old_authorities_key, &alt_authorities_key]
+    } else {
+        [&alt_authorities_key, old_authorities_key]
+    };
+    let mut authorities_key: &[u8] = &[];
+    let mut value = None;
+    for key in authorities_key_candidates {
+        if let Some(data) = api.rpc().storage(key, Some(hash)).await? {
+            authorities_key = key;
+            value = Some(data.0);
+            break;
+        }
+        OLD_AUTH_KEY_PRIOR.store(!old_prior, Ordering::Relaxed);
+    }
+    let value = value.ok_or_else(|| anyhow!("No grandpa authorities found"))?;
     let list: AuthorityList = VersionedAuthorityList::decode(&mut value.as_slice())
         .expect("Failed to decode VersionedAuthorityList")
         .into();
@@ -451,8 +466,7 @@ pub async fn get_authority_with_proof_at(
     // Set id
     let id = api.current_set_id(Some(hash)).await?;
     // Proof
-    let proof =
-        chain_client::read_proofs(api, Some(hash), vec![GRANDPA_AUTHORITIES_KEY, &id_key]).await?;
+    let proof = chain_client::read_proofs(api, Some(hash), vec![authorities_key, &id_key]).await?;
     Ok(AuthoritySetChange {
         authority_set: AuthoritySet { list, id },
         authority_proof: proof,

--- a/standalone/pruntime/Cargo.lock
+++ b/standalone/pruntime/Cargo.lock
@@ -5742,6 +5742,7 @@ dependencies = [
  "derive_more",
  "ethers",
  "frame-system",
+ "hex-literal",
  "im",
  "log",
  "parity-scale-codec",

--- a/standalone/replay/src/replay_gk.rs
+++ b/standalone/replay/src/replay_gk.rs
@@ -93,10 +93,7 @@ impl ReplayFactory {
         event_tx: &Option<RecordSender>,
     ) -> Result<(), &'static str> {
         // Dispatch events
-        let messages = self
-            .storage
-            .mq_messages()
-            .or(Err("Can not get mq messages from storage"))?;
+        let messages = self.storage.mq_messages();
 
         let now_ms = self.storage.timestamp_now();
 


### PR DESCRIPTION
According to the upstream change [here](https://github.com/paritytech/polkadot-sdk/pull/2181/files#diff-d87d7e51ef525dc88a419ecbcf83d5a69afb3dd91aec05c99e81c46ef5368ecaR346).

By the way, dropped the compatibility of `PhalaMa::OutboundMessagesV2` in pruntime as the on-chain implementation #828 was dropped.