### PR TITLE
chore: remove unused imports

### DIFF
--- a/pallets/offchain-rollup/src/mock.rs
+++ b/pallets/offchain-rollup/src/mock.rs
@@ -1,5 +1,3 @@
-use crate::{anchor, oracle};
-
 use frame_support::{pallet_prelude::ConstU32, parameter_types};
 use frame_system as system;
 use sp_core::H256;


### PR DESCRIPTION
Remove unused imports in mock runtime code