### PR TITLE
phala-node: Configurable gossip duration.

### DIFF
--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -579,7 +579,7 @@ pub(crate) mod tests {
                 sync,
                 transaction_pool,
                 ..
-            } = new_full_base(config, false, |_, _| ())?;
+            } = new_full_base(config, false, |_, _| (), None)?;
             Ok(sc_service_test::TestNetComponents::new(
                 task_manager,
                 client,

--- a/standalone/node/src/cli.rs
+++ b/standalone/node/src/cli.rs
@@ -40,6 +40,10 @@ pub struct Cli {
     /// Custom block duration in milliseconds (only useful with --dev)
     #[arg(long)]
     pub block_millisecs: Option<u64>,
+
+    /// Custom gossip duration in milliseconds.
+    #[arg(long)]
+    pub gossip_duration_millisecs: Option<u64>,
 }
 
 /// Possible subcommands of the main binary.

--- a/standalone/node/src/command.rs
+++ b/standalone/node/src/command.rs
@@ -94,8 +94,12 @@ pub fn run() -> sc_cli::Result<()> {
         None => {
             let runner = cli.create_runner(&cli.run)?;
             runner.run_node_until_exit(|config| async move {
-                service::new_full(config, cli.no_hardware_benchmarks)
-                    .map_err(sc_cli::Error::Service)
+                service::new_full(
+                    config,
+                    cli.no_hardware_benchmarks,
+                    cli.gossip_duration_millisecs,
+                )
+                .map_err(sc_cli::Error::Service)
             })
         }
         Some(Subcommand::Inspect(cmd)) => {


### PR DESCRIPTION
The hardcoded `gossip_duration=333ms` caused the phala-node block finalizing interval to be at least 1s. Therefore, it remained slow even when we set the block interval to 100ms in e2e.

This PR introduces configurability to the gossip_duration, allowing for more flexibility.