### PR TITLE
Add a method to get the latest hash of the finalized header

### DIFF
--- a/crates/pink-libs/subrpc/Cargo.toml
+++ b/crates/pink-libs/subrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pink-subrpc"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Phala Network"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Add `subprc::get_finalized_head` method