### PR TITLE
pruntime: Box large value in OrdMap

### DIFF
--- a/crates/phactory/src/contracts/support/keeper.rs
+++ b/crates/phactory/src/contracts/support/keeper.rs
@@ -37,12 +37,12 @@ impl ContractsKeeper {
 
     pub fn get_mut(&mut self, id: &AccountId) -> Option<&mut Contract> {
         let boxed = self.contracts.get_mut(id)?;
-        Some(&mut *boxed)
+        Some(boxed)
     }
 
     pub fn get(&self, id: &AccountId) -> Option<&Contract> {
         let boxed = self.contracts.get(id)?;
-        Some(&*boxed)
+        Some(boxed)
     }
 
     #[allow(clippy::len_without_is_empty)]

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -31,8 +31,8 @@ use phala_types::{
     ChallengeHandlerInfo, EncryptedWorkerKey, HandoverChallenge, SignedContentType,
     VersionedWorkerEndpoints, WorkerEndpointPayload, WorkerPublicKey, WorkerRegistrationInfoV2,
 };
-use pink_loader::types::{AccountId, ExecSideEffects, ExecutionMode};
 use phala_types::{DcapChallengeHandlerInfo, DcapHandoverChallenge};
+use pink_loader::types::{AccountId, ExecSideEffects, ExecutionMode};
 use sp_application_crypto::UncheckedFrom;
 use sp_core::hashing::blake2_256;
 use tracing::{error, info};


### PR DESCRIPTION
This PR intends to solve the stack overflow issue in pRuntime by boxing the large values in OrdMap. 
In the previous implementation, we utilize `OrdMap<H256, Contract>` to store the contract info, where `sizeof::<Contract> == 1064`. Even though the size of Contract is approximately 1k, the `OrdMap::insert` demanded an over 8MB stack in certain scenarios. (Not sure why!)

After being boxed, it works fine when 200,000 contracts are deployed, with a 300k stack size.
