### PR TITLE
Remove tempfile usage in rustfmt-snippet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12328,7 +12328,6 @@ name = "rustfmt-snippet"
 version = "0.1.1"
 dependencies = [
  "proc-macro2",
- "tempfile",
 ]
 
 [[package]]

--- a/crates/rustfmt-snippet/Cargo.toml
+++ b/crates/rustfmt-snippet/Cargo.toml
@@ -3,10 +3,8 @@ description = "Format given Rust code snippet with rustfmt"
 homepage = "https://github.com/Phala-Network/phala-blockchain"
 license = "Apache-2.0"
 name = "rustfmt-snippet"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 
 [dependencies]
 proc-macro2 = "1.0.36"
-tempfile = "3.10.1"
-

--- a/crates/rustfmt-snippet/src/lib.rs
+++ b/crates/rustfmt-snippet/src/lib.rs
@@ -16,18 +16,8 @@ pub fn rustfmt(source: &str) -> std::io::Result<String> {
         io::Write,
         process::{Command, Stdio},
     };
-    use tempfile::NamedTempFile;
-    // Create a temporary file
-    let mut tempfile: NamedTempFile = NamedTempFile::new()?;
-
-    // Write the source code to the temporary file
-    writeln!(tempfile, "{}", source)?;
-
-    // Retrieve the path of the temporary file to pass it to rustfmt
-    let path = tempfile.path();
-    let path = format!("{}", path.display());
     let proc = Command::new("rustfmt")
-        .args([path.as_str(), "--emit", "stdout", "--edition", "2018"])
+        .args(["--emit", "stdout", "--edition", "2018"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()?;
@@ -36,9 +26,7 @@ pub fn rustfmt(source: &str) -> std::io::Result<String> {
         .expect("It always exists")
         .write_all(source.as_bytes())?;
     let output = proc.wait_with_output().unwrap();
-    let result = String::from_utf8_lossy(output.stdout.as_slice()).to_string();
-    let pos = result.find("\n\n").unwrap() + 2;
-    Ok(result[pos..].to_string())
+    Ok(String::from_utf8_lossy(output.stdout.as_slice()).to_string())
 }
 
 /// Format given TokenStream with rustfmt


### PR DESCRIPTION
Use stdin instead as rustfmt supports it now.