### PR TITLE
fix: upgrade sccache-action and add fallback for cache service outages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
@@ -32,7 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
       - uses: actions/checkout@v3
         with:
           submodules: 'true'


### PR DESCRIPTION
- Update mozilla-actions/sccache-action from v0.0.3 to v0.0.9
- Add continue-on-error to sccache steps to handle GitHub cache service outages

🤖 Generated with [Claude Code](https://claude.ai/code)