### PR TITLE
pink: Limit number of http headers to 256

### DIFF
--- a/crates/pink/chain-extension/src/lib.rs
+++ b/crates/pink/chain-extension/src/lib.rs
@@ -115,6 +115,11 @@ async fn async_http_request(
 
     let method: Method =
         FromStr::from_str(request.method.as_str()).or(Err(HttpRequestError::InvalidMethod))?;
+
+    const MAX_ALLOWED_HEADERS: usize = 256;
+    if request.headers.len() > MAX_ALLOWED_HEADERS {
+        return Err(HttpRequestError::TooManyHeaders);
+    }
     let mut headers = HeaderMap::new();
     for (key, value) in &request.headers {
         let key =

--- a/crates/pink/pink/src/chain_extension/http_request.rs
+++ b/crates/pink/pink/src/chain_extension/http_request.rs
@@ -54,6 +54,7 @@ pub enum HttpRequestError {
     TooManyRequests,
     NetworkError,
     ResponseTooLarge,
+    TooManyHeaders,
 }
 
 impl super::sealed::Sealed for HttpRequestError {}
@@ -99,6 +100,7 @@ impl HttpRequestError {
             Self::TooManyRequests => "Too many requests",
             Self::NetworkError => "Network error",
             Self::ResponseTooLarge => "Response too large",
+            Self::TooManyHeaders => "Too many headers",
         }
     }
 }

--- a/crates/pink/pink/tests/snapshots/test_chain_extensions__dump_type_info.snap
+++ b/crates/pink/pink/tests/snapshots/test_chain_extensions__dump_type_info.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pink/pink/tests/test_chain_extensions.rs
-assertion_line: 203
+assertion_line: 202
 expression: "type_info_stringify::<Root>()"
 ---
 pink::chain_extension::http_request::HttpRequest = struct {
@@ -26,6 +26,7 @@ pink::chain_extension::http_request::HttpRequestError = enum {
     [7]TooManyRequests,
     [8]NetworkError,
     [9]ResponseTooLarge,
+    [10]TooManyHeaders,
 }
 pink::chain_extension::StorageQuotaExceeded = struct {
 }
@@ -141,4 +142,3 @@ test_chain_extensions::Root = struct {
     _driver_err: pink::system::DriverError,
     _code_type: pink::system::CodeType,
 }
-


### PR DESCRIPTION
This fixes the audit report https://github.com/code-423n4/2024-03-phala-network-findings/issues/46