### PR TITLE
Add WM navigation through url

### DIFF
--- a/frontend/apps/prb3-monitor/src/components/Nav.js
+++ b/frontend/apps/prb3-monitor/src/components/Nav.js
@@ -14,7 +14,11 @@ import {useStyletron} from 'baseui';
 
 const WmSelector = ({isOpen, onClose}) => {
   const allWm = useAtomValue(allWmAtom);
-  const setCurrWm = useSetAtom(currentWmIdAtom);
+  const setCurrWm = (key) => {
+    const parts = document.location.pathname.split('/');
+    parts[1] = key;
+    document.location.href = parts.join('/');
+  };
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalHeader>Select WM</ModalHeader>
@@ -22,7 +26,7 @@ const WmSelector = ({isOpen, onClose}) => {
         <StatefulMenu
           items={allWm}
           onItemSelect={({item}) => {
-            setCurrWm(item.name);
+            setCurrWm(item.key);
             onClose();
           }}
           overrides={{
@@ -84,8 +88,8 @@ export default function Nav() {
             content={() => (
               <StatefulMenu
                 items={[
-                  {label: 'Workers', url: '/status/worker'},
-                  {label: 'Transactions', url: '/status/tx'},
+                  {label: 'Workers', url: `/${currWm.key}/status/worker`},
+                  {label: 'Transactions', url: `/${currWm.key}/status/tx`},
                 ]}
                 onItemSelect={({item: i}) => router.push(i.url)}
               />
@@ -107,10 +111,10 @@ export default function Nav() {
                 items={[
                   {
                     label: 'Workers',
-                    url: '/inv/worker',
+                    url: `/${currWm.key}/inv/worker`,
                   },
-                  {label: 'Pools', url: '/inv/pool'},
-                  {label: 'Pool Operators', url: '/inv/po'},
+                  {label: 'Pools', url: `/${currWm.key}/inv/pool`},
+                  {label: 'Pool Operators', url: `/${currWm.key}/inv/po`},
                 ]}
                 onItemSelect={({item: i}) => router.push(i.url)}
               />

--- a/frontend/apps/prb3-monitor/src/pages/[wm]/inv/po.js
+++ b/frontend/apps/prb3-monitor/src/pages/[wm]/inv/po.js
@@ -47,7 +47,7 @@ export default function PoolOperatorInvPage() {
       id: data.pid,
     }));
   }, [rawFetcher]);
-  const {data, isLoading, mutate} = useSWR(`inv_po_${currWm?.name}`, fetcher, {refreshInterval: 6000});
+  const {data, isLoading, mutate} = useSWR(`inv_po_${currWm?.key}`, fetcher, {refreshInterval: 6000});
   const [isModalOpen, setModalOpen] = useState(false);
   const onModalClose = (reset) => {
     setModalOpen(false);

--- a/frontend/apps/prb3-monitor/src/pages/[wm]/status/tx.js
+++ b/frontend/apps/prb3-monitor/src/pages/[wm]/status/tx.js
@@ -92,7 +92,7 @@ export default function WorkerStatusPage() {
     ret.txs = [...ret.running_txs, ...ret.pending_txs, ...ret.past_txs].map((data) => ({data, id: data.id}));
     return ret;
   }, [rawFetcher]);
-  const {data, isLoading, mutate} = useSWR(`tx_status_${currWm?.name}`, fetcher, {refreshInterval: 6000});
+  const {data, isLoading, mutate} = useSWR(`tx_status_${currWm?.key}`, fetcher, {refreshInterval: 6000});
 
   return (
     <>

--- a/frontend/apps/prb3-monitor/src/pages/[wm]/status/worker.js
+++ b/frontend/apps/prb3-monitor/src/pages/[wm]/status/worker.js
@@ -136,7 +136,7 @@ export default function WorkerStatusPage() {
       id: data.worker.id,
     }));
   }, [rawFetcher]);
-  const {data, isLoading, mutate} = useSWR(`worker_status_${currWm?.name}`, fetcher, {refreshInterval: 6000});
+  const {data, isLoading, mutate} = useSWR(`worker_status_${currWm?.key}`, fetcher, {refreshInterval: 6000});
 
   const batchActions = useMemo(() => {
     return [
@@ -369,10 +369,10 @@ export default function WorkerStatusPage() {
                   }
             }
             actionButtons={[
-              {
-                onClick: reloadWm,
-                label: 'Restart WM',
-              },
+              // {
+              //   onClick: reloadWm,
+              //   label: 'Restart WM',
+              // },
             ]}
           />
           <div className={css({width: '12px'})} />

--- a/frontend/apps/prb3-monitor/src/pages/api/p/[...slug].js
+++ b/frontend/apps/prb3-monitor/src/pages/api/p/[...slug].js
@@ -6,11 +6,25 @@ export default async function handler(req, res) {
   const headers = req.headers;
   delete headers['content-length'];
   delete headers['Content-Length'];
+  delete headers['transfer-encoding'];
+  delete headers['Transfer-Encoding'];
+  delete headers['content-type'];
+  headers['Content-Type'] = 'application/json';
+
+  const body = req.body
+    ? (
+      typeof req.body === 'object'
+        ? JSON.stringify(req.body)
+        : req.body
+      )
+    : undefined
+  ;
+
   const r = await fetch(url, {
     method: req.method,
     cache: 'no-cache',
     headers,
-    body: req.body ? (typeof req.body === 'object' ? JSON.stringify(req.body) : req.body) : undefined,
+    body,
   });
   res.status(r.status);
   res.end(await r.text());

--- a/frontend/apps/prb3-monitor/src/state.js
+++ b/frontend/apps/prb3-monitor/src/state.js
@@ -15,18 +15,33 @@ export const allWmAtomRaw = loadable(
 
 export const allWmAtom = atom((get) => {
   const r = get(allWmAtomRaw);
-  return r.data || [];
+  if (!r.data) {
+      return [];
+  }
+
+  for (const wm of r.data) {
+    wm.key = wm.name.toLowerCase()
+      .replaceAll(/[\s]+/g, '-')
+      .replaceAll(/[^a-z0-9-]/g, '')
+    ;
+  }
+
+  return r.data;
 });
 
 export const allWmAtomInObject = atom((get) => {
   const ret = {};
   for (const i of get(allWmAtom)) {
-    ret[i.name] = i;
+    ret[i.key] = i;
   }
   return ret;
 });
 
-export const currentWmIdAtom = atomWithStorage('currentWmIdAtom', '');
+export const currentWmIdAtom = atom((get) => {
+  const allWm = get(allWmAtom);
+  const wmid = document?.location.pathname.split('/')[1];
+  return wmid;
+});
 
 export const currentWmAtom = atom((get) => {
   const currentWmId = get(currentWmIdAtom);


### PR DESCRIPTION
Adds navigation through different WMs via url. WM key is used as first part in URL.
In case you manage multiple different WMs it is easier to create bookmarks and open multiple windows with different WMs at once.
With previous implementation (local storage) change WM in one tab made all other tabs to switch WM.

My docker image for tests: https://hub.docker.com/r/l00ky/prb3-monitor