### PR TITLE
pruntime: Allow HTTP proxy to sidevm when syncing chain state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10158,7 +10158,7 @@ dependencies = [
 
 [[package]]
 name = "phala-rocket-middleware"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "log",
  "rocket",
@@ -12325,7 +12325,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-snippet"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
 ]

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -1315,6 +1315,7 @@ impl<Platform: pal::Platform> RpcService<Platform> {
         let guard = self.phactory.lock().unwrap();
         debug!(target: "phactory::lock", "Locked phactory");
         if !allow_rcu && guard.rcu_dispatching {
+            warn!(target: "phactory::lock", "RCU in progress, returning error");
             return Err(from_display(
                 "RCU in progress, please try the request again later",
             ));

--- a/standalone/pruntime/src/runtime.rs
+++ b/standalone/pruntime/src/runtime.rs
@@ -91,7 +91,7 @@ pub(crate) async fn ecall_connect_sidevm(
     let contract_id = hex::decode(id.trim_start_matches("0x"))
         .map_err(|err| (Status::BadRequest, err.to_string()))?;
     let Some(command_tx) = APPLICATION
-        .lock_phactory(false, false)
+        .lock_phactory(true, false)
         .map_err(|err| (Status::InternalServerError, err.to_string()))?
         .sidevm_command_sender(&contract_id)
     else {


### PR DESCRIPTION
It will return an error if the runtime is syncing chain state while an incoming HTTP request to SideVM arrives. This behavior is unnecessary. This PR fixes the issue.