### PR TITLE
pruntime: Adds blocknum in query response

### DIFF
--- a/crates/phactory/api/proto/pruntime_rpc.proto
+++ b/crates/phactory/api/proto/pruntime_rpc.proto
@@ -405,6 +405,8 @@ message ContractQueryResponse {
   // The query result.
   // @codec scale crate::crypto::EncryptedData
   bytes encoded_encrypted_data = 1;
+  // The block number of the state when the query was executed.
+  uint32 blocknum = 2;
 }
 
 // Request parameters for GetWorkerState

--- a/crates/phactory/src/prpc_service.rs
+++ b/crates/phactory/src/prpc_service.rs
@@ -609,9 +609,9 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
     ) -> RpcResult<
         impl Future<Output = RpcResult<(pb::ContractQueryResponse, Option<ExecSideEffects>)>>,
     > {
+        let current_block = self.get_info().blocknum - 1;
         // Validate signature
         let origin = if let Some(sig) = &request.signature {
-            let current_block = self.get_info().blocknum - 1;
             // At most two level cert chain supported
             match sig.verify(
                 &request.encoded_encrypted_data,
@@ -687,7 +687,10 @@ impl<Platform: pal::Platform + Serialize + DeserializeOwned> Phactory<Platform> 
             )
             .map_err(from_debug)?;
 
-            Ok((pb::ContractQueryResponse::new(encrypted_resp), effects))
+            Ok((
+                pb::ContractQueryResponse::new(encrypted_resp, current_block),
+                effects,
+            ))
         })
     }
 


### PR DESCRIPTION
This PR adds a blocknum in the query response so that the front end can make sure the returned data is based on the correct block state.

Note: All RPC responses are already signed by the worker identity key.