### PR TITLE
pruntime: Fix possible mis-update last_header on error

### DIFF
--- a/crates/phactory/src/light_validation/mod.rs
+++ b/crates/phactory/src/light_validation/mod.rs
@@ -181,7 +181,6 @@ where
 
         match self.tracked_bridges.get_mut(&bridge_id) {
             Some(bridge_info) => {
-                bridge_info.last_finalized_block_header = header;
                 if let Some(change) = auhtority_set_change {
                     // Check the validator set increment
                     if change.authority_set.id != voter_set_id + 1 {
@@ -201,6 +200,7 @@ where
                         id: change.authority_set.id,
                     }
                 }
+                bridge_info.last_finalized_block_header = header;
             }
             _ => panic!("We succesfully got this bridge earlier, therefore it exists; qed"),
         };


### PR DESCRIPTION
pRuntime recently encountered "invalid ancestry proof"。 After digged into the log, it turned out that when pRuntime get invalid validator set proofs, it would abort with an error but still update the last header.
This PR fixes it by move the updating statement after the proof checking finished.