### PR TITLE
pherry: Verify justification and authority set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10196,6 +10196,7 @@ dependencies = [
  "clap 4.4.11",
  "env_logger 0.9.0",
  "futures",
+ "hash-db",
  "hex",
  "log",
  "parity-scale-codec",
@@ -10206,12 +10207,14 @@ dependencies = [
  "phala-types",
  "phaxt",
  "reqwest",
+ "sc-consensus-grandpa",
  "serde",
  "serde_json",
  "sgx-attestation",
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
+ "sp-trie",
  "tokio",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-.PHONY: all node pruntime e2e test clippy dist
+.PHONY: all node pruntime e2e test clippy dist pherry
 
 all: node pruntime e2e
 
 node:
 	cargo build --release
+pherry:
+	cargo build --release -p pherry
 pruntime:
 	make -C standalone/pruntime
 e2e:

--- a/standalone/pherry/Cargo.toml
+++ b/standalone/pherry/Cargo.toml
@@ -19,9 +19,12 @@ serde_json = "1.0"
 clap = { version = "4.0.32", features = ["derive"] }
 
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.5.0" }
+sp-trie = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.5.0" }
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.5.0", package = "sp-runtime" }
 sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.5.0", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.5.0", default-features = false }
 codec = { package = 'parity-scale-codec', version = "3.6.5" }
+hash-db = "0.16.0"
 
 phala-types = { path = "../../crates/phala-types" }
 phala-pallets = { path = "../../pallets/phala" }

--- a/standalone/pherry/src/authority.rs
+++ b/standalone/pherry/src/authority.rs
@@ -1,0 +1,107 @@
+use anyhow::{anyhow, bail, Context, Result};
+use codec::Decode;
+use hash_db::{HashDB, EMPTY_PREFIX};
+use log::info;
+use phactory_api::blocks::{AuthoritySet, AuthoritySetChange};
+use phaxt::RelaychainApi;
+use sc_consensus_grandpa::GrandpaJustification;
+use sp_consensus_grandpa::{AuthorityList, SetId};
+use sp_trie::trie_types::TrieDBBuilder;
+use sp_trie::{MemoryDB, Trie};
+
+use crate::types::UnsigedBlock;
+use crate::{get_header_at, types::Header};
+
+type VersionedAuthorityList = (u8, AuthorityList);
+
+pub struct StorageKeys;
+
+impl StorageKeys {
+    pub fn authorities_v0() -> &'static [u8] {
+        b":grandpa_authorities"
+    }
+    pub fn authorities_v1() -> Vec<u8> {
+        phaxt::dynamic::storage_key("Grandpa", "Authorities")
+    }
+    pub fn current_set_id() -> Vec<u8> {
+        phaxt::dynamic::storage_key("Grandpa", "CurrentSetId")
+    }
+}
+
+pub async fn get_authority_with_proof_at(
+    api: &RelaychainApi,
+    header: &Header,
+) -> Result<AuthoritySetChange> {
+    let authority_proof = crate::chain_client::read_proofs(
+        api,
+        Some(header.hash()),
+        vec![
+            StorageKeys::authorities_v0(),
+            &StorageKeys::current_set_id(),
+            &StorageKeys::authorities_v1(),
+        ],
+    )
+    .await?;
+    let mut mdb = MemoryDB::<sp_core::Blake2Hasher>::default();
+    for value in authority_proof.iter() {
+        mdb.insert(EMPTY_PREFIX, value);
+    }
+    let trie = TrieDBBuilder::new(&mdb, &header.state_root).build();
+
+    let id_key = StorageKeys::current_set_id();
+    let alt_authorities_key = StorageKeys::authorities_v1();
+    let old_authorities_key: &[u8] = StorageKeys::authorities_v0();
+
+    // Read auth list
+    let mut auth_list = None;
+    for key in [&alt_authorities_key, old_authorities_key] {
+        if let Some(value) = trie.get(key).context("Check grandpa authorities failed")? {
+            let list: AuthorityList = if key == old_authorities_key {
+                VersionedAuthorityList::decode(&mut value.as_slice())
+                    .expect("Failed to decode VersionedAuthorityList")
+                    .1
+            } else {
+                AuthorityList::decode(&mut value.as_slice())
+                    .expect("Failed to decode AuthorityList")
+            };
+            auth_list = Some(list);
+            break;
+        }
+    }
+    let list = auth_list.ok_or_else(|| anyhow!("No grandpa authorities found"))?;
+
+    // Read auth id
+    let Ok(Some(id_value)) = trie.get(&id_key) else {
+        bail!("Check grandpa set id failed");
+    };
+    let id: SetId = Decode::decode(&mut id_value.as_slice()).context("Failed to decode set id")?;
+    Ok(AuthoritySetChange {
+        authority_set: AuthoritySet { list, id },
+        authority_proof,
+    })
+}
+
+pub async fn verify(api: &RelaychainApi, header: &Header, mut justifications: &[u8]) -> Result<()> {
+    if header.number == 0 {
+        return Ok(());
+    }
+    let prev_header = get_header_at(api, Some(header.number - 1)).await?.0;
+    let auth_set = get_authority_with_proof_at(api, &prev_header).await?;
+    let justification: GrandpaJustification<UnsigedBlock> =
+        Decode::decode(&mut justifications).context("Failed to decode justification")?;
+    if (
+        justification.justification.commit.target_hash,
+        justification.justification.commit.target_number,
+    ) != (header.hash(), header.number)
+    {
+        bail!("Invalid commit target in grandpa justification");
+    }
+    justification
+        .verify(auth_set.authority_set.id, &auth_set.authority_set.list)
+        .context("Failed to verify justification")?;
+    info!(
+        "Verified grandpa justification at block {}, auth_id={}",
+        header.number, auth_set.authority_set.id
+    );
+    Ok(())
+}

--- a/standalone/pherry/src/types.rs
+++ b/standalone/pherry/src/types.rs
@@ -24,6 +24,7 @@ pub type BlockNumber = u32;
 pub type Hash = sp_core::H256;
 pub type Header = sp_runtime::generic::Header<BlockNumber, sp_runtime::traits::BlakeTwo256>;
 pub type Block = SignedBlock<Header, OpaqueExtrinsic>;
+pub type UnsigedBlock = sp_runtime::generic::Block<Header, OpaqueExtrinsic>;
 // API: notify
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
This PR adds the below improvements to `pherry` and `headers-cache`:
- Verifying justifications
- Checking the authority set by comparing the data from RPC to the one extracted from the trie.

This would reduce the chance of data corruption in headers-cache.