### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/crates/pink/pink/src/logger.rs
+++ b/crates/pink/pink/src/logger.rs
@@ -78,7 +78,7 @@ macro_rules! panic {
 
 /// An extension for Result<T, E> to log error conveniently.
 pub trait ResultExt {
-    /// Log the the error message with `pink::error!` with a tip `msg` in front if the Result is Err.
+    /// Log the error message with `pink::error!` with a tip `msg` in front if the Result is Err.
     fn log_err(self, msg: &str) -> Self
     where
         Self: Sized,
@@ -86,7 +86,7 @@ pub trait ResultExt {
         self.log_err_with_level(Level::Error, msg)
     }
 
-    /// Log the the error message with `level` and a tip `msg` in front if the Result is Err.
+    /// Log the error message with `level` and a tip `msg` in front if the Result is Err.
     fn log_err_with_level(self, level: Level, msg: &str) -> Self
     where
         Self: Sized;

--- a/crates/sidevm/host/README.md
+++ b/crates/sidevm/host/README.md
@@ -15,7 +15,7 @@ sidevm-host <sideprogram.wasm>
 ## Push messages to the sidevm program
 Sidevm programs can receive messages from the host. There are three message channels:
 
-- message: A arbitrary message can be sent from an ink contract in the the phat contract.
+- message: A arbitrary message can be sent from an ink contract in the phat contract.
 - sysmessage: A message sent from the phat contract host to the sidevm program to inform some system events: ink logs, ink message outputs, ink events emitted by commands.
 - query: A query is sent from a external user via a worker local RPC in the phat contract system.
 

--- a/pallets/phala/src/phat_tokenomic.rs
+++ b/pallets/phala/src/phat_tokenomic.rs
@@ -92,7 +92,7 @@ pub mod pallet {
 		///
 		/// If users stake on a contract doesn't deployed yet. The deposit would send to the cluster
 		/// even if the contract is deployed later. User can re-stake with or without changing the amount
-		/// to sync the depoit the the cluster after the contract is actually deployed.
+		/// to sync the depoit the cluster after the contract is actually deployed.
 		#[pallet::call_index(0)]
 		#[pallet::weight({0})]
 		pub fn adjust_stake(


### PR DESCRIPTION
 remove redundant word in comment